### PR TITLE
Add tests for Messages in p2p/eth

### DIFF
--- a/ethereumj-core/src/test/java/test/ethereum/net/DisconnectMessageTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/DisconnectMessageTest.java
@@ -1,5 +1,11 @@
 package test.ethereum.net;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import java.lang.System;
+
 import org.ethereum.net.message.ReasonCode;
 import org.ethereum.net.p2p.DisconnectMessage;
 
@@ -49,16 +55,58 @@ public class DisconnectMessageTest {
         assertEquals(ReasonCode.INCOMPATIBLE_NETWORK, disconnectMessage.getReason());
     }
 
-    @Test //handling unknown codes properly
+    @Test //handling boundary-high
     public void test_4() {
 
-        String disconnectMessageRaw = "C25555";
+        String disconnectMessageRaw = "C28080";
         byte[] payload = Hex.decode(disconnectMessageRaw);
 
         DisconnectMessage disconnectMessage = new DisconnectMessage(payload);
         System.out.println(disconnectMessage);
 
-        assertEquals(disconnectMessage.getReason(), ReasonCode.UNKNOWN);
+        assertEquals(disconnectMessage.getReason(), ReasonCode.REQUESTED); //high numbers are zeroed
+    }
+
+    @Test //handling boundary-low
+    public void test_5() {
+
+        String disconnectMessageRaw = "C20000";
+        byte[] payload = Hex.decode(disconnectMessageRaw);
+
+        DisconnectMessage disconnectMessage = new DisconnectMessage(payload);
+        System.out.println(disconnectMessage);
+
+        assertEquals(disconnectMessage.getReason(), ReasonCode.REQUESTED);
+    }
+
+    @Test //handling boundary-low minus 1 (error)
+    public void test_6() {
+
+        String disconnectMessageRaw = "C19999";
+        byte[] payload = Hex.decode(disconnectMessageRaw);
+
+        try{
+          DisconnectMessage disconnectMessage = new DisconnectMessage(payload);
+          disconnectMessage.toString(); //throws exception
+          assertTrue("Valid raw encoding for disconnectMessage", false);
+        } catch (RuntimeException e) {
+          assertTrue("Invalid raw encoding for disconnectMessage", true);
+        }
+    }
+
+    @Test //handling boundary-high plus 1 (error)
+    public void test_7() {
+
+        String disconnectMessageRaw = "C28081";
+        byte[] payload = Hex.decode(disconnectMessageRaw);
+
+        try{
+          DisconnectMessage disconnectMessage = new DisconnectMessage(payload);
+          disconnectMessage.toString(); //throws exception
+          assertTrue("Valid raw encoding for disconnectMessage", false);
+        } catch (RuntimeException e) {
+          assertTrue("Invalid raw encoding for disconnectMessage", true);
+        }
     }
 }
 

--- a/ethereumj-core/src/test/java/test/ethereum/net/DisconnectMessageTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/DisconnectMessageTest.java
@@ -48,5 +48,17 @@ public class DisconnectMessageTest {
 
         assertEquals(ReasonCode.INCOMPATIBLE_NETWORK, disconnectMessage.getReason());
     }
+
+    @Test //handling unknown codes properly
+    public void test_4() {
+
+        String disconnectMessageRaw = "C25555";
+        byte[] payload = Hex.decode(disconnectMessageRaw);
+
+        DisconnectMessage disconnectMessage = new DisconnectMessage(payload);
+        System.out.println(disconnectMessage);
+
+        assertEquals(disconnectMessage.getReason(), ReasonCode.UNKNOWN);
+    }
 }
 

--- a/ethereumj-core/src/test/java/test/ethereum/net/GetPeersMessageTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/GetPeersMessageTest.java
@@ -1,0 +1,36 @@
+package test.ethereum.net;
+
+import static org.junit.Assert.assertEquals;
+
+import org.spongycastle.util.encoders.Hex;
+import org.ethereum.net.p2p.P2pMessageCodes;
+import org.ethereum.net.p2p.GetPeersMessage;
+import org.junit.Test;
+
+public class GetPeersMessageTest {
+
+    /* GETPEERS_MESSAGE */
+
+    @Test
+    public void testGetPeers() {
+        
+        //Init
+        GetPeersMessage getPeersMessage = new GetPeersMessage();
+
+        //System.out.println(getPeersMessage.getEncoded());
+
+        //toString
+        assertEquals("[GET_PEERS]", getPeersMessage.toString());
+
+        //getEncoded
+        assertEquals("C104", Hex.toHexString(  getPeersMessage.getEncoded() ).toUpperCase() );
+
+        //getAnswerMessage
+        assertEquals(null, getPeersMessage.getAnswerMessage());
+        
+        //getCommand
+        assertEquals(P2pMessageCodes.GET_PEERS, getPeersMessage.getCommand());
+        
+    }
+}
+

