### PR TITLE
Disabling Lint of javadoc for java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,12 @@ wrapper.gradleVersion = '2.2.1'
 
 allprojects {
     apply plugin: 'eclipse'
+    if (JavaVersion.current().isJava8Compatible()) {
+        //Disable lint of javadoc until someone fixes all the html
+        tasks.withType(Javadoc) {
+          options.addStringOption('Xdoclint:none', '-quiet')
+      }
+    }
 }
 
 subprojects {


### PR DESCRIPTION
The build in java 8 failed because of invalid html in the javadoc. Java 8's javadoc has the unfortunate addition to validate html by default.
For more info see, amongst others, http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html

On don't know if ethereumj is java-8 compatible then, but at least all tests succeed except for one: org.ethereum.config.ConfigTest.fallbackTest As this test also fails under java 7 I guess that's something non-relevant
