### PR TITLE
Remove denomination values absent in white paper

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/Denomination.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Denomination.java
@@ -5,14 +5,9 @@ import java.math.BigInteger;
 public enum Denomination {
 
     WEI(newBigInt(0)),
-    ADA(newBigInt(3)),
-    BABBAGE(newBigInt(6)),
-    SHANNON(newBigInt(9)),
     SZABO(newBigInt(12)),
     FINNY(newBigInt(15)),
-    ETHER(newBigInt(18)),
-    EINSTEIN(newBigInt(21)),
-    DOUGLAS(newBigInt(42));
+    ETHER(newBigInt(18));
 
     private BigInteger amount;
 
@@ -33,13 +28,7 @@ public enum Denomination {
     }
 
     public static String toFriendlyString(BigInteger value) {
-        if(value.compareTo(DOUGLAS.value()) == 1 || value.compareTo(DOUGLAS.value()) == 0) {
-            return Float.toString(value.divide(DOUGLAS.value()).floatValue()) +  " DOUGLAS";
-        }
-        else if(value.compareTo(EINSTEIN.value()) == 1 || value.compareTo(EINSTEIN.value()) == 0) {
-            return Float.toString(value.divide(EINSTEIN.value()).floatValue()) +  " EINSTEIN";
-        }
-        else if(value.compareTo(ETHER.value()) == 1 || value.compareTo(ETHER.value()) == 0) {
+        if (value.compareTo(ETHER.value()) == 1 || value.compareTo(ETHER.value()) == 0) {
             return Float.toString(value.divide(ETHER.value()).floatValue()) +  " ETHER";
         }
         else if(value.compareTo(FINNY.value()) == 1 || value.compareTo(FINNY.value()) == 0) {
@@ -47,15 +36,6 @@ public enum Denomination {
         }
         else if(value.compareTo(SZABO.value()) == 1 || value.compareTo(SZABO.value()) == 0) {
             return Float.toString(value.divide(SZABO.value()).floatValue()) +  " SZABO";
-        }
-        else if(value.compareTo(SHANNON.value()) == 1 || value.compareTo(SHANNON.value()) == 0) {
-            return Float.toString(value.divide(SHANNON.value()).floatValue()) +  " SHANNON";
-        }
-        else if(value.compareTo(BABBAGE.value()) == 1 || value.compareTo(BABBAGE.value()) == 0) {
-            return Float.toString(value.divide(BABBAGE.value()).floatValue()) +  " BABBAGE";
-        }
-        else if(value.compareTo(ADA.value()) == 1 || value.compareTo(ADA.value()) == 0) {
-            return Float.toString(value.divide(ADA.value()).floatValue()) +  " ADA";
         }
         else
             return Float.toString(value.divide(WEI.value()).floatValue()) +  " WEI";


### PR DESCRIPTION
A recent revision of the Ethereum white paper [removes the denominations
labeled 'lovelace', 'babbage' and 'shannon'](http://git.io/xJJf7g). This commit reflects
the change to the whitepaper by removing the corresponding labels from
the Denomination enum (as an aside, note the discrepancy between
'lovelace' in the whitepaper and 'ada' in our implementation).

go-ethereum still contains these values, but cpp-ethereum does
not. This commit assumes that the whitepaper and cpp implementation
represent the current consensus on explicitly named denominations.

By the same rationale, the 'douglas' and 'einstein' labels have been
removed as well. These values never appeared in the whitepaper or cpp
implementations. They were introduced to the go implementation in
ethereum/go-ethereum@e7d9bcd, but because the whitepaper and cpp
implementation are silent on these values, they are omitted here.