--- a/ethereumj-core/src/test/java/test/ethereum/net/HelloMessageTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/HelloMessageTest.java
@@ -1,8 +1,23 @@
 package test.ethereum.net;
 
+<<<<<<< HEAD
 import org.ethereum.net.p2p.HelloMessage;
 import org.ethereum.net.p2p.P2pMessageCodes;
 
+=======
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.ethereum.net.client.Capability;
+import org.ethereum.net.eth.EthHandler;
+import org.ethereum.net.p2p.HelloMessage;
+import org.ethereum.net.p2p.P2pMessageCodes;
+import org.ethereum.net.p2p.P2pHandler;
+import org.ethereum.net.shh.ShhHandler;
+>>>>>>> 0266dac... Added fail tests, constructor tests
 import org.junit.Test;
 
 import org.slf4j.Logger;
@@ -17,7 +32,7 @@ public class HelloMessageTest {
     /* HELLO_MESSAGE */
     private static final Logger logger = LoggerFactory.getLogger("test");
 
-
+    //Parsing from raw bytes
     @Test
     public void test1() {
         String helloMessageRaw = "f87a8002a5457468657265756d282b2b292f76302e372e392f52656c656173652f4c696e75782f672b2bccc58365746827c583736868018203e0b8401fbf1e41f08078918c9f7b6734594ee56d7f538614f602c71194db0a1af5a77f9b86eb14669fe7a8a46a2dd1b7d070b94e463f4ecd5b337c8b4d31bbf8dd5646";
@@ -37,6 +52,55 @@ public class HelloMessageTest {
 
 
     }
+    
+    //Instantiate from constructor
+    @Test
+    public void test2() {
+        //Init
+        byte version = 2;
+        String clientStr = "Ethereum(++)/v0.7.9/Release/Linux/g++";
+        List<Capability> capabilities = Arrays.asList(
+          new Capability( Capability.ETH, EthHandler.VERSION),
+          new Capability( Capability.SHH, ShhHandler.VERSION),
+          new Capability( Capability.P2P, P2pHandler.VERSION) );
+        int listenPort = 992;
+        String peerId = "1fbf1e41f08078918c9f7b6734594ee56d7f538614f602c71194db0a1af5a";
 
+        HelloMessage helloMessage = new HelloMessage(version, clientStr, capabilities, listenPort, peerId);
+        logger.info(helloMessage.toString());
 
+        assertEquals(P2pMessageCodes.HELLO, helloMessage.getCommand());
+        assertEquals(version, helloMessage.getP2PVersion());
+        assertEquals(clientStr, helloMessage.getClientId());
+        assertEquals( 3 ,   helloMessage.getCapabilities().size());
+        assertEquals( listenPort , helloMessage.getListenPort());
+        assertEquals( peerId , helloMessage.getPeerId());
+    
+        //TODO tostring?
+    }
+
+    //Fail test
+    @Test
+    public void test3() {
+        //Init
+        byte version = -1; //invalid version
+        String clientStr = ""; //null id
+        List<Capability> capabilities = Arrays.asList(
+          new Capability( null, (byte) 0 ), 
+          new Capability( null, (byte) 0 ), 
+          null, //null here causes NullPointerException when using toString
+          new Capability( null, (byte) 0 ) ); //encoding null capabilities
+        int listenPort = 99999; //invalid port
+        String peerId = ""; //null id
+
+        HelloMessage helloMessage = new HelloMessage(version, clientStr, capabilities, listenPort, peerId);
+        logger.info(helloMessage.toString());
+
+        assertEquals(P2pMessageCodes.HELLO, helloMessage.getCommand());
+        assertEquals(version, helloMessage.getP2PVersion());
+        assertEquals(clientStr, helloMessage.getClientId());
+        assertEquals( 4 ,   helloMessage.getCapabilities().size());
+        assertEquals( listenPort , helloMessage.getListenPort());
+        assertEquals( peerId , helloMessage.getPeerId());
+    }
 }

--- a/ethereumj-core/src/test/java/test/ethereum/net/HelloMessageTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/HelloMessageTest.java
@@ -88,7 +88,7 @@ public class HelloMessageTest {
         String peerId = ""; //null id
 
         HelloMessage helloMessage = new HelloMessage(version, clientStr, capabilities, listenPort, peerId);
-        logger.info(helloMessage.toString());
+        //logger.info(helloMessage.toString());
 
         assertEquals(P2pMessageCodes.HELLO, helloMessage.getCommand());
         assertEquals(version, helloMessage.getP2PVersion());

--- a/ethereumj-core/src/test/java/test/ethereum/net/HelloMessageTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/HelloMessageTest.java
@@ -1,10 +1,5 @@
 package test.ethereum.net;
 
-<<<<<<< HEAD
-import org.ethereum.net.p2p.HelloMessage;
-import org.ethereum.net.p2p.P2pMessageCodes;
-
-=======
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -17,7 +12,6 @@ import org.ethereum.net.p2p.HelloMessage;
 import org.ethereum.net.p2p.P2pMessageCodes;
 import org.ethereum.net.p2p.P2pHandler;
 import org.ethereum.net.shh.ShhHandler;
->>>>>>> 0266dac... Added fail tests, constructor tests
 import org.junit.Test;
 
 import org.slf4j.Logger;

--- a/ethereumj-core/src/test/java/test/ethereum/net/PeerTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/PeerTest.java
@@ -1,0 +1,57 @@
+package test.ethereum.net;
+
+import static org.junit.Assert.assertEquals;
+
+import org.ethereum.net.client.Capability;
+import org.ethereum.net.p2p.Peer;
+
+import org.spongycastle.util.encoders.Hex;
+import java.net.InetAddress;
+import java.util.List;
+import java.util.ArrayList;
+import org.junit.Test;
+
+public class PeerTest {
+
+    /* PEER */
+
+    @Test
+    public void testPeer() {
+        
+        //Init
+        InetAddress address = InetAddress.getLoopbackAddress();
+        List<Capability> capabilities = new ArrayList<>(); 
+        int port = 1010;
+        String peerId = "1010";
+        Peer peerCopy = new Peer(address, port, peerId );
+
+        //Peer
+        Peer peer = new Peer(address, port, peerId );
+
+        //getAddress
+        assertEquals( "127.0.0.1" , peer.getAddress().getHostAddress() );
+
+        //getPort
+        assertEquals( port , peer.getPort() );
+
+        //getPeerId
+        assertEquals( peerId , peer.getPeerId() );
+
+        //getCapabilities
+        assertEquals( capabilities , peer.getCapabilities() );
+                                       
+        //getEncoded
+        assertEquals("CC847F0000018203F2821010C0", Hex.toHexString(  peer.getEncoded() ).toUpperCase() );
+        
+        //toString
+        assertEquals("[ip=" + address.getHostAddress() + " port=" + Integer.toString( port ) + " peerId=" + peerId + "]", peer.toString() );
+
+        //equals
+        assertEquals(true, peer.equals( peerCopy ) );
+        assertEquals(false, peer.equals( null ) );
+
+        //hashCode
+        assertEquals(-1, peer.hashCode());
+    }
+}
+

--- a/ethereumj-core/src/test/java/test/ethereum/net/PeersMessageTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/PeersMessageTest.java
@@ -1,5 +1,18 @@
 package test.ethereum.net;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.ethereum.net.client.Capability;
 import org.ethereum.net.p2p.GetPeersMessage;
 import org.ethereum.net.p2p.P2pMessageCodes;
 import org.ethereum.net.p2p.Peer;
@@ -54,4 +67,58 @@ public class PeersMessageTest {
     }
 
 
+    @Test /* PeersMessage 1 from constructor */
+    public void testPeers_2() {
+        //Init
+        InetAddress address = InetAddress.getLoopbackAddress();
+        List<Capability> capabilities = new ArrayList<>(); 
+        int port = 112;
+        String peerId = "36659c3656c488437cceb11abeb9b9fc69b8055144a7e7db3584d03e606083f90e" +
+          "17a1d3021d674579407cdaaafdfeef485872ab719db9f2b6283f498bb90a71";
+         
+        Set<Peer> peers = new HashSet<>();
+        peers.add(new Peer(address, port, peerId )); 
+        
+        PeersMessage peersMessage= new PeersMessage(peers);
+        logger.info(peersMessage.toString());
+
+        assertEquals(1, peersMessage.getPeers().size());
+
+        Iterator<Peer> it = peersMessage.getPeers().iterator();
+        Peer peer = it.next();
+
+        assertEquals(P2pMessageCodes.PEERS, peersMessage.getCommand());
+        assertEquals("127.0.0.1", peer.getAddress().getHostAddress());
+        assertEquals(112, peer.getPort());
+        assertEquals("36659c3656c488437cceb11abeb9b9fc69b8055144a7e7db3584d03e6" +
+        "06083f90e17a1d3021d674579407cdaaafdfeef485872ab719db9f2b6283f498bb90a71", peer.getPeerId());
+    }
+
+    @Test /* failing test */
+    public void testPeers_3() {
+        //Init
+        InetAddress address = InetAddress.getLoopbackAddress();
+        List<Capability> capabilities = Arrays.asList(
+          new Capability( null, (byte) 0 ), 
+          null //null here can cause NullPointerException when using toString
+          ); //encoding null capabilities
+        int port = -1; //invalid port
+        String peerId = ""; //invalid peerid
+         
+        Set<Peer> peers = new HashSet<>();
+        peers.add(new Peer(address, port, peerId )); 
+        
+        PeersMessage peersMessage= new PeersMessage(peers);
+        logger.info(peersMessage.toString());
+
+        assertEquals(1, peersMessage.getPeers().size());
+
+        Iterator<Peer> it = peersMessage.getPeers().iterator();
+        Peer peer = it.next();
+
+        assertEquals(P2pMessageCodes.PEERS, peersMessage.getCommand());
+        assertEquals("127.0.0.1", peer.getAddress().getHostAddress());
+        assertEquals(-1, peer.getPort());
+        assertEquals( "" , peer.getPeerId());
+    }
 }

--- a/ethereumj-core/src/test/java/test/ethereum/net/StatusMessageTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/net/StatusMessageTest.java
@@ -2,6 +2,8 @@ package test.ethereum.net;
 
 import org.ethereum.net.eth.StatusMessage;
 
+import java.math.BigInteger;
+
 import org.junit.Test;
 
 import org.slf4j.Logger;
@@ -32,5 +34,48 @@ public class StatusMessageTest {
                 Hex.toHexString(statusMessage.getBestHash()));
     }
 
