### PR TITLE
Use gradle $projectDir var to fix relative path in build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ allprojects {
 subprojects {
     apply plugin: 'java'
 
-    def config = new ConfigSlurper().parse(new File("ethereumj-core/src/main/resources/version.properties").toURI().toURL())
+    def config = new ConfigSlurper().parse(new File("$projectDir/src/main/resources/version.properties").toURI().toURL())
 
     group = 'org.ethereum'
 


### PR DESCRIPTION
I was running into problems with the build failing via the eclipse plugin because it was looking for a path relative to the eclipse working directory. Simple fix..