### PR TITLE
Gas checks must be made earlier than other checks

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/facade/Blockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/Blockchain.java
@@ -1,14 +1,12 @@
 package org.ethereum.facade;
 
-import org.ethereum.core.Block;
-import org.ethereum.core.Chain;
-import org.ethereum.core.Genesis;
-import org.ethereum.core.TransactionReceipt;
+import org.ethereum.core.*;
 import org.ethereum.net.BlockQueue;
 
 import java.math.BigInteger;
 
 import java.util.List;
+import java.util.Set;
 
 public interface Blockchain {
 
@@ -53,4 +51,10 @@ public interface Blockchain {
     public List<Chain> getAltChains();
 
     public List<Block> getGarbage();
+
+    public Set<Transaction> getPendingTransactions();
+    public void addPendingTransactions(Set<Transaction> transactions);
+    public void clearPendingTransactions(List<Transaction> receivedTransactions);
+
+
 }

--- a/ethereumj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -133,4 +133,6 @@ public interface Ethereum {
 
     public ChannelManager getChannelManager();
 
+    public Set<Transaction> getPendingTransactions();
+
 }

--- a/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -243,4 +243,10 @@ public class EthereumImpl implements Ethereum {
     public ChannelManager getChannelManager() {
         return channelManager;
     }
+
+
+    @Override
+    public Set<Transaction> getPendingTransactions() {
+        return getBlockchain().getPendingTransactions();
+    }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -71,7 +71,6 @@ public class WorldManager {
     @Autowired
     private AdminInfo adminInfo;
 
-    private final Set<Transaction> pendingTransactions = Collections.synchronizedSet(new HashSet<Transaction>());
 
     @Autowired
     private EthereumListener listener;
@@ -99,22 +98,6 @@ public class WorldManager {
     public void stopPeerDiscovery() {
         if (peerDiscovery.isStarted())
             peerDiscovery.stop();
-    }
-
-    public void addPendingTransactions(Set<Transaction> transactions) {
-        logger.info("Pending transaction list added: size: [{}]", transactions.size());
-
-        if (listener != null)
-            listener.onPendingTransactionsReceived(transactions);
-        pendingTransactions.addAll(transactions);
-    }
-
-    public void clearPendingTransactions(List<Transaction> receivedTransactions) {
-
-        for (Transaction tx : receivedTransactions) {
-            logger.info("Clear transaction, hash: [{}]", Hex.toHexString(tx.getHash()));
-            pendingTransactions.remove(tx);
-        }
     }
 
     public ChannelManager getChannelManager() {
@@ -153,14 +136,11 @@ public class WorldManager {
         return activePeer;
     }
 
-    public Set<Transaction> getPendingTransactions() {
-        return pendingTransactions;
-    }
 
     public boolean isBlockchainLoading() {
         return blockchain.getQueue().size() > 2;
     }
-    
+
     public void loadBlockchain() {
 
         Block bestBlock = blockStore.getBestBlock();
@@ -176,6 +156,7 @@ public class WorldManager {
             blockchain.setBestBlock(Genesis.getInstance());
             blockchain.setTotalDifficulty(BigInteger.ZERO);
 
+            listener.onBlock(Genesis.getInstance());
             repository.dumpState(Genesis.getInstance(), 0, 0, null);
 
             logger.info("Genesis block loaded");

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/EthHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/EthHandler.java
@@ -168,7 +168,8 @@ public class EthHandler extends SimpleChannelInboundHandler<EthMessage> {
     private void processTransactions(TransactionsMessage msg) {
 
         Set<Transaction> txSet = msg.getTransactions();
-        worldManager.addPendingTransactions(txSet);
+        worldManager.getBlockchain().
+                addPendingTransactions(txSet);
 
         for (Transaction tx : txSet) {
             worldManager.getWallet().addTransaction(tx);
@@ -421,7 +422,8 @@ public class EthHandler extends SimpleChannelInboundHandler<EthMessage> {
 
     private void sendPendingTransactions() {
         Set<Transaction> pendingTxs =
-                worldManager.getPendingTransactions();
+                worldManager.getBlockchain()
+                        .getPendingTransactions();
         TransactionsMessage msg = new TransactionsMessage(pendingTxs);
         msgQueue.sendMessage(msg);
     }

--- a/ethereumj-core/src/main/java/org/ethereum/vm/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/Program.java
@@ -322,10 +322,17 @@ public class Program {
             return;
         }
 
+        byte[] senderAddress = this.getOwnerAddress().getLast20Bytes();
+        BigInteger endowment = value.value();
+        BigInteger senderBalance = result.getRepository().getBalance(senderAddress);
+        if (senderBalance.compareTo(endowment) < 0) {
+            stackPushZero();
+            return;
+        }
+
         // [1] FETCH THE CODE FROM THE MEMORY
         byte[] programCode = memoryChunk(memStart, memSize).array();
 
-        byte[] senderAddress = this.getOwnerAddress().getLast20Bytes();
         if (logger.isInfoEnabled())
             logger.info("creating a new contract inside contract run: [{}]", Hex.toHexString(senderAddress));
 
@@ -346,12 +353,6 @@ public class Program {
         }
 
         // [4] TRANSFER THE BALANCE
-        BigInteger endowment = value.value();
-        BigInteger senderBalance = result.getRepository().getBalance(senderAddress);
-        if (senderBalance.compareTo(endowment) < 0) {
-            stackPushZero();
-            return;
-        }
         result.getRepository().addBalance(senderAddress, endowment.negate());
         BigInteger newBalance = result.getRepository().addBalance(newAddress, endowment);
 

--- a/ethereumj-core/src/test/java/test/ethereum/jsontestsuite/GitHubStateTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/jsontestsuite/GitHubStateTest.java
@@ -44,7 +44,6 @@ public class GitHubStateTest {
     public void stInitCodeTest() throws ParseException { // [V]
 
         Set<String> excluded = new HashSet<>();
-        excluded.add("NotEnoughCashContractCreation");
         excluded.add("CallContractToCreateContractOOG");
         excluded.add("CallContractToCreateContractNoCash");
         excluded.add("CallContractToCreateContractWhichWouldCreateContractInInitCode");

--- a/ethereumj-core/src/test/java/test/ethereum/jsontestsuite/GitHubStateTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/jsontestsuite/GitHubStateTest.java
@@ -44,8 +44,6 @@ public class GitHubStateTest {
     public void stInitCodeTest() throws ParseException { // [V]
 
         Set<String> excluded = new HashSet<>();
-        excluded.add("CallContractToCreateContractOOG");
-        excluded.add("CallContractToCreateContractNoCash");
         excluded.add("CallContractToCreateContractWhichWouldCreateContractInInitCode");
 
         String json = JSONReader.loadJSON("StateTests/stInitCodeTest.json");


### PR DESCRIPTION
Gas checks must be done before other operations, such as type checking, to prevent state issues in the repository.