### PR TITLE
Refactoring and cleanup with documentation

### DIFF
--- a/src/main/java/org/ethereum/core/Account.java
+++ b/src/main/java/org/ethereum/core/Account.java
@@ -1,0 +1,51 @@
+package org.ethereum.core;
+
+import java.math.BigInteger;
+
+import org.ethereum.crypto.ECKey;
+import org.ethereum.util.Utils;
+
+/**
+ * Representation of an actual account or contract
+ */
+public class Account {
+
+	private ECKey ecKey;
+	private byte[] address;
+	private AccountState state;
+	
+	public Account() {
+		this.ecKey = new ECKey(Utils.getRandom());
+		this.state = new AccountState();
+	}
+	
+	public Account(ECKey ecKey) {
+		this.ecKey = ecKey;
+		this.state = new AccountState();
+	}
+
+	public Account(ECKey ecKey, BigInteger nonce, BigInteger balance) {
+		this.ecKey = ecKey;
+		this.state = new AccountState(nonce, balance);
+	}	
+	
+    public ECKey getEcKey() {
+        return ecKey;
+    }
+
+	public byte[] getAddress() {
+		return address;
+	}
+
+	public void setAddress(byte[] address) {
+		this.address = address;
+	}
+
+	public AccountState getState() {
+		return state;
+	}
+
+	public void setState(AccountState state) {
+		this.state = state;
+	}	
+}

--- a/src/main/java/org/ethereum/core/AccountState.java
+++ b/src/main/java/org/ethereum/core/AccountState.java
@@ -1,16 +1,13 @@
 package org.ethereum.core;
 
