### PR TITLE
init account's ecKey and address, avoid reported NPE

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/Wallet.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Wallet.java
@@ -80,6 +80,7 @@ public class Wallet {
 
     public void addNewAccount() {
         Account account = new Account();
+        account.init();
         String address = Hex.toHexString(account.getEcKey().getAddress());
         rows.put(address, account);
         for (WalletListener listener : listeners)


### PR DESCRIPTION
there's a `init()` method that is not referenced anywhere in the project.
Seems like it might be the reason why you're getting the reported NPE when trying to add a new account.

https://github.com/ethereum/ethereumj/issues/195

This is just a suggestion, perhaps that defaul `.init()` call could be called on the default constructor, but I was just reading out of curiosity to see where the project stands.

