### PR TITLE
Correct stSystemOperationsTest run with programCode.length protection

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/vm/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/Program.java
@@ -389,6 +389,11 @@ public class Program {
             return;
         }
 
+        if (programCode.length == 0) {
+           result = new ProgramResult();
+           result.setHReturn(new byte[] {}); 
+        }
+
         // 4. CREATE THE CONTRACT OUT OF RETURN
         byte[] code = result.getHReturn().array();
 

--- a/ethereumj-core/src/test/java/test/ethereum/jsontestsuite/GitHubStateTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/jsontestsuite/GitHubStateTest.java
@@ -104,10 +104,6 @@ public class GitHubStateTest {
     public void stSystemOperationsTest() throws ParseException {
 
         Set<String> excluded = new HashSet<>();
-        excluded.add("createNameRegistratorZeroMem2");
-        excluded.add("createNameRegistratorZeroMem");
-        excluded.add("createNameRegistratorZeroMemExpansion");
-
 
         String json = JSONReader.loadJSON("StateTests/stSystemOperationsTest.json");
         GitHubJSONTestSuite.runGitHubJsonStateTest(json, excluded);


### PR DESCRIPTION
This removes certain exclusions and improves our coverage.