-import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
-import org.ethereum.util.Utils;
 
 import java.math.BigInteger;
 
 public class AccountState {
 
-    private ECKey ecKey;
     private byte[] rlpEncoded;
     
     /* A value equal to the number of transactions sent
@@ -42,37 +39,24 @@ public class AccountState {
     private byte[] codeHash = HashUtil.sha3(new byte[0]);
 
     public AccountState() {
-        this(new ECKey(Utils.getRandom()));
+        this(BigInteger.ZERO, BigInteger.ZERO);
     }
 
-    public AccountState(ECKey ecKey) {
-        this(ecKey, BigInteger.ZERO, BigInteger.ZERO);
+    public AccountState(BigInteger nonce, BigInteger balance) {
+        this.nonce = nonce;
+        this.balance = balance;
     }
-
+    
     public AccountState(byte[] rlpData) {
         this.rlpEncoded = rlpData;
 
 		RLPList items 	= (RLPList) RLP.decode2(rlpEncoded).get(0);
 		this.nonce 		= new BigInteger(1, ((items.get(0).getRLPData()) == null ? new byte[]{0} :
                                                                                    items.get(0).getRLPData()));
-		this.balance 	= new BigInteger(1, items.get(1).getRLPData());
+		this.balance 	= new BigInteger(1, ((items.get(1).getRLPData()) == null ? new byte[]{0} : 
+																					items.get(1).getRLPData()));
 		this.stateRoot 	= items.get(2).getRLPData();
 		this.codeHash 	= items.get(3).getRLPData();
-    }
-
-    public AccountState(ECKey ecKey, BigInteger nonce, BigInteger balance) {
-        this.ecKey = ecKey;
-        this.nonce = nonce;
-        this.balance = balance;
-    }
-    
-    public AccountState(BigInteger nonce, BigInteger balance) {
-        this.nonce = nonce;
-        this.balance = balance;
-    }
-
-    public ECKey getEcKey() {
-        return ecKey;
     }
 
     public BigInteger getNonce() {

--- a/src/main/java/org/ethereum/core/Block.java
+++ b/src/main/java/org/ethereum/core/Block.java
@@ -56,7 +56,7 @@ public class Block {
 				difficulty, number, minGasPrice, gasLimit, gasUsed,
 				timestamp, extraData, nonce);
         this.txsState = new Trie(null);
-        this.header.setStateRoot(WorldManager.instance.allAccountsState.getRootHash());
+        this.header.setStateRoot(WorldManager.instance.worldState.getRootHash());
         this.header.setTxTrieRoot(txsState.getRootHash());
         this.transactionsList = transactionsList;
         this.uncleList = uncleList;
@@ -275,8 +275,8 @@ public class Block {
     
     public byte[] updateState(byte[] key, byte[] value) {
 
-        WorldManager.instance.allAccountsState.update(key, value);
-    	byte[] stateRoot = WorldManager.instance.allAccountsState.getRootHash();
+        WorldManager.instance.worldState.update(key, value);
+    	byte[] stateRoot = WorldManager.instance.worldState.getRootHash();
     	this.header.setStateRoot(stateRoot);
     	return stateRoot;
     }

--- a/src/main/java/org/ethereum/core/Blockchain.java
+++ b/src/main/java/org/ethereum/core/Blockchain.java
@@ -18,7 +18,7 @@ public class Blockchain extends ArrayList<Block> {
 
 	private static final long serialVersionUID = -143590724563460486L;
 
-	private static Logger logger = LoggerFactory.getLogger(Blockchain.class);
+	private static Logger logger = LoggerFactory.getLogger("Chain");
 	
 	// to avoid using minGasPrice=0 from Genesis for the wallet
 	private static long INITIAL_MIN_GAS_PRICE = 10 * SZABO.longValue();

--- a/src/main/java/org/ethereum/core/Transaction.java
+++ b/src/main/java/org/ethereum/core/Transaction.java
@@ -12,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.BigIntegers;
 
-import java.math.BigInteger;
 import java.security.SignatureException;
 import java.util.Arrays;
 

--- a/src/main/java/org/ethereum/gui/ContractCallDialog.java
+++ b/src/main/java/org/ethereum/gui/ContractCallDialog.java
@@ -1,6 +1,6 @@
 package org.ethereum.gui;
 
-import org.ethereum.core.AccountState;
+import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
 import org.ethereum.manager.MainData;
 import org.ethereum.net.client.ClientPeer;
@@ -36,7 +36,7 @@ class ContractCallDialog extends JDialog implements MessageAwareDialog{
 
 
     ContractCallDialog dialog;
-    JComboBox<AddressStateWraper> creatorAddressCombo;
+    JComboBox<AccountWrapper> creatorAddressCombo;
     final JTextField gasInput;
     final JTextField contractAddrInput;
     JTextArea   msgDataTA;
@@ -116,7 +116,7 @@ class ContractCallDialog extends JDialog implements MessageAwareDialog{
 
         gasInput.setText("1000");
 
-		JComboBox<AddressStateWraper> creatorAddressCombo = new JComboBox<AddressStateWraper>() {
+		JComboBox<AccountWrapper> creatorAddressCombo = new JComboBox<AccountWrapper>() {
 			@Override
 			public ComboBoxUI getUI() {
 				BasicComboBoxUI ui = (BasicComboBoxUI) super.getUI();
@@ -135,11 +135,11 @@ class ContractCallDialog extends JDialog implements MessageAwareDialog{
         JComponent editor = (JComponent)(creatorAddressCombo.getEditor().getEditorComponent());
         editor.setForeground(Color.RED);
 
-        Collection<AccountState> addressStates =
-                MainData.instance.getWallet().getAddressStateCollection();
+        Collection<Account> accounts =
+                MainData.instance.getWallet().getAccountCollection();
 
-        for (AccountState addressState : addressStates){
-            creatorAddressCombo.addItem(new AddressStateWraper(addressState));
+        for (Account account : accounts){
+            creatorAddressCombo.addItem(new AccountWrapper(account));
         }
 
 		creatorAddressCombo.setRenderer(new DefaultListCellRenderer() {
@@ -229,10 +229,10 @@ class ContractCallDialog extends JDialog implements MessageAwareDialog{
 
         byte[] contractAddress = Hex.decode( contractAddrInput.getText());
 
-        AccountState addressState = ((AddressStateWraper)creatorAddressCombo.getSelectedItem()).getAddressState();
+        Account account = ((AccountWrapper)creatorAddressCombo.getSelectedItem()).getAccount();
 
-        byte[] senderPrivKey = addressState.getEcKey().getPrivKeyBytes();
-        byte[] nonce = addressState.getNonce() == BigInteger.ZERO ? null : addressState.getNonce().toByteArray();
+        byte[] senderPrivKey = account.getEcKey().getPrivKeyBytes();
+        byte[] nonce = account.getState().getNonce() == BigInteger.ZERO ? null : account.getState().getNonce().toByteArray();
         byte[] gasPrice = new BigInteger("10000000000000").toByteArray();
 
         BigInteger gasBI = new BigInteger(gasInput.getText());
@@ -269,22 +269,22 @@ class ContractCallDialog extends JDialog implements MessageAwareDialog{
         worker.execute();
     }
 
-	public class AddressStateWraper {
+	public class AccountWrapper {
 
-        private AccountState addressState;
+        private Account account;
 
-        public AddressStateWraper(AccountState addressState) {
-            this.addressState = addressState;
+        public AccountWrapper(Account account) {
+            this.account = account;
         }
 
-        public AccountState getAddressState() {
-            return addressState;
+        public Account getAccount() {
+            return account;
         }
 
 		@Override
 		public String toString() {
-			String addressShort = Utils.getAddressShortString(addressState.getEcKey().getAddress());
-			String valueShort = Utils.getValueShortString(addressState.getBalance());
+			String addressShort = Utils.getAddressShortString(account.getEcKey().getAddress());
+			String valueShort = Utils.getValueShortString(account.getState().getBalance());
 			String result = String.format(" By: [%s] %s", addressShort,
 					valueShort);
 			return result;

--- a/src/main/java/org/ethereum/gui/ContractSubmitDialog.java
+++ b/src/main/java/org/ethereum/gui/ContractSubmitDialog.java
@@ -1,5 +1,6 @@
 package org.ethereum.gui;
 
+import org.ethereum.core.Account;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 import org.ethereum.manager.MainData;
@@ -32,7 +33,7 @@ class ContractSubmitDialog extends JDialog implements MessageAwareDialog {
     private static final long serialVersionUID = -3622984456084608996L;
 	
 	ContractSubmitDialog dialog;
-    JComboBox<AddressStateWraper> creatorAddressCombo;
+    JComboBox<AccountWrapper> creatorAddressCombo;
     final JTextField gasInput;
     final JTextField contractAddrInput;
 
@@ -139,7 +140,7 @@ class ContractSubmitDialog extends JDialog implements MessageAwareDialog {
 
         gasInput.setText("1000");
 
-        JComboBox<AddressStateWraper> creatorAddressCombo = new JComboBox<AddressStateWraper>(){
+        JComboBox<AccountWrapper> creatorAddressCombo = new JComboBox<AccountWrapper>(){
             @Override
             public ComboBoxUI getUI() {
 
@@ -160,12 +161,11 @@ class ContractSubmitDialog extends JDialog implements MessageAwareDialog {
         JComponent editor = (JComponent)(creatorAddressCombo.getEditor().getEditorComponent());
         editor.setForeground(Color.RED);
 
-        Collection<AccountState> addressStates =
-                MainData.instance.getWallet().getAddressStateCollection();
+        Collection<Account> accounts =
+                MainData.instance.getWallet().getAccountCollection();
 
-        for (AccountState addressState : addressStates){
-
-            creatorAddressCombo.addItem(new AddressStateWraper(addressState));
+        for (Account account : accounts){
+            creatorAddressCombo.addItem(new AccountWrapper(account));
         }
 
         creatorAddressCombo.setRenderer(new DefaultListCellRenderer() {
@@ -251,10 +251,10 @@ class ContractSubmitDialog extends JDialog implements MessageAwareDialog {
 
     public void submitContract(){
 
-        AccountState addressState = ((AddressStateWraper)creatorAddressCombo.getSelectedItem()).getAddressState();
+        Account account = ((AccountWrapper)creatorAddressCombo.getSelectedItem()).getAccount();
 
-        byte[] senderPrivKey = addressState.getEcKey().getPrivKeyBytes();
-        byte[] nonce = addressState.getNonce() == BigInteger.ZERO ? null : addressState.getNonce().toByteArray();
+        byte[] senderPrivKey = account.getEcKey().getPrivKeyBytes();
+        byte[] nonce = account.getState().getNonce() == BigInteger.ZERO ? null : account.getState().getNonce().toByteArray();
         byte[] gasPrice = new BigInteger("10000000000000").toByteArray();
 
         BigInteger gasBI = new BigInteger(gasInput.getText());
@@ -297,22 +297,22 @@ class ContractSubmitDialog extends JDialog implements MessageAwareDialog {
         pod.setVisible(true);
     }
 
-    public class AddressStateWraper{
+    public class AccountWrapper{
 
-        private AccountState addressState;
+        private Account account;
 
-        public AddressStateWraper(AccountState addressState) {
-            this.addressState = addressState;
+        public AccountWrapper(Account account) {
+            this.account = account;
         }
 
-        public AccountState getAddressState() {
-            return addressState;
+        public Account getAccount() {
+            return account;
         }
 
         @Override
         public String toString() {
-            String addressShort = Utils.getAddressShortString(addressState.getEcKey().getAddress());
-            String valueShort   = Utils.getValueShortString(addressState.getBalance());
+            String addressShort = Utils.getAddressShortString(account.getEcKey().getAddress());
+            String valueShort   = Utils.getValueShortString(account.getState().getBalance());
 
             String result =
                     String.format(" By: [%s] %s", addressShort, valueShort);

--- a/src/main/java/org/ethereum/gui/PayOutDialog.java
+++ b/src/main/java/org/ethereum/gui/PayOutDialog.java
@@ -1,5 +1,6 @@
 package org.ethereum.gui;
 
+import org.ethereum.core.Account;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 import org.ethereum.manager.MainData;
@@ -35,11 +36,11 @@ class PayOutDialog extends JDialog implements MessageAwareDialog {
     final JTextField amountInput;
     final JTextField feeInput;
 
-	public PayOutDialog(Frame parent, final AccountState addressState) {
+	public PayOutDialog(Frame parent, final Account account) {
 		super(parent, "Payout details: ", false);
 		dialog = this;
 
-		this.addressState = addressState;
+		this.addressState = account.getState();
 
         receiverInput = new JTextField(18);
         GUIUtils.addStyle(receiverInput, "Pay to:");
@@ -114,7 +115,7 @@ class PayOutDialog extends JDialog implements MessageAwareDialog {
 					return;
 				}
 
-				byte[] senderPrivKey = addressState.getEcKey().getPrivKeyBytes();
+				byte[] senderPrivKey = account.getEcKey().getPrivKeyBytes();
 				byte[] nonce = addressState.getNonce() == BigInteger.ZERO ? null : addressState.getNonce().toByteArray();
 
                 byte[] gasPrice = BigInteger.valueOf( MainData.instance.getBlockchain().getGasPrice()).toByteArray();
@@ -189,7 +190,6 @@ class PayOutDialog extends JDialog implements MessageAwareDialog {
             return false;
         }
 
-
         // check if the tx is affordable
         BigInteger ammountValue = new BigInteger(amountText);
         BigInteger feeValue = new BigInteger(feeText);
@@ -261,8 +261,8 @@ class PayOutDialog extends JDialog implements MessageAwareDialog {
     }
 
     public static void main(String args[]) {
-        AccountState as = new AccountState();
-        PayOutDialog pod = new PayOutDialog(null,  as);
+        Account account = new Account();
+        PayOutDialog pod = new PayOutDialog(null,  account);
         pod.setVisible(true);
     }
 }

--- a/src/main/java/org/ethereum/gui/WalletAddressPanel.java
+++ b/src/main/java/org/ethereum/gui/WalletAddressPanel.java
@@ -1,5 +1,6 @@
 package org.ethereum.gui;
 
+import org.ethereum.core.Account;
 import org.ethereum.core.AccountState;
 import org.ethereum.util.Utils;
 import org.spongycastle.util.encoders.Hex;
@@ -21,7 +22,7 @@ import java.net.URL;
  */
 public class WalletAddressPanel extends JPanel{
 
-    public WalletAddressPanel(final AccountState addressState) {
+    public WalletAddressPanel(final Account account) {
 
         final WalletAddressPanel walletAddressPanel = this;
 
@@ -35,7 +36,7 @@ public class WalletAddressPanel extends JPanel{
         addressField.setBorder(border);
         addressField.setEnabled(true);
         addressField.setEditable(false);
-        addressField.setText(Hex.toHexString(addressState.getEcKey().getAddress()).toUpperCase());
+        addressField.setText(Hex.toHexString(account.getEcKey().getAddress()).toUpperCase());
         addressField.setForeground(new Color(143, 170, 220));
         addressField.setFont(new Font("Monospaced", 0, 12));
         addressField.setPreferredSize(new Dimension(300, 35));
@@ -46,7 +47,7 @@ public class WalletAddressPanel extends JPanel{
         amount.setBorder(border);
         amount.setEnabled(true);
         amount.setEditable(false);
-        amount.setText(Utils.getValueShortString(addressState.getBalance()));
+        amount.setText(Utils.getValueShortString(account.getState().getBalance()));
         amount.setForeground(new Color(143, 170, 220));
         amount.setBackground(Color.WHITE);
         amount.setPreferredSize(new Dimension(100, 35));
@@ -65,7 +66,7 @@ public class WalletAddressPanel extends JPanel{
 
                 PayOutDialog payOutDialog =
                         new PayOutDialog((Frame)SwingUtilities.getAncestorOfClass(JFrame.class,
-                                walletAddressPanel), addressState);
+                                walletAddressPanel), account);
             }
         });
 

--- a/src/main/java/org/ethereum/gui/WalletWindow.java
+++ b/src/main/java/org/ethereum/gui/WalletWindow.java
@@ -1,6 +1,6 @@
 package org.ethereum.gui;
 
-import org.ethereum.core.AccountState;
+import org.ethereum.core.Account;
 import org.ethereum.core.Wallet;
 import org.ethereum.manager.MainData;
 
@@ -56,10 +56,9 @@ public class WalletWindow extends JFrame implements Wallet.WalletListener{
 
         Wallet wallet = MainData.instance.getWallet();
 
-        for (AccountState addressState : wallet.getAddressStateCollection()){
+        for (Account account : wallet.getAccountCollection()){
 
-            WalletAddressPanel rowPanel =
-                    new WalletAddressPanel(addressState);
+			WalletAddressPanel rowPanel = new WalletAddressPanel(account);
             contentPane.add(rowPanel);
         }
 
@@ -78,13 +77,13 @@ public class WalletWindow extends JFrame implements Wallet.WalletListener{
             public void mouseClicked(MouseEvent e) {
 
                 Wallet wallet = MainData.instance.getWallet();
-                if (wallet.getAddressStateCollection().size() >=5){
+                if (wallet.getAccountCollection().size() >=5){
                     JOptionPane.showMessageDialog(walletWindow,
                             "Hey do you really need more than 5 address for a demo wallet");
                     return;
                 }
 
-                wallet.addNewKey();
+                wallet.addNewAccount();
                 Dimension dimension = walletWindow.getSize();
                 int height = dimension.height;
                 int width = dimension.width;

--- a/src/main/java/org/ethereum/manager/MainData.java
+++ b/src/main/java/org/ethereum/manager/MainData.java
@@ -47,7 +47,7 @@ public class MainData {
         ECKey key = ECKey.fromPrivate(cowAddr);
 
         wallet.importKey(cowAddr);
-        AccountState state = wallet.getAddressState(key.getAddress());
+        AccountState state = wallet.getAccountState(key.getAddress());
         state.addToBalance(BigInteger.valueOf(2).pow(200));
         wallet.importKey(HashUtil.sha3("cat".getBytes()));
 

--- a/src/main/java/org/ethereum/net/client/ClientPeer.java
+++ b/src/main/java/org/ethereum/net/client/ClientPeer.java
@@ -7,7 +7,6 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 
-import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Transaction;
 import org.ethereum.gui.PeerListener;
 import org.ethereum.manager.MainData;
@@ -22,7 +21,6 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 import static org.ethereum.config.SystemProperties.CONFIG;
-
 
 /**
  * www.ethereumJ.com

--- a/src/main/java/org/ethereum/net/client/EthereumProtocolHandler.java
+++ b/src/main/java/org/ethereum/net/client/EthereumProtocolHandler.java
@@ -10,7 +10,6 @@ import io.netty.channel.FixedRecvByteBufAllocator;
 import java.util.*;
 
 import org.ethereum.core.Block;
-import org.ethereum.core.Transaction;
 import org.ethereum.gui.PeerListener;
 import org.ethereum.manager.MainData;
 import org.ethereum.manager.WorldManager;
@@ -38,7 +37,7 @@ import org.spongycastle.util.encoders.Hex;
  */
 public class EthereumProtocolHandler extends ChannelInboundHandlerAdapter {
 
-    Logger logger = LoggerFactory.getLogger("wire");
+    Logger logger = LoggerFactory.getLogger("Wire");
 
     Timer chainAskTimer = new Timer();
     int secToAskForChain = 1;

--- a/src/main/java/org/ethereum/net/peerdiscovery/EthereumPeerTasterHandler.java
+++ b/src/main/java/org/ethereum/net/peerdiscovery/EthereumPeerTasterHandler.java
@@ -5,7 +5,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.FixedRecvByteBufAllocator;
-import org.ethereum.crypto.HashUtil;
 import org.ethereum.gui.PeerListener;
 import org.ethereum.manager.MainData;
 import org.ethereum.net.Command;
@@ -29,13 +28,12 @@ import static org.ethereum.net.Command.*;
  */
 public class EthereumPeerTasterHandler extends ChannelInboundHandlerAdapter {
 
-    Logger logger = LoggerFactory.getLogger(getClass());
+    Logger logger = LoggerFactory.getLogger("Wire");
 
     Timer timer = null;
     private final static byte[] MAGIC_PREFIX = {(byte)0x22, (byte)0x40, (byte)0x08, (byte)0x91};
 
     private final static byte[] HELLO_MESSAGE = StaticMessages.HELLO_MESSAGE.getPayload();
-    private final static byte[] HELLO_MESSAGE_LEN = ByteUtil.calcPacketLength(HELLO_MESSAGE);
 
     private long lastPongTime = 0;
     private boolean tearDown = false;
@@ -200,7 +198,4 @@ public class EthereumPeerTasterHandler extends ChannelInboundHandlerAdapter {
         buffer.writeBytes(StaticMessages.GET_PEERS);
         ctx.writeAndFlush(buffer);
     }
-
-
-
 }

--- a/src/main/java/org/ethereum/vm/VM.java
+++ b/src/main/java/org/ethereum/vm/VM.java
@@ -47,7 +47,7 @@ public class VM {
 
     static private BigInteger _32_ = BigInteger.valueOf(32);
 
-    private Logger logger = LoggerFactory.getLogger("VM");
+    private Logger logger = LoggerFactory.getLogger(VM.class);
 
     public void step(Program program) {
 

--- a/src/test/java/org/ethereum/core/WalletTest.java
+++ b/src/test/java/org/ethereum/core/WalletTest.java
@@ -29,8 +29,8 @@ public class WalletTest {
         wallet.importKey(catKey.getPrivKeyBytes());
 
 
-        AccountState cowAddressState = (AccountState) wallet.getAddressState(cowKey.getAddress());
-        AccountState catAddressState = (AccountState) wallet.getAddressState(catKey.getAddress());
+        AccountState cowAddressState = wallet.getAccountState(cowKey.getAddress());
+        AccountState catAddressState = wallet.getAccountState(catKey.getAddress());
 
         cowAddressState.addToBalance(new BigInteger("234234"));
         catAddressState.addToBalance(new BigInteger("84758"));


### PR DESCRIPTION
- Cleanup WorldManager
- Document VM class and set switch indentations to comply with  http://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html
- Create separate Account which contains AccountState. This because an AccountState doesn't have a key, so it can be used separately and Account can be used in the wallet. Creating new AccountState, automatically sets the nonce and balance to BigInteger.ZERO.
- Fixed bug where tx.getValue() could be null
- Fixed bug where rlpEncoded accountState could end up with `null` as balance
