### PR TITLE
Fix TrieTest for JSON dump and add logging to Trie

### DIFF
--- a/src/main/java/org/ethereum/trie/Trie.java
+++ b/src/main/java/org/ethereum/trie/Trie.java
@@ -10,6 +10,9 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.Value;
 import org.iq80.leveldb.DB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
 /**
  * The modified Merkle Patricia tree (trie) provides a persistent data structure 
@@ -34,6 +37,8 @@ import org.iq80.leveldb.DB;
  */
 public class Trie implements TrieFacade{
 
+	private Logger logger = LoggerFactory.getLogger("trie");
+	
 	private static byte PAIR_SIZE = 2;
 	private static byte LIST_SIZE = 17;
 	
@@ -96,6 +101,10 @@ public class Trie implements TrieFacade{
 			throw new NullPointerException("Key should not be blank");
 		byte[] k = binToNibbles(key);
 		this.root = this.insertOrDelete(this.root, k, value);
+		if(logger.isDebugEnabled()) {
+			logger.debug("Added key {} and value {}", Hex.toHexString(key), Hex.toHexString(value));
+			logger.debug("New root-hash: {}", Hex.toHexString(this.getRootHash()));
+		}
 	}
 
 	/**
@@ -115,6 +124,9 @@ public class Trie implements TrieFacade{
      * @return value
      */
     public byte[] get(byte[] key) {
+		if(logger.isDebugEnabled()) {
+			logger.debug("Retrieving key {}", Hex.toHexString(key));
+		}
         byte[] k = binToNibbles(key);
         Value c = new Value( this.get(this.root, k) );
         return c.asBytes();
@@ -127,6 +139,10 @@ public class Trie implements TrieFacade{
      */
     public void delete(byte[] key) {
         delete(new String(key));
+		if(logger.isDebugEnabled()) {
+			logger.debug("Deleted value for key {}", Hex.toHexString(key));
+			logger.debug("New root-hash: {}", Hex.toHexString(this.getRootHash()));
+		}
     }
 
 	/**

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -23,9 +23,11 @@ log4j.logger.io.netty = ERROR
 log4j.logger.wire = ERROR
 log4j.logger.VM = ERROR
 log4j.logger.main = INFO
+log4j.logger.trie = ERROR
 log4j.logger.state = ERROR
 log4j.logger.repository = ERROR
 log4j.logger.blockchain = DEBUG
+log4j.logger.txs = ERROR
 log4j.logger.ui = ERROR
 log4j.logger.gas = ERROR
 

--- a/src/test/java/org/ethereum/trie/TrieTest.java
+++ b/src/test/java/org/ethereum/trie/TrieTest.java
@@ -1,7 +1,18 @@
 package org.ethereum.trie;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+
 import org.ethereum.core.AccountState;
-import org.ethereum.db.Database;
 import org.ethereum.db.DatabaseImpl;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -11,14 +22,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-
-import static org.junit.Assert.*;
 
 public class TrieTest {
 
@@ -576,25 +579,31 @@ public class TrieTest {
            byte[] val = Hex.decode(obj.get("val").toString());
 
            db.put(key, val);
-
         }
 
-        // TEST: load trie out of this run:
+        // TEST: load trie out of this run up to block#33
         byte[] rootNode = Hex.decode("bb690805d24882bc7ccae6fc0f80ac146274d5b81c6a6e9c882cd9b0a649c9c7");
         Trie trie = new Trie(db.getDb(), rootNode);
 
-        byte[] val = trie.get(Hex.decode("61e202e8be7f1047131bc9574ea0001b4a9fa200d082076065c0f70105eec5b4"));
-        AccountState state = new AccountState(val);
+        // first key added in genesis
+        byte[] val1 = trie.get(Hex.decode("51ba59315b3a95761d0863b05ccc7a7f54703d99"));
+        AccountState accountState1 = new AccountState(val1);
 
-        System.out.println(state.getBalance());
-        System.out.println(Hex.toHexString(state.getCodeHash()));
-        System.out.println(state.getNonce());
-        System.out.println(Hex.toHexString(state.getStateRoot()));
+        assertEquals(BigInteger.valueOf(2).pow(200), accountState1.getBalance());
+        assertEquals("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470", Hex.toHexString(accountState1.getCodeHash()));
+        assertEquals(BigInteger.ZERO, accountState1.getNonce());
+        assertEquals(null, accountState1.getStateRoot());
 
+        // last key added up to block#33
+        byte[] val2 = trie.get(Hex.decode("a39c2067eb45bc878818946d0f05a836b3da44fa"));
+        AccountState accountState2 = new AccountState(val2);
+        
+        assertEquals(new BigInteger("1500000000000000000"), accountState2.getBalance());
+        assertEquals("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470", Hex.toHexString(accountState2.getCodeHash()));
+        assertEquals(BigInteger.ZERO, accountState2.getNonce());
+        assertEquals(null, accountState2.getStateRoot());
 
         db.close();
 
     }
-
-
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -17,9 +17,11 @@ log4j.logger.io.netty = ERROR
 log4j.logger.wire = ERROR
 log4j.logger.VM = OFF
 log4j.logger.main = INFO
+log4j.logger.trie = ERROR
 log4j.logger.state = ERROR
 log4j.logger.repository = ERROR
-log4j.logger.blockchain = DEBUG
+log4j.logger.blockchain = ERROR
+log4j.logger.txs = ERROR
 log4j.logger.ui = ERROR
 log4j.logger.gas = ERROR
 


### PR DESCRIPTION
The trie for the stateDB only stores:
- **key:** address     ----> 20 bytes
- **value:** rlp_encode(accountState)

The actual data in the stateDB has:
- **key:** sha3(rlp_encode(node))   ----> 32 bytes
- **value:** rlp_encode(node)
