### PR TITLE
Fixed NPE on reset to empty root via trie.setRoot( EMPTY_TRIE_HASH )

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/trie/TrieImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/trie/TrieImpl.java
@@ -61,8 +61,13 @@ public class TrieImpl implements Trie {
 
     public TrieImpl(KeyValueDataSource db, Object root) {
         this.cache = new Cache(db);
-        this.root = root;
-        this.prevRoot = root;
+
+	if ( root instanceof byte[] )
+	    this.setRoot( (byte[]) root );
+	else
+	    this.root = root;
+
+        this.prevRoot = this.root;
     }
 
     public TrieIterator getIterator() {

--- a/ethereumj-core/src/main/java/org/ethereum/trie/TrieImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/trie/TrieImpl.java
@@ -46,6 +46,8 @@ public class TrieImpl implements Trie {
 
     private static final Logger logger = LoggerFactory.getLogger("trie");
 
+    private static final ByteArrayWrapper EMPTY_TRIE_HASH_WRAPPED = new ByteArrayWrapper( EMPTY_TRIE_HASH );
+
     private static byte PAIR_SIZE = 2;
     private static byte LIST_SIZE = 17;
 
@@ -85,7 +87,11 @@ public class TrieImpl implements Trie {
 
     @Override
     public void setRoot(byte[] root) {
-        this.root = root;
+	if ( EMPTY_TRIE_HASH_WRAPPED.equals( new ByteArrayWrapper( root ) ) ) {
+	    this.root = "";
+	} else {
+	    this.root = root;
+	}
     }
 
     /**************************************

--- a/ethereumj-core/src/test/java/test/ethereum/trie/TrieTest.java
+++ b/ethereumj-core/src/test/java/test/ethereum/trie/TrieTest.java
@@ -107,6 +107,14 @@ public class TrieTest {
     }
 
     @Test
+    public void testResetToEmptyRoot() {
+        TrieImpl trie = new TrieImpl(mockDb);
+	trie.setRoot( EMPTY_TRIE_HASH );
+        trie.update("", dog);
+        assertEquals(dog, new String(trie.get("")));
+    }
+
+    @Test
     public void testInsertMultipleItems1() {
         TrieImpl trie = new TrieImpl(mockDb);
         trie.update(ca, dude);


### PR DESCRIPTION
On TrieImpl, resetting root by calling `trie.setRoot( EMPTY_TRIE_HASH )` seems like an operation that ought to be okay. But `EMPTY_TRIE_HASH` is interpreted as an ordinary hash value, such that updates of the trie following the reset provoke a NPE as no node with that hash is found. fwiw, here's a test that currently fails and quick fix of the problem.