### PR TITLE
Add random.json and fix in Repository

### DIFF
--- a/src/main/java/org/ethereum/db/Repository.java
+++ b/src/main/java/org/ethereum/db/Repository.java
@@ -95,6 +95,12 @@ public class Repository {
 
     public AccountState createAccount(byte[] addr) {
 
+		if (addr.length < 20) {
+			byte[] newAddr = new byte[20];
+			System.arraycopy(addr, 0, newAddr, newAddr.length - addr.length, addr.length);
+			addr = newAddr;
+		}
+    	
         // 1. Save AccountState
         AccountState state =  new AccountState();
         accountStateDB.update(addr, state.getEncoded());

--- a/src/main/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/src/main/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -65,7 +65,8 @@ public class TestRunner {
         Env  env  = testCase.getEnv();
         Exec exec = testCase.getExec();
 
-        byte[] address     = exec.getAddress(); //repository.createAccount(address);
+        byte[] address     = exec.getAddress(); 
+        if(repository.getAccountState(address) == null) { repository.createAccount(address); }
         byte[] origin      = exec.getOrigin();
         byte[] caller      = exec.getCaller();
         byte[] balance     =  ByteUtil.bigIntegerToBytes(repository.getBalance(exec.getAddress()));
@@ -95,7 +96,6 @@ public class TestRunner {
         } catch (RuntimeException e) {
             program.setRuntimeFailure(e);
         }
-
 
         /* 5. Assert Post values */
         for (ByteArrayWrapper key : testCase.getPost().keySet()){
@@ -185,7 +185,6 @@ public class TestRunner {
                                     );
                     logger.info(output);
                     results.add(output);
-
                 }
             }
         }
@@ -193,7 +192,6 @@ public class TestRunner {
         // TODO: assert that you have no extra accounts in the repository
         // TODO:  -> basically the deleted by suicide should be deleted
         // TODO:  -> and no unexpected created
-
 
         List<org.ethereum.vm.CallCreate> resultCallCreates  =
                 program.getResult().getCallCreateList();
@@ -257,7 +255,6 @@ public class TestRunner {
                                 Hex.toHexString( resultCallCreate.getGasLimit()) );
                 logger.info(output);
                 results.add(output);
-
             }
 
             boolean assertValue = Arrays.equals(expectedCallCreate.getValue(),
@@ -271,7 +268,6 @@ public class TestRunner {
                 logger.info(output);
                 results.add(output);
             }
-
         }
 
         // assert out

--- a/src/main/java/org/ethereum/vm/Program.java
+++ b/src/main/java/org/ethereum/vm/Program.java
@@ -220,8 +220,7 @@ public class Program {
             logger.info("Transfer to: [ {} ] heritage: [ {} ]", Hex.toHexString(obtainer.getNoLeadZeroesData())
                         , balance.longValue());
 
-        this.result.getRepository().addBalance(obtainer.getNoLeadZeroesData(),
-                balance.value());
+        this.result.getRepository().addBalance(obtainer.getNoLeadZeroesData(), balance.value());
 
         // 2) mark the account as for delete
         result.addDeleteAccount(getOwnerAddress());

--- a/src/test/java/org/ethereum/jsontestsuite/JSONTestSuiteTest.java
+++ b/src/test/java/org/ethereum/jsontestsuite/JSONTestSuiteTest.java
@@ -339,4 +339,26 @@ public class JSONTestSuiteTest {
         }
     }
     
+    @Test // testing full suite
+    public void testRandomFromGitHub() throws ParseException {
+
+        String json = Utils.getFromUrl("https://raw.githubusercontent.com/ethereum/tests/develop/random.json");
+        Assume.assumeFalse("Online test suite is no available", json.equals(""));
+
+        JSONParser parser = new JSONParser();
+        JSONObject testSuiteObj = (JSONObject)parser.parse(json);
+
+        TestSuite testSuite = new TestSuite(testSuiteObj);
+        Iterator<TestCase> testIterator = testSuite.iterator();
+
+        while (testIterator.hasNext()){
+
+            TestCase testCase = testIterator.next();
+
+            System.out.println("Running: " + testCase.getName());
+            TestRunner runner = new TestRunner();
+            List<String> result = runner.runTestCase(testCase);
+            Assert.assertTrue(result.isEmpty());
+        }
+    }
 }


### PR DESCRIPTION
- The Repository.createAccount method was called with addresses from DataWord.NoLeadingZeroes, but they should be stored as 20 bytes, regardless. This might be fixed in a better way, but for now this fixes the random.json test. 

The code should be checked if there are any other locations where the Repository methods are called with byte-arrays with length < 20 bytes.
