### PR TITLE
Fix for consensus block 1501

### DIFF
--- a/src/main/java/org/ethereum/trie/Cache.java
+++ b/src/main/java/org/ethereum/trie/Cache.java
@@ -83,12 +83,9 @@ public class Cache {
 			}
 		}
 		this.isDirty = false;
-
-		// If the nodes grows beyond the 200 entries we simple empty it
-		// FIXME come up with something better
-		if (this.nodes.size() > 200) {
-			this.nodes = new HashMap<>();
-		}
+		
+		// TODO come up with a way to clean up this.nodes 
+		// from memory without breaking consensus
 	}
 
 	public void undo() {

--- a/src/main/resources/system.properties
+++ b/src/main/resources/system.properties
@@ -99,7 +99,7 @@ coinbase.secret = monkey
 # posible values [true/false]
 dump.full = false
 dump.dir = dmp
-dump.block = 1501
+dump.block = -1
 
 # clean the dump dir each start
 dump.clean.on.restart = true


### PR DESCRIPTION
The state conflict was caused by a part of the Trie code where the cache was deleted after 200 nodes. This was done to avoid memory issues, but at block 1501 the memory is not an issue with ~12424 nodes. However it will be later. This needs to be reimplemented properly when we get to that, but for now this fixes the issue.