+    @Test //from constructor
+    public void test2(){
+        //Init
+        byte version = 39;
+        byte netId = 0;
+        byte[] difficulty = new BigInteger("25c60144", 16).toByteArray();
+        byte[] bestHash = new BigInteger("832056d3c93ff2739ace7199952e5365aa29f18805be05634c4db125c5340216",16).toByteArray();
+        byte[] genesisHash = new BigInteger("955f36d073ccb026b78ab3424c15cf966a7563aa270413859f78702b9e8e22cb",16).toByteArray();
+
+        StatusMessage statusMessage = new StatusMessage(version, netId, difficulty, bestHash, genesisHash);
+
+        logger.info(statusMessage.toString());
+
+        assertEquals(39, statusMessage.getProtocolVersion());
+        assertEquals("25c60144",
+                Hex.toHexString(statusMessage.getTotalDifficulty()));
+        assertEquals("00832056d3c93ff2739ace7199952e5365aa29f18805be05634c4db125c5340216",
+                Hex.toHexString(statusMessage.getBestHash()));
+        assertEquals("00955f36d073ccb026b78ab3424c15cf966a7563aa270413859f78702b9e8e22cb",
+                Hex.toHexString(statusMessage.getGenesisHash()));
+    }
+
+    @Test //fail test
+    public void test3(){
+        //Init
+        byte version = -1; //invalid version
+        byte netId = -1;  //invalid netid
+        byte[] difficulty = new BigInteger("-1000000", 16).toByteArray(); //negative difficulty
+        byte[] bestHash = new BigInteger("-100000000000000000000000000",16).toByteArray(); //invalid hash
+        byte[] genesisHash = new BigInteger("-1000000000000000000000000000000",16).toByteArray(); //invalid hash
+
+        StatusMessage statusMessage = new StatusMessage(version, netId, difficulty, bestHash, genesisHash);
+
+        logger.info(statusMessage.toString());
+
+        assertEquals(-1, statusMessage.getProtocolVersion());
+        assertEquals("ff000000",
+                Hex.toHexString(statusMessage.getTotalDifficulty()));
+        assertEquals("ff00000000000000000000000000",
+                Hex.toHexString(statusMessage.getBestHash()));
+        assertEquals("ff000000000000000000000000000000",
+                Hex.toHexString(statusMessage.getGenesisHash()));
+    }
 }
 


### PR DESCRIPTION
This includes a few new tests:

DisconnectMessageTest.java - Added bounds checking
GetPeersMessageTest.java - broke this out into its own file for testing
HelloMessageTest.java - Added constructor, fail/bounds test
PeerTest.java - test peer object
StatusMessageTest.java - Added constructor, fail/bounds test

I'll have to run things with the new gradle framework, but these should all run and pass as well