### PR TITLE
Specify explicit UTF-8 encoding for compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ subprojects {
     group = 'org.ethereum'
     version = '0.7.14-SNAPSHOT'
 
+    tasks.withType(Compile) {
+        options.encoding = 'UTF-8'
+    }
+
     repositories {
         jcenter()
     }


### PR DESCRIPTION
UTF-8 is the default file encoding on some platforms (e.g. OS X), but
for other platforms (e.g. Windows), UTF-8 characters in classes like
ECKey cause errors during compilation on other platforms (e.g. Windows).

See http://pastebin.com/X9jEemje for examples of these errors.

This commit configures Gradle to explicitly use UTF-8 encoding for all
compilation tasks.
