### PR TITLE
Minor fixes: make public static field CONFIG final and unquote variable expression

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -57,7 +57,7 @@ public class SystemProperties {
 
     private final static String DEFAULT_PROTOCOL_LIST = "eth,shh";
 
-    public static SystemProperties CONFIG = new SystemProperties();
+    public final static SystemProperties CONFIG = new SystemProperties();
     private final Properties prop = new Properties();
 
     public SystemProperties() {
@@ -118,7 +118,7 @@ public class SystemProperties {
     }
 
     public int transactionApproveTimeout() {
-        return Integer.parseInt(prop.getProperty("transaction.approve.timeout", String.valueOf("DEFAULT_TX_APPROVE_TIMEOUT")));
+        return Integer.parseInt(prop.getProperty("transaction.approve.timeout", String.valueOf(DEFAULT_TX_APPROVE_TIMEOUT)));
     }
 
     public String peerDiscoveryIPList() {


### PR DESCRIPTION
Tiny tiny things...

It's pretty clear that DEFAULT_TX_APPROVE_TIMEOUT ought not be quoted.

Letting CONFIG be a nonfinal variable seems a bit loose; any code anywhere could swap out the entire config.

Sorry again about the f*ed up pull request last night!