### PR TITLE
Fixes javadoc errors.

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/Block.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Block.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * (such blocks are known as uncles).
  *
  * www.ethereumJ.com
- * @authors: Roman Mandeleil,
+ * @author Roman Mandeleil,
  *           Nick Savers
  * Created on: 20/05/2014 10:44
  */

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -154,7 +154,7 @@ public class BlockHeader {
 	/**
 	 * Verify that block is valid for its difficulty
 	 * 
-	 * @return
+	 * @return boolean
 	 */
 	public boolean validateNonce() {
 		BigInteger max = BigInteger.valueOf(2).pow(256);

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -43,7 +43,7 @@ import static org.ethereum.core.Denomination.SZABO;
  * See <a href="https://github.com/ethereum/wiki/wiki/White-Paper#blockchain-and-mining">Ethereum Whitepaper</a>
  *
  * www.ethereumJ.com
- * @authors: Roman Mandeleil,
+ * @author Roman Mandeleil,
  *           Nick Savers
  * Created on: 20/05/2014 10:44
  */

--- a/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -171,7 +171,7 @@ public class Transaction {
         return this.receiveAddress == null || this.receiveAddress == ByteUtil.EMPTY_BYTE_ARRAY;
     }
 
-    /*********
+    /*
      * Crypto
      */
 

--- a/ethereumj-core/src/main/java/org/ethereum/crypto/ECKey.java
+++ b/ethereumj-core/src/main/java/org/ethereum/crypto/ECKey.java
@@ -65,7 +65,7 @@ import org.spongycastle.util.encoders.Hex;
  * this class so round-tripping preserves state. Unless you're working with old software or doing unusual things, you
  * can usually ignore the compressed/uncompressed distinction.</p>
  *
- * This code is borrowed from the bitcoinj project and altered to fit Ethereum.</br> 
+ * This code is borrowed from the bitcoinj project and altered to fit Ethereum.<br>
  * See <a href="https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/com/google/bitcoin/core/ECKey.java">bitcoinj on GitHub</a>
  */
 public class ECKey implements Serializable {
@@ -375,7 +375,7 @@ public class ECKey implements Serializable {
      * Signs the given hash and returns the R and S components as BigIntegers 
      * and put them in ECDSASignature 
      * 
-     * @param rlpData to sign
+     * @param input to sign
      * @return ECDSASignature signature that contains the R and S components
      */
     public ECDSASignature doSign(byte[] input) {
@@ -419,7 +419,7 @@ public class ECKey implements Serializable {
      * containing the public key that was used to sign it. This can then be compared to the expected public key to
      * determine if the signature was correct.
      * 
-     * @param message a piece of human readable text that was signed
+     * @param messageHash a piece of human readable text that was signed
      * @param signatureBase64 The Ethereum-format message signature in base64
      * @throws SignatureException If the public key could not be recovered or if there was a signature format error.
      */

--- a/ethereumj-core/src/main/java/org/ethereum/crypto/HashUtil.java
+++ b/ethereumj-core/src/main/java/org/ethereum/crypto/HashUtil.java
@@ -67,7 +67,7 @@ public class HashUtil {
     }
     
     /**
-     * See {@link ByteUtil#doubleDigest(byte[], int, int)}.
+     * @see #doubleDigest(byte[], int, int)
      */
     public static byte[] doubleDigest(byte[] input) {
         return doubleDigest(input, 0, input.length);

--- a/ethereumj-core/src/main/java/org/ethereum/db/RepositoryImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/RepositoryImpl.java
@@ -36,17 +36,17 @@ import static org.ethereum.config.SystemProperties.CONFIG;
 /**
  *
  ***********************************************************************************
-         Repository
-         |
-             --> AccountState      ---> Trie ---> leveldb (state) /key=address
-                 --> nonce
-                 --> balance
-                 --> stateRoot
-                 --> codeHash
-         |
-             -->  ContractDetails  ---> leveldb(details) /key=address
-                 --> code      ---> sha3(code) // saved into AccountInfo.codeHash
-                 --> storage   ---> Trie // to calculate the AccountInfo.stateRoot
+         Repository<br>
+         |<br>
+             --&gt; AccountState      ---&gt; Trie ---&gt; leveldb (state) /key=address<br>
+                 --&gt; nonce<br>
+                 --&gt; balance<br>
+                 --&gt; stateRoot<br>
+                 --&gt; codeHash<br>
+         |<br>
+             --&gt;  ContractDetails  ---&gt; leveldb(details) /key=address<br>
+                 --&gt; code      ---&gt; sha3(code) // saved into AccountInfo.codeHash<br>
+                 --&gt; storage   ---&gt; Trie // to calculate the AccountInfo.stateRoot<br>
  ***********************************************************************************
  *
  * www.ethereumJ.com
@@ -73,7 +73,7 @@ public class RepositoryImpl implements Repository {
      * Create a new Repository DAO 
      * 		assuming empty db and thus no stateRoot
      * 
-     * @See loadBlockchain() to update the stateRoot
+     * @see #loadBlockchain() to update the stateRoot
      */
     public RepositoryImpl() {
     	this("blockchain", "details", "state");
@@ -147,7 +147,6 @@ public class RepositoryImpl implements Repository {
                     listener.onPreloadedBlock(Genesis.getInstance());
                 }
 
-               	logger.debug("Block #{} -> {}", Genesis.NUMBER, blockchain.getLastBlock().toFlatString());
                	dumpState(Genesis.getInstance(), 0, 0, null);
             } else {
             	logger.debug("Displaying blocks stored in DB sorted on blocknumber");

--- a/ethereumj-core/src/main/java/org/ethereum/facade/Repository.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/Repository.java
@@ -21,7 +21,7 @@ public interface Repository {
 	/**
 	 * Create a new account in the database
 	 *  
-	 * @param address of the contract
+	 * @param addr of the contract
 	 * @return newly created account state
 	 */
 	public AccountState createAccount(byte[] addr);
@@ -29,7 +29,7 @@ public interface Repository {
 	/**
 	 * Retrieve an account
 	 * 
-	 * @param address of the account
+	 * @param addr of the account
 	 * @return account state as stored in the database
 	 */
     public AccountState getAccountState(byte[] addr);
@@ -37,7 +37,7 @@ public interface Repository {
     /**
      * Deletes the account
      * 
-     * @param address of the account
+     * @param addr of the account
      */
     public void delete(byte[] addr);
     
@@ -52,7 +52,7 @@ public interface Repository {
     /**
      * Get current nonce of a given account
      * 
-     * @param addres of the account
+     * @param addr of the account
      * @return value of the nonce
      */
     public BigInteger getNonce(byte[] addr);
@@ -60,7 +60,7 @@ public interface Repository {
     /**
      * Retrieve contract details for a given account from the database
      * 
-     * @param address of the account
+     * @param addr of the account
      * @return new contract details 
      */
     public ContractDetails getContractDetails(byte[] addr);
@@ -68,7 +68,7 @@ public interface Repository {
     /**
      * Store code associated with an account
      * 
-     * @param address for the account
+     * @param addr for the account
      * @param code that will be associated with this account
      */
     public void saveCode(byte[] addr, byte[] code);
@@ -76,7 +76,7 @@ public interface Repository {
     /**
      * Retrieve the code associated with an account
      * 
-     * @param address of the account
+     * @param addr of the account
      * @return code in byte-array format
      */
     public byte[] getCode(byte[] addr);
@@ -84,7 +84,7 @@ public interface Repository {
     /**
      * Put a value in storage of an account at a given key
      * 
-     * @param address of the account
+     * @param addr of the account
      * @param key of the data to store
      * @param value is the data to store
      */
@@ -93,7 +93,7 @@ public interface Repository {
     /**
      * Retrieve storage value from an account for a given key
      * 
-     * @param address of the account 
+     * @param addr of the account
      * @param key associated with this value
      * @return data in the form of a <code>DataWord</code>
      */
@@ -117,7 +117,7 @@ public interface Repository {
     /**
      * Retrieve balance of an account
      * 
-     * @param address of the account
+     * @param addr of the account
      * @return balance of the account as a <code>BigInteger</code> value
      */
     public BigInteger getBalance(byte[] addr);
@@ -125,7 +125,7 @@ public interface Repository {
     /**
      * Add value to the balance of an account
      * 
-     * @param address of the account
+     * @param addr of the account
      * @param value to be added
      * @return new balance of the account
      */

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/BlockHashesMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/BlockHashesMessage.java
@@ -14,7 +14,7 @@ import org.ethereum.util.Utils;
 /**
  * Wrapper around an Ethereum BlockHashes message on the network
  *
- * @see {@link org.ethereum.net.eth.EthMessageCodes#BLOCK_HASHES}
+ * @see org.ethereum.net.eth.EthMessageCodes#BLOCK_HASHES
  */
 public class BlockHashesMessage extends EthMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/BlocksMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/BlocksMessage.java
@@ -11,7 +11,7 @@ import org.ethereum.util.RLPList;
 /**
  * Wrapper around an Ethereum Blocks message on the network
  *
- * @see {@link org.ethereum.net.eth.EthMessageCodes#BLOCKS}
+ * @see org.ethereum.net.eth.EthMessageCodes#BLOCKS
  */
 public class BlocksMessage extends EthMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/EthHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/EthHandler.java
@@ -24,7 +24,7 @@ import static org.ethereum.net.message.StaticMessages.GET_TRANSACTIONS_MESSAGE;
 
 /**
  * Process the messages between peers with 'eth' capability on the network.
- * <p/>
+ * <p>
  * Peers with 'eth' capability can send/receive:
  * <ul>
  * <li>STATUS				:	Announce their status to the peer</li>

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/EthMessageCodes.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/EthMessageCodes.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /**
  * A list of commands for the Ethereum network protocol.
- * <br/>
+ * <br>
  * The codes for these commands are the first byte in every packet.
  * 
  * @see <a href="https://github.com/ethereum/wiki/wiki/Wire-Protocol">
@@ -15,7 +15,7 @@ public enum EthMessageCodes {
 
 	/* Ethereum protocol */
 
-	/** [0x00, [PROTOCOL_VERSION, NETWORK_ID, TD, BEST_HASH, GENESIS_HASH] <br/>
+	/** [0x00, [PROTOCOL_VERSION, NETWORK_ID, TD, BEST_HASH, GENESIS_HASH] <br>
 	 * Inform a peer of it's current ethereum state. This message should be
 	 * send after the initial handshake and prior to any ethereum related messages. */
 	STATUS(0x00),
@@ -26,38 +26,38 @@ public enum EthMessageCodes {
 	 * currently in the queue. */
 	GET_TRANSACTIONS(0x01),
 
-	/** [+0x02, [nonce, receiving_address, value, ...], ...] <br/>
+	/** [+0x02, [nonce, receiving_address, value, ...], ...] <br>
 	 * Specify (a) transaction(s) that the peer should make sure is included
 	 * on its transaction queue. The items in the list (following the first item 0x12)
 	 * are transactions in the format described in the main Ethereum specification. */
 	TRANSACTIONS(0x02),
 
-	/** [+0x03, [hash : B_32, maxBlocks: P]: <br/>
+	/** [+0x03, [hash : B_32, maxBlocks: P]: <br>
 	 * Requests a BlockHashes message of at most maxBlocks entries,
 	 * of block hashes from the blockchain, starting at the parent of block hash.
 	 * Does not require the peer to give maxBlocks hashes -
 	 * they could give somewhat fewer. */
 	GET_BLOCK_HASHES(0x03),
 
-	/** [+0x04, [hash_0: B_32, hash_1: B_32, ....]: <br/>Gives a series of hashes
+	/** [+0x04, [hash_0: B_32, hash_1: B_32, ....]: <br>Gives a series of hashes
 	 * of blocks (each the child of the next). This implies that the blocks
 	 * are ordered from youngest to oldest. */
 	BLOCK_HASHES(0x04),
 
-	/** [+0x05, [hash_0: B_32, hash_1: B_32, ....]: <br/>Requests a Blocks message
-	 * detailing a number of blocks to be sent, each referred to by a hash. <br/>
+	/** [+0x05, [hash_0: B_32, hash_1: B_32, ....]: <br>Requests a Blocks message
+	 * detailing a number of blocks to be sent, each referred to by a hash. <br>
 	 * <b>Note:</b> Don't expect that the peer necessarily give you all these blocks
 	 * in a single message - you might have to re-request them. */
 	GET_BLOCKS(0x05),
 
-	/** [+0x06, [block_header, transaction_list, uncle_list], ...] <br/>
+	/** [+0x06, [block_header, transaction_list, uncle_list], ...] <br>
 	 * Specify (a) block(s) that the peer should know about.
 	 * The items in the list (following the first item, 0x13)
 	 * are blocks in the format described in the main Ethereum specification. */
 	BLOCKS(0x06),
 
     /**
-     * [+0x07 [blockHeader, transactionList, uncleList], totalDifficulty] <br/>
+     * [+0x07 [blockHeader, transactionList, uncleList], totalDifficulty] <br>
      * Specify a single block that the peer should know about. The composite item 
      * in the list (following the message ID) is a block in the format described 
      * in the main Ethereum specification. */

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/GetBlockHashesMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/GetBlockHashesMessage.java
@@ -10,7 +10,7 @@ import org.spongycastle.util.encoders.Hex;
 /**
  * Wrapper around an Ethereum GetBlockHashes message on the network
  * 
- * @see {@link org.ethereum.net.eth.EthMessageCodes#GET_BLOCK_HASHES}
+ * @see org.ethereum.net.eth.EthMessageCodes#GET_BLOCK_HASHES
  */
 public class GetBlockHashesMessage extends EthMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/GetBlocksMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/GetBlocksMessage.java
@@ -13,7 +13,7 @@ import static org.ethereum.net.eth.EthMessageCodes.GET_BLOCKS;
 /**
  * Wrapper around an Ethereum GetBlocks message on the network
  * 
- * @see {@link org.ethereum.net.eth.EthMessageCodes#GET_BLOCKS}
+ * @see org.ethereum.net.eth.EthMessageCodes#GET_BLOCKS
  */
 public class GetBlocksMessage extends EthMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/GetTransactionsMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/GetTransactionsMessage.java
@@ -7,7 +7,7 @@ import org.spongycastle.util.encoders.Hex;
 /**
  * Wrapper around an Ethereum GetTransactions message on the network
  * 
- * @see {@link org.ethereum.net.eth.EthMessageCodes#GET_TRANSACTIONS} *
+ * @see org.ethereum.net.eth.EthMessageCodes#GET_TRANSACTIONS
  */
 public class GetTransactionsMessage extends EthMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/NewBlockMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/NewBlockMessage.java
@@ -7,7 +7,7 @@ import org.ethereum.util.RLPList;
 /**
  * Wrapper around an Ethereum Blocks message on the network
  * 
- * @see {@link org.ethereum.net.eth.EthMessageCodes#NEW_BLOCK}
+ * @see org.ethereum.net.eth.EthMessageCodes#NEW_BLOCK
  */
 public class NewBlockMessage extends EthMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/StatusMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/StatusMessage.java
@@ -11,7 +11,7 @@ import static org.ethereum.net.eth.EthMessageCodes.STATUS;
 /**
  * Wrapper around an Ethereum Status message on the network 
  * 
- * @see {@link org.ethereum.net.eth.EthMessageCodes#STATUS}
+ * @see org.ethereum.net.eth.EthMessageCodes#STATUS
  */
 public class StatusMessage extends EthMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/TransactionsMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/TransactionsMessage.java
@@ -15,7 +15,7 @@ import java.util.Set;
 /**
  * Wrapper around an Ethereum Transactions message on the network 
  * 
- * @see {@link org.ethereum.net.eth.EthMessageCodes#TRANSACTIONS}
+ * @see org.ethereum.net.eth.EthMessageCodes#TRANSACTIONS
  */
 public class TransactionsMessage extends EthMessage {
 	

--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/DisconnectMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/DisconnectMessage.java
@@ -11,8 +11,8 @@ import static org.ethereum.net.message.ReasonCode.REQUESTED;
 
 /**
  * Wrapper around an Ethereum Disconnect message on the network
- * 
- * @see {@link org.ethereum.net.p2p.P2pMessageCodes#DISCONNECT}
+ *
+ * @see org.ethereum.net.p2p.P2pMessageCodes#DISCONNECT
  */
 public class DisconnectMessage extends P2pMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/GetPeersMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/GetPeersMessage.java
@@ -5,7 +5,7 @@ import org.spongycastle.util.encoders.Hex;
 /**
  * Wrapper around an Ethereum GetPeers message on the network
  * 
- * @see {@link org.ethereum.net.p2p.P2pMessageCodes#GET_PEERS}
+ * @see org.ethereum.net.p2p.P2pMessageCodes#GET_PEERS
  */
 public class GetPeersMessage extends P2pMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/HelloMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/HelloMessage.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * Wrapper around an Ethereum HelloMessage on the network
  * 
- * @see {@link org.ethereum.net.p2p.P2pMessageCodes#HELLO}
+ * @see org.ethereum.net.p2p.P2pMessageCodes#HELLO
  */
 public class HelloMessage extends P2pMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/P2pMessageCodes.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/P2pMessageCodes.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /**
  * A list of commands for the Ethereum network protocol.
- * <br/>
+ * <br>
  * The codes for these commands are the first byte in every packet.
  * 
  * @see <a href="https://github.com/ethereum/wiki/wiki/Wire-Protocol">
@@ -15,28 +15,28 @@ public enum P2pMessageCodes {
 
 	/* P2P */
 
-	/** [0x00, P2P_VERSION, CLIEND_ID, CAPS, LISTEN_PORT, CLIENT_ID] <br/>
+	/** [0x00, P2P_VERSION, CLIEND_ID, CAPS, LISTEN_PORT, CLIENT_ID] <br>
 	 * First packet sent over the connection, and sent once by both sides.
 	 * No other messages may be sent until a Hello is received. */
 	HELLO(0x00),
 
-	/** [0x01, REASON] <br/>Inform the peer that a disconnection is imminent;
+	/** [0x01, REASON] <br>Inform the peer that a disconnection is imminent;
 	 * if received, a peer should disconnect immediately. When sending,
 	 * well-behaved hosts give their peers a fighting chance (read: wait 2 seconds)
 	 * to disconnect to before disconnecting themselves. */
 	DISCONNECT(0x01),
 
-	/** [0x02] <br/>Requests an immediate reply of Pong from the peer. */
+	/** [0x02] <br>Requests an immediate reply of Pong from the peer. */
 	PING(0x02),
 
-	/** [0x03] <br/>Reply to peer's Ping packet. */
+	/** [0x03] <br>Reply to peer's Ping packet. */
 	PONG(0x03),
 
-	/** [0x04] <br/>Request the peer to enumerate some known peers
+	/** [0x04] <br>Request the peer to enumerate some known peers
 	 * for us to connect to. This should include the peer itself. */
 	GET_PEERS(0x04),
 
-	/** [0x05, [IP1, Port1, Id1], [IP2, Port2, Id2], ... ] <br/>
+	/** [0x05, [IP1, Port1, Id1], [IP2, Port2, Id2], ... ] <br>
 	 * Specifies a number of known peers. IP is a 4-byte array 'ABCD'
 	 * that should be interpreted as the IP address A.B.C.D.
 	 * Port is a 2-byte array that should be interpreted as a

--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/PeersMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/PeersMessage.java
@@ -17,7 +17,7 @@ import org.spongycastle.util.encoders.Hex;
 /**
  * Wrapper around an Ethereum Peers message on the network
  * 
- * @see {@link org.ethereum.net.p2p.P2pMessageCodes#PEERS}
+ * @see org.ethereum.net.p2p.P2pMessageCodes#PEERS
  */
 public class PeersMessage extends P2pMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/PingMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/PingMessage.java
@@ -5,7 +5,7 @@ import org.spongycastle.util.encoders.Hex;
 /**
  * Wrapper around an Ethereum Ping message on the network
  * 
- * @see {@link org.ethereum.net.p2p.P2pMessageCodes#PING}
+ * @see org.ethereum.net.p2p.P2pMessageCodes#PING
  */
 public class PingMessage extends P2pMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/PongMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/PongMessage.java
@@ -6,7 +6,7 @@ import org.spongycastle.util.encoders.Hex;
 /**
  * Wrapper around an Ethereum Pong message on the network
  * 
- * @see {@link org.ethereum.net.p2p.P2pMessageCodes#PONG}
+ * @see org.ethereum.net.p2p.P2pMessageCodes#PONG
  */
 public class PongMessage extends P2pMessage {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/shh/ShhHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/shh/ShhHandler.java
@@ -11,8 +11,8 @@ import org.slf4j.LoggerFactory;
  * Process the messages between peers with 'shh' capability on the network.
  * 
  * Peers with 'shh' capability can send/receive:
- * <ul>
- * </ul>
+ *
+ *
  */
 public class ShhHandler extends SimpleChannelInboundHandler<ShhMessage> {
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/shh/ShhMessageCodes.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/shh/ShhMessageCodes.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /**
  * A list of commands for the Whisper network protocol.
- * <br/>
+ * <br>
  * The codes for these commands are the first byte in every packet.
  * 
  * @see <a href="https://github.com/ethereum/wiki/wiki/Wire-Protocol">

--- a/ethereumj-core/src/main/java/org/ethereum/serpent/SerpentCompiler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/serpent/SerpentCompiler.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 
 /**
  * www.ethereumJ.com
- * @author: Roman Mandeleil
+ * @author Roman Mandeleil
  * Created on: 13/05/14 19:37
  */
 public class SerpentCompiler {
@@ -197,7 +197,7 @@ public class SerpentCompiler {
      *
      * @param code
      * @param init
-     * @return
+     * @return encoded bytes
      */
     public static byte[] encodeMachineCodeForVMRun(byte[] code, byte[] init) {
 

--- a/ethereumj-core/src/main/java/org/ethereum/trie/Cache.java
+++ b/ethereumj-core/src/main/java/org/ethereum/trie/Cache.java
@@ -28,7 +28,7 @@ public class Cache {
 	 * Put the node in the cache if RLP encoded value is longer than 32 bytes
 	 * 
 	 * @param o the Node which could be a pair-, multi-item Node or single Value  
-	 * @return sha3 hash of RLP encoded node if length > 32 otherwise return node itself
+	 * @return sha3 hash of RLP encoded node if length &gt; 32 otherwise return node itself
 	 */
 	public Object put(Object o) {
 		Value value = new Value(o);

--- a/ethereumj-core/src/main/java/org/ethereum/trie/Node.java
+++ b/ethereumj-core/src/main/java/org/ethereum/trie/Node.java
@@ -32,15 +32,15 @@ import org.ethereum.util.Value;
  * 
  * Where a node is referenced inside a node, what is included is:
  * 
- *  	H(rlp.encode(x)) where H(x) = sha3(x) if len(x) >= 32 else x 
+ *  	H(rlp.encode(x)) where H(x) = sha3(x) if len(x) &gt;= 32 else x
  * 
  * Note that when updating a trie, you will need to store the key/value pair (sha3(x), x) 
- * in a persistent lookup table when you create a node with length >= 32, 
+ * in a persistent lookup table when you create a node with length &gt;= 32,
  * but if the node is shorter than that then you do not need to store anything 
- * when length < 32 for the obvious reason that the function f(x) = x is reversible.
+ * when length &lt; 32 for the obvious reason that the function f(x) = x is reversible.
  *
  * www.ethereumJ.com
- * @author: Nick Savers
+ * @author Nick Savers
  * Created on: 20/05/2014 10:44
  */
 public class Node {

--- a/ethereumj-core/src/main/java/org/ethereum/trie/Trie.java
+++ b/ethereumj-core/src/main/java/org/ethereum/trie/Trie.java
@@ -18,7 +18,7 @@ public interface Trie {
 	 * Insert or update a value in the trie for a specified key
 	 * 
 	 * @param key - any length byte array
-	 * @param an rlp encoded byte array of the object to store
+	 * @param value rlp encoded byte array of the object to store
 	 */
     public void update(byte[] key, byte[] value);
     

--- a/ethereumj-core/src/main/java/org/ethereum/util/ByteUtil.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/ByteUtil.java
@@ -42,9 +42,9 @@ public class ByteUtil {
 
     /**
      * Omitting sign indication byte.
-     * <br/><br/>
+     * <br><br>
      * Instead of {@link org.spongycastle.util.BigIntegers#asUnsignedByteArray(BigInteger)} 
-     * <br/>we use this custom method to avoid an empty array in case of BigInteger.ZERO
+     * <br>we use this custom method to avoid an empty array in case of BigInteger.ZERO
      *
      * @param value - any big integer number. A <code>null</code>-value will return <code>null</code>
      * @return A byte array without a leading zero byte if present in the signed encoding. 
@@ -94,14 +94,15 @@ public class ByteUtil {
     }
     
     /**
-     * Convert a byte-array into a hex String. <br/>
+     * Convert a byte-array into a hex String.<br>
      * Works similar to {@link Hex#toHexString} 
      * but allows for <code>null</code>
      * 
      * @param data - byte-array to convert to a hex-string
-     * @return hex representation of the data.<br/> 
+     * @return hex representation of the data.<br>
      * 		Returns an empty String if the input is <code>null</code>
-     * @see {@link Hex#toHexString}
+     *
+     * @see Hex#toHexString
      */
     public static String toHexString(byte[] data) {
         return data == null ? "" : Hex.toHexString(data);
@@ -109,7 +110,7 @@ public class ByteUtil {
     
     /**
      * Calculate packet length
-     * @param msg
+     * @param msg byte[]
      * @return byte-array with 4 elements
      */
     public static byte[] calcPacketLength(byte[] msg) {
@@ -213,6 +214,8 @@ public class ByteUtil {
 
 	/**
 	 * encode the values and concatenate together
+     * @param args Object
+     * @return byte[]
 	 */
 	public static byte[] encodeDataList(Object... args) {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -253,6 +256,10 @@ public class ByteUtil {
 
     /**
      * increment byte array as a number until max is reached
+     *
+     * @param bytes byte[]
+     *
+     * @return boolean
      */
     public static boolean increment(byte[] bytes) {
         final int startIndex = 0;
@@ -272,7 +279,7 @@ public class ByteUtil {
      * with zeros.
      * 
      * @param value - a BigInteger with a maximum value of 2^256-1
-     * @return Byte array of given size with a copy of the </code>src</code>
+     * @return Byte array of given size with a copy of the <code>src</code>
      */
     public static byte[] copyToArray(BigInteger value) {
 		byte[] src = ByteUtil.bigIntegerToBytes(value);

--- a/ethereumj-core/src/main/java/org/ethereum/util/CompactEncoder.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/CompactEncoder.java
@@ -36,13 +36,13 @@ import java.util.Map;
  * to ensure the hex-string is even in length and thus is representable by a whole number of bytes. 
  *  
  * Examples:
- * > [ 1, 2, 3, 4, 5 ]
+ * &gt; [ 1, 2, 3, 4, 5 ]
  * '\x11\x23\x45'
- * > [ 0, 1, 2, 3, 4, 5 ]
+ * &gt; [ 0, 1, 2, 3, 4, 5 ]
  * '\x00\x01\x23\x45'
- * > [ 0, 15, 1, 12, 11, 8, T ]
+ * &gt; [ 0, 15, 1, 12, 11, 8, T ]
  * '\x20\x0f\x1c\xb8'
- * > [ 15, 1, 12, 11, 8, T ]
+ * &gt; [ 15, 1, 12, 11, 8, T ]
  * '\x3f\x1c\xb8'
  *
  */
@@ -121,6 +121,7 @@ public class CompactEncoder {
 	/**
 	 * Transforms a binary array to hexadecimal format + terminator
 	 *
+     * @param str byte[]
 	 * @return array with each individual nibble adding a terminator at the end 
 	 */
 	public static byte[] binToNibbles(byte[] str) {

--- a/ethereumj-core/src/main/java/org/ethereum/util/FastByteComparisons.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/FastByteComparisons.java
@@ -37,6 +37,15 @@ public abstract class FastByteComparisons {
 
   /**
    * Lexicographically compare two byte arrays.
+   *
+   * @param b1 buffer1
+   * @param s1 offset1
+   * @param l1 length1
+   * @param b2 buffer2
+   * @param s2 offset2
+   * @param l2 length2
+   *
+   * @return int
    */
   public static int compareTo(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
     return LexicographicalComparerHolder.BEST_COMPARER.compareTo(

--- a/ethereumj-core/src/main/java/org/ethereum/util/Utils.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/Utils.java
@@ -19,7 +19,7 @@ public class Utils {
 
     /**
      * @param hexNum should be in form '0x34fabd34....'
-     * @return
+     * @return String
      */
     public static String hexStringToDecimalString(String hexNum) {
 

--- a/ethereumj-core/src/main/java/org/ethereum/vm/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/Program.java
@@ -152,7 +152,7 @@ public class Program {
     
     /**
      * Verifies that the stack is at least <code>stackSize</code>
-     * @param stackSize
+     * @param stackSize int
      * @throws StackTooSmallException If the stack is 
      * 		smaller than <code>stackSize</code>
      */


### PR DESCRIPTION
This should fix all javadoc errors. I did not fix the warnings. Most of them are about missing parameter descriptions. Adding placeholders would remove the warnings, but wouldn't help users of the library.
