### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/db/InMemoryBlockStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/InMemoryBlockStore.java
@@ -134,7 +134,7 @@ public class InMemoryBlockStore extends AbstractBlockstore{
 
     @Override
     public Block getBestBlock() {
-        if (blocks.size() == 0) return null;
+        if (blocks.isEmpty()) return null;
         return blocks.get(blocks.size() - 1);
     }
 
@@ -147,7 +147,7 @@ public class InMemoryBlockStore extends AbstractBlockstore{
         List result = s.createQuery("from BlockVO where number = :number").
                 setParameter("number", blockNumber).list();
 
-        if (result.size() == 0) return null;
+        if (result.isEmpty()) return null;
         BlockVO vo = (BlockVO) result.get(0);
 
         return vo.getHash();
@@ -160,7 +160,7 @@ public class InMemoryBlockStore extends AbstractBlockstore{
         List result = s.createQuery("from BlockVO where number = :number").
                 setParameter("number", blockNumber).list();
 
-        if (result.size() == 0) return null;
+        if (result.isEmpty()) return null;
         BlockVO vo = (BlockVO) result.get(0);
 
         s.close();
@@ -176,7 +176,7 @@ public class InMemoryBlockStore extends AbstractBlockstore{
         List result = s.createQuery("from BlockVO where hash = :hash").
                 setParameter("hash", hash).list();
 
-        if (result.size() == 0) return null;
+        if (result.isEmpty()) return null;
         BlockVO vo = (BlockVO) result.get(0);
 
         s.close();

--- a/ethereumj-core/src/main/java/org/ethereum/manager/AdminInfo.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/AdminInfo.java
@@ -43,7 +43,7 @@ public class AdminInfo {
 
     public Long getExecAvg(){
 
-        if (blockExecTime.size() == 0) return 0L;
+        if (blockExecTime.isEmpty()) return 0L;
 
         long sum = 0;
         for (int i = 0; i < blockExecTime.size(); ++i){

--- a/ethereumj-core/src/main/java/org/ethereum/net/swarm/bzz/BzzProtocol.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/swarm/bzz/BzzProtocol.java
@@ -98,7 +98,7 @@ public class BzzProtocol implements Functional.Consumer<BzzMessage> {
 
             start();
 
-            if (pendingHandshakeOutMessages.size() > 0) {
+            if (!pendingHandshakeOutMessages.isEmpty()) {
                 LOG.info("Send pending handshake messages: " + pendingHandshakeOutMessages.size());
                 for (BzzMessage pmsg : pendingHandshakeOutMessages) {
                     sendMessageImpl(pmsg);
@@ -109,7 +109,7 @@ public class BzzProtocol implements Functional.Consumer<BzzMessage> {
             // ping the peer for self neighbours
             sendMessageImpl(new BzzRetrieveReqMessage(Key.zeroKey()));
 
-            if (pendingHandshakeInMessages.size() > 0) {
+            if (!pendingHandshakeInMessages.isEmpty()) {
                 LOG.info("Processing pending handshake inbound messages: " + pendingHandshakeInMessages.size());
                 for (BzzMessage pmsg : pendingHandshakeInMessages) {
                     handleMsg(pmsg);

--- a/ethereumj-core/src/main/java/org/ethereum/sync/SyncManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/SyncManager.java
@@ -505,7 +505,7 @@ public class SyncManager {
         }
         logger.trace(
                 "Node list obtained from discovery: {}",
-                nodes.size() > 0 ? sb.toString() : "empty"
+                !nodes.isEmpty() ? sb.toString() : "empty"
         );
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/util/RLP.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/RLP.java
@@ -672,7 +672,7 @@ public class RLP {
         Value val = new Value(input);
         if (val.isList()) {
             List<Object> inputArray = val.asList();
-            if (inputArray.size() == 0) {
+            if (inputArray.isEmpty()) {
                 return encodeLength(inputArray.size(), OFFSET_SHORT_LIST);
             }
             byte[] output = ByteUtil.EMPTY_BYTE_ARRAY;

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubJSONTestSuite.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubJSONTestSuite.java
@@ -210,7 +210,7 @@ public class GitHubJSONTestSuite {
             logger.info(line);
             List<String> fails = StateTestRunner.run(testCases.get(testName));
 
-            Assert.assertTrue(fails.size() == 0);
+            Assert.assertTrue(fails.isEmpty());
 
         } else {
             logger.error("Sorry test case doesn't exist: {}", testName);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat