### PR TITLE
fix an error ( Error: Unable to access jarfile ./lib/ethereumj-0.7.9.jar )

### DIFF
--- a/ethereumj-studio/src/main/resources/config/cli.sh
+++ b/ethereumj-studio/src/main/resources/config/cli.sh
@@ -1,1 +1,1 @@
-java -Xmx6144M -Dlog4j.configuration=file:./config/log4j.properties -jar ./lib/ethereumj-0.7.9.jar org.ethereum.Start -o true $@
+java -Xmx6144M -Dlog4j.configuration=file:./config/log4j.properties -jar ./lib/ethereumj-0.7.9*.jar org.ethereum.Start -o true $@


### PR DESCRIPTION
the file that was trying to load is not available - has some timestampish thing now at the end. Here and now it was: ethereumj-0.7.9.20141123.2140.jar 

the *.bat might have the same problem - but I have no environment to test such a change.

On linux I am one step further now - now I have to find a way around [net]  Exception: Connection refused
