### PR TITLE
Remove global static `SystemProperties`, make configurable

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/Start.java
+++ b/ethereumj-core/src/main/java/org/ethereum/Start.java
@@ -1,13 +1,14 @@
 package org.ethereum;
 
 import org.ethereum.cli.CLIInterface;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.EthereumFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * @author Roman Mandeleil
@@ -16,16 +17,16 @@ import static org.ethereum.config.SystemProperties.CONFIG;
 public class Start {
 
     public static void main(String args[]) throws IOException, URISyntaxException {
-        CLIInterface.call(args);
+        SystemProperties config = CLIInterface.call(args);
 
-        if (!CONFIG.blocksLoader().equals("")) {
-            CONFIG.setSyncEnabled(false);
-            CONFIG.setDiscoveryEnabled(false);
+        if (!config.blocksLoader().equals("")) {
+            config.setSyncEnabled(false);
+            config.setDiscoveryEnabled(false);
         }
 
-        Ethereum ethereum = EthereumFactory.createEthereum();
+        Ethereum ethereum = EthereumFactory.createEthereum(config);
 
-        if (!CONFIG.blocksLoader().equals(""))
+        if (!config.blocksLoader().equals(""))
             ethereum.getBlockLoader().loadBlocks();
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/cli/CLIInterface.java
+++ b/ethereumj-core/src/main/java/org/ethereum/cli/CLIInterface.java
@@ -19,7 +19,8 @@ public class CLIInterface {
     private static final Logger logger = LoggerFactory.getLogger("general");
 
 
-    public static void call(String[] args) {
+    public static SystemProperties call(String[] args) {
+        SystemProperties config = SystemProperties.getDefault();
 
         try {
             Map<String, String> cliOptions = new HashMap<>();
@@ -67,12 +68,14 @@ public class CLIInterface {
             if (cliOptions.size() > 0) {
                 logger.info("Overriding config file with CLI options: " + cliOptions);
             }
-            SystemProperties.CONFIG.overrideParams(cliOptions);
 
+            config.overrideParams(cliOptions);
         } catch (Throwable e) {
             logger.error("Error parsing command line: [{}]", e.getMessage());
             System.exit(1);
         }
+
+        return config;
     }
 
     private static Boolean interpret(String arg) {

--- a/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
@@ -156,9 +156,9 @@ public class CommonConfig {
 
         List<BlockHeaderRule> rules = new ArrayList<>(asList(
                 new GasValueRule(),
-                new ExtraDataRule(),
+                new ExtraDataRule(config),
                 new ProofOfWorkRule(),
-                new GasLimitRule()
+                new GasLimitRule(config)
         ));
 
         return new BlockHeaderValidator(rules);

--- a/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
@@ -37,12 +37,18 @@ public class CommonConfig {
     @Autowired
     private MapDBFactory mapDBFactory;
     @Autowired
-    SystemProperties config = SystemProperties.CONFIG;
+    private SystemProperties config;
 
+    public CommonConfig() { }
 
+    public CommonConfig(SystemProperties config, RedisConnection redisConnection, MapDBFactory mapDBFactory) {
+        this.config = config;
+        this.redisConnection = redisConnection;
+        this.mapDBFactory = mapDBFactory;
+    }
     @Bean
     Repository repository() {
-        return new RepositoryImpl(keyValueDataSource(), keyValueDataSource());
+        return new RepositoryImpl(config, keyValueDataSource(), keyValueDataSource());
     }
 
     @Bean
@@ -58,7 +64,7 @@ public class CommonConfig {
             }
 
             dataSource = "leveldb";
-            return new LevelDbDataSource();
+            return new LevelDbDataSource(config);
         } finally {
             logger.info(dataSource + " key-value data source created.");
         }
@@ -163,15 +169,11 @@ public class CommonConfig {
 
         List<DependentBlockHeaderRule> rules = new ArrayList<>(asList(
                 new ParentNumberRule(),
-                new DifficultyRule(),
-                new ParentGasLimitRule()
+                new DifficultyRule(config.getBlockchainConfig()),
+                new ParentGasLimitRule(config.getBlockchainConfig())
         ));
 
         return new ParentBlockHeaderValidator(rules);
     }
 
-    @Bean
-    public SystemProperties systemProperties() {
-        return SystemProperties.CONFIG;
-    }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -1,9 +1,6 @@
 package org.ethereum.config;
 
-import org.ethereum.datasource.CachingDataSource;
-import org.ethereum.datasource.HashMapDB;
-import org.ethereum.datasource.KeyValueDataSource;
-import org.ethereum.datasource.LevelDbDataSource;
+import org.ethereum.datasource.*;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.IndexedBlockStore;
 import org.ethereum.db.TransactionStore;
@@ -52,6 +49,14 @@ public class DefaultConfig {
             @Override
             public void uncaughtException(Thread t, Throwable e) {
                 logger.error("Uncaught exception", e);
+            }
+        });
+
+        // TODO: this is setting global state across all EthereumJ instances
+        DataSourcePool.setDataSourceMaker(new DataSourcePool.DataSourceMaker() {
+            @Override
+            public KeyValueDataSource makeDataSource() {
+                return commonConfig.keyValueDataSource();
             }
         });
     }

--- a/ethereumj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -81,6 +81,6 @@ public class DefaultConfig {
 
     @Bean @Scope("prototype")
     LevelDbDataSource levelDbDataSource(String name) {
-        return new LevelDbDataSource(name);
+        return new LevelDbDataSource(config, name);
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -110,6 +110,8 @@ public class SystemProperties {
     private BlockchainNetConfig blockchainConfig;
     private Genesis genesis;
 
+    private final ClassLoader classLoader;
+
     public SystemProperties(File configFile) {
         this(ConfigFactory.parseFile(configFile));
     }
@@ -119,7 +121,13 @@ public class SystemProperties {
     }
 
     public SystemProperties(Config apiConfig) {
+        this(apiConfig, SystemProperties.class.getClassLoader());
+    }
+
+    public SystemProperties(Config apiConfig, ClassLoader classLoader) {
         try {
+            this.classLoader = classLoader;
+
             Config javaSystemProperties = ConfigFactory.load("no-such-resource-only-system-props");
             Config referenceConfig = ConfigFactory.parseResources("ethereumj.conf");
             logger.info("Config (" + (referenceConfig.entrySet().size() > 0 ? " yes " : " no  ") + "): default properties from resource 'ethereumj.conf'");
@@ -249,7 +257,7 @@ public class SystemProperties {
             } else {
                 String className = config.getString("blockchain.config.class");
                 try {
-                    Class<? extends BlockchainNetConfig> aClass = (Class<? extends BlockchainNetConfig>) Class.forName(className);
+                    Class<? extends BlockchainNetConfig> aClass = (Class<? extends BlockchainNetConfig>) classLoader.loadClass(className);
                     blockchainConfig = aClass.newInstance();
                 } catch (ClassNotFoundException e) {
                     throw new RuntimeException("The class specified via blockchain.config.class '" + className + "' not found" , e);

--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -761,7 +761,7 @@ public class SystemProperties {
 
     public Genesis getGenesis() {
         if (genesis == null) {
-            genesis = GenesisLoader.loadGenesis(this);
+            genesis = GenesisLoader.loadGenesis(this, classLoader);
         }
         return genesis;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/core/AccountState.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/AccountState.java
@@ -1,5 +1,6 @@
 package org.ethereum.core;
 
+import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -45,11 +46,10 @@ public class AccountState {
     private boolean dirty = false;
     private boolean deleted = false;
 
-    public static final AccountState EMPTY = new AccountState();
+    public static BigInteger EMPTY_BALANCE = BigInteger.ZERO;
 
-
-    public AccountState() {
-        this(SystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getInitialNonce(), BigInteger.ZERO);
+    public AccountState(BlockchainNetConfig config) {
+        this(config.getCommonConstants().getInitialNonce(), EMPTY_BALANCE);
     }
 
     public AccountState(BigInteger nonce, BigInteger balance) {
@@ -148,10 +148,8 @@ public class AccountState {
     }
 
     public AccountState clone() {
-        AccountState accountState = new AccountState();
+        AccountState accountState = new AccountState(this.getNonce(), this.getBalance());
 
-        accountState.addToBalance(this.getBalance());
-        accountState.setNonce(this.getNonce());
         accountState.setCodeHash(this.getCodeHash());
         accountState.setStateRoot(this.getStateRoot());
         accountState.setDirty(false);

--- a/ethereumj-core/src/main/java/org/ethereum/core/Block.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Block.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * The block in Ethereum is the collection of relevant pieces of information

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -1,5 +1,6 @@
 package org.ethereum.core;
 
+import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
@@ -327,8 +328,8 @@ public class BlockHeader {
         return HashUtil.sha3(concat);
     }
 
-    public BigInteger calcDifficulty(BlockHeader parent) {
-        return SystemProperties.CONFIG.getBlockchainConfig().getConfigForBlock(getNumber()).
+    public BigInteger calcDifficulty(BlockchainNetConfig config, BlockHeader parent) {
+        return config.getConfigForBlock(getNumber()).
                 calcDifficulty(this, parent);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/Genesis.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Genesis.java
@@ -56,10 +56,6 @@ public class Genesis extends Block {
                 mixHash, nonce, null, null);
     }
 
-    public static Block getInstance() {
-        return SystemProperties.CONFIG.getGenesis();
-    }
-
     public static Block getInstance(SystemProperties config) {
         return config.getGenesis();
     }

--- a/ethereumj-core/src/main/java/org/ethereum/core/PendingStateImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/PendingStateImpl.java
@@ -1,6 +1,7 @@
 package org.ethereum.core;
 
 import org.apache.commons.collections4.map.LRUMap;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.listener.EthereumListener;
@@ -20,7 +21,7 @@ import java.math.BigInteger;
 import java.util.*;
 
 import static java.math.BigInteger.ZERO;
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.ethereum.util.BIUtil.toBI;
 
 /**
@@ -51,20 +52,17 @@ public class PendingStateImpl implements PendingState {
 
     private static final Logger logger = LoggerFactory.getLogger("state");
 
-    @Autowired
     private EthereumListener listener;
 
-    @Autowired
     private Repository repository;
 
-    @Autowired
     private Blockchain blockchain;
 
-    @Autowired
     private BlockStore blockStore;
 
-    @Autowired
     private ProgramInvokeFactory programInvokeFactory;
+
+    private SystemProperties config;
 
 //    @Resource
 //    @Qualifier("wireTransactions")
@@ -82,10 +80,9 @@ public class PendingStateImpl implements PendingState {
 
     private Block best = null;
 
-    public PendingStateImpl() {
-    }
-
-    public PendingStateImpl(EthereumListener listener, BlockchainImpl blockchain) {
+    @Autowired
+    public PendingStateImpl(SystemProperties config, EthereumListener listener, BlockchainImpl blockchain) {
+        this.config = config;
         this.listener = listener;
         this.blockchain = blockchain;
         this.repository = blockchain.getRepository();
@@ -309,7 +306,7 @@ public class PendingStateImpl implements PendingState {
 
         synchronized (wireTransactions) {
             for (PendingTransaction tx : wireTransactions)
-                if (blockNumber - tx.getBlockNumber() > CONFIG.txOutdatedThreshold())
+                if (blockNumber - tx.getBlockNumber() > config.txOutdatedThreshold())
                     outdated.add(tx);
         }
 
@@ -363,7 +360,7 @@ public class PendingStateImpl implements PendingState {
         Block best = blockchain.getBestBlock();
 
         TransactionExecutor executor = new TransactionExecutor(
-                tx, best.getCoinbase(), pendingState,
+                config, tx, best.getCoinbase(), pendingState,
                 blockStore, programInvokeFactory, best
         );
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -1,6 +1,7 @@
 package org.ethereum.core;
 
-import org.ethereum.config.SystemProperties;
+import org.ethereum.config.BlockchainConfig;
+import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.ECKey.ECDSASignature;
 import org.ethereum.crypto.ECKey.MissingPrivateKeyException;
@@ -111,11 +112,11 @@ public class Transaction {
         this.signature = signature;
     }
 
-    public long transactionCost(Block block){
+    public long transactionCost(BlockchainNetConfig blockchainConfig, Block block){
 
         if (!parsed) rlpParse();
 
-        return SystemProperties.CONFIG.getBlockchainConfig().getConfigForBlock(block.getNumber()).
+        return blockchainConfig.getConfigForBlock(block.getNumber()).
                 getTransactionCost(this);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
@@ -29,7 +29,7 @@ public class GenesisLoader {
     public static Genesis loadGenesis(SystemProperties config, ClassLoader classLoader)  {
         String genesisFile = config.genesisInfo();
 
-        InputStream is = classLoader.getResourceAsStream("/genesis/" + genesisFile);
+        InputStream is = classLoader.getResourceAsStream("genesis/" + genesisFile);
         return loadGenesis(config, is);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
@@ -26,10 +26,10 @@ import static org.ethereum.util.ByteUtil.wrap;
 
 public class GenesisLoader {
 
-    public static Genesis loadGenesis(SystemProperties config)  {
+    public static Genesis loadGenesis(SystemProperties config, ClassLoader classLoader)  {
         String genesisFile = config.genesisInfo();
 
-        InputStream is = GenesisLoader.class.getResourceAsStream("/genesis/" + genesisFile);
+        InputStream is = classLoader.getResourceAsStream("/genesis/" + genesisFile);
         return loadGenesis(config, is);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
@@ -19,16 +19,12 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.ethereum.core.Genesis.ZERO_HASH_2048;
 import static org.ethereum.crypto.HashUtil.EMPTY_LIST_HASH;
 import static org.ethereum.util.ByteUtil.wrap;
 
 public class GenesisLoader {
-
-    public static Block loadGenesis() {
-        return loadGenesis(CONFIG);
-    }
 
     public static Genesis loadGenesis(SystemProperties config)  {
         String genesisFile = config.genesisInfo();
@@ -38,7 +34,7 @@ public class GenesisLoader {
     }
 
     public static Genesis loadGenesis(InputStream genesisJsonIS) {
-        return loadGenesis(CONFIG, genesisJsonIS);
+        return loadGenesis(SystemProperties.getDefault(), genesisJsonIS);
     }
     
     public static Genesis loadGenesis(SystemProperties config, InputStream genesisJsonIS)  {

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/DataSourcePool.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/DataSourcePool.java
@@ -19,7 +19,8 @@ public class DataSourcePool {
     }
 
     public static KeyValueDataSource levelDbByName(String name) {
-        return (KeyValueDataSource) getDataSourceFromPool(name, new LevelDbDataSource());
+        return null;
+//        return (KeyValueDataSource) getDataSourceFromPool(name, new LevelDbDataSource());
     }
 
     private static DataSource getDataSourceFromPool(String name, @Nonnull DataSource dataSource) {

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/DataSourcePool.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/DataSourcePool.java
@@ -1,9 +1,8 @@
 package org.ethereum.datasource;
 
+import org.ethereum.config.SystemProperties;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.xml.crypto.dsig.keyinfo.KeyValue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -12,20 +11,33 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class DataSourcePool {
 
     private static final Logger logger = getLogger("db");
-    private static ConcurrentMap<String, DataSource> pool = new ConcurrentHashMap<>();
+    private static ConcurrentMap<String, KeyValueDataSource> pool = new ConcurrentHashMap<>();
 
-    public static KeyValueDataSource hashMapDBByName(String name){
-        return (KeyValueDataSource) getDataSourceFromPool(name, new HashMapDB());
+    public interface DataSourceMaker {
+        KeyValueDataSource makeDataSource();
     }
 
-    public static KeyValueDataSource levelDbByName(String name) {
-        return null;
-//        return (KeyValueDataSource) getDataSourceFromPool(name, new LevelDbDataSource());
+    private static final DataSourceMaker defaultDataSourceMaker = new DataSourceMaker() {
+        @Override
+        public KeyValueDataSource makeDataSource() {
+            return new LevelDbDataSource(SystemProperties.getDefault());
+        }
+    };
+
+    // TODO: remove this global state
+    private static DataSourceMaker dataSourceMaker = defaultDataSourceMaker;
+
+    public static void setDataSourceMaker(DataSourceMaker dataSourceMaker) {
+        DataSourcePool.dataSourceMaker = dataSourceMaker;
+    }
+    public static void setDefaultDataSourceMaker() {
+        DataSourcePool.dataSourceMaker = defaultDataSourceMaker;
     }
 
-    private static DataSource getDataSourceFromPool(String name, @Nonnull DataSource dataSource) {
+    public static KeyValueDataSource getDataSourceFromPool(String name) {
+        KeyValueDataSource dataSource = dataSourceMaker.makeDataSource();
         dataSource.setName(name);
-        DataSource result = pool.putIfAbsent(name, dataSource);
+        KeyValueDataSource result = pool.putIfAbsent(name, dataSource);
         if (result == null) {
             result = dataSource;
             logger.debug("Data source '{}' created and added to pool.", name);
@@ -42,7 +54,7 @@ public class DataSourcePool {
 
     public static void closeDataSource(String name){
 
-        DataSource dataSource = pool.remove(name);
+        KeyValueDataSource dataSource = pool.remove(name);
         if (dataSource != null){
             synchronized (dataSource) {
 

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -21,7 +21,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static java.lang.System.getProperty;
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.fusesource.leveldbjni.JniDBFactory.factory;
 
 /**
@@ -35,7 +35,7 @@ public class LevelDbDataSource implements KeyValueDataSource {
     private static final Logger logger = LoggerFactory.getLogger("db");
 
     @Autowired
-    SystemProperties config  = SystemProperties.CONFIG; // initialized for standalone test
+    SystemProperties config;
 
     String name;
     DB db;
@@ -49,10 +49,12 @@ public class LevelDbDataSource implements KeyValueDataSource {
     // however blocks them on init/close/delete operations
     private ReadWriteLock resetDbLock = new ReentrantReadWriteLock();
 
-    public LevelDbDataSource() {
+    public LevelDbDataSource(SystemProperties config) {
+        this.config = config;
     }
 
-    public LevelDbDataSource(String name) {
+    public LevelDbDataSource(SystemProperties config, String name) {
+        this(config);
         this.name = name;
         logger.info("New LevelDbDataSource: " + name);
     }

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/mapdb/MapDBFactoryImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/mapdb/MapDBFactoryImpl.java
@@ -19,7 +19,13 @@ public class MapDBFactoryImpl implements MapDBFactory {
     private ApplicationContext ctx;
 
     @Autowired
-    SystemProperties config = SystemProperties.CONFIG; // initialized for standalone test
+    SystemProperties config;
+
+    public MapDBFactoryImpl() {}
+
+    public MapDBFactoryImpl(SystemProperties config) {
+        this.config = config;
+    }
 
     @Override
     public KeyValueDataSource createDataSource() {

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/redis/RedisDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/redis/RedisDataSource.java
@@ -1,16 +1,21 @@
 package org.ethereum.datasource.redis;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 import java.util.Map;
 import java.util.Set;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.ethereum.util.Functional.Consumer;
 
 public class RedisDataSource extends RedisMap<byte[], byte[]> implements KeyValueDataSource {
+
+    @Autowired
+    SystemProperties config;
 
     RedisDataSource(String namespace, JedisPool pool) {
         super(namespace, pool, null, null);
@@ -38,7 +43,7 @@ public class RedisDataSource extends RedisMap<byte[], byte[]> implements KeyValu
 
     @Override
     public void init() {
-        if (CONFIG.databaseReset()) {
+        if (config.databaseReset()) {
             pooled(new Consumer<Jedis>() {
                 @Override
                 public void accept(Jedis jedis) {

--- a/ethereumj-core/src/main/java/org/ethereum/db/BlockQueueImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/BlockQueueImpl.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockWrapper;
 import org.ethereum.datasource.mapdb.MapDBFactory;
@@ -10,12 +11,13 @@ import org.mapdb.DB;
 import org.mapdb.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * @author Mikhail Kalinin
@@ -47,6 +49,13 @@ public class BlockQueueImpl implements BlockQueue {
     private final Object writeMutex = new Object();
     private final Object readMutex = new Object();
 
+    @Autowired
+    SystemProperties config;
+
+    public BlockQueueImpl(SystemProperties config) {
+        this.config = config;
+    }
+
     @Override
     public void open() {
         new Thread(new Runnable() {
@@ -63,7 +72,7 @@ public class BlockQueueImpl implements BlockQueue {
                             .serializer(Serializers.BYTE_ARRAY_WRAPPER)
                             .makeOrGet();
 
-                    if(CONFIG.databaseReset()) {
+                    if(config.databaseReset()) {
                         blocks.clear();
                         hashes.clear();
                         db.commit();

--- a/ethereumj-core/src/main/java/org/ethereum/db/ContractDetails.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/ContractDetails.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.vm.DataWord;
 
 import javax.annotation.Nullable;
@@ -22,7 +23,7 @@ public interface ContractDetails {
 
     byte[] getStorageHash();
 
-    void decode(byte[] rlpCode);
+    void decode(SystemProperties config, byte[] rlpCode);
 
     void setDirty(boolean dirty);
 

--- a/ethereumj-core/src/main/java/org/ethereum/db/ContractDetailsCacheImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/ContractDetailsCacheImpl.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.trie.SecureTrie;
 import org.ethereum.util.RLP;
 import org.ethereum.vm.DataWord;
@@ -16,7 +17,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
 
     private Map<DataWord, DataWord> storage = new HashMap<>();
 
-    ContractDetails origContract = new ContractDetailsImpl();
+    ContractDetails origContract;
 
     public ContractDetailsCacheImpl(ContractDetails origContract) {
         this.origContract = origContract;
@@ -70,7 +71,7 @@ public class ContractDetailsCacheImpl extends AbstractContractDetails {
     }
 
     @Override
-    public void decode(byte[] rlpCode) {
+    public void decode(SystemProperties config, byte[] rlpCode) {
         throw new RuntimeException("Not supported by this implementation.");
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/db/ContractDetailsImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/ContractDetailsImpl.java
@@ -10,11 +10,11 @@ import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
 import org.ethereum.vm.DataWord;
 import org.spongycastle.util.Arrays;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
 
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
-import static org.ethereum.datasource.DataSourcePool.levelDbByName;
 import static org.ethereum.util.ByteUtil.*;
 
 /**
@@ -33,14 +33,13 @@ public class ContractDetailsImpl extends AbstractContractDetails {
     boolean externalStorage;
     private KeyValueDataSource externalStorageDataSource;
 
-    public ContractDetailsImpl() {
+    public ContractDetailsImpl() {}
+
+    public ContractDetailsImpl(SystemProperties config, byte[] rlpCode) {
+        decode(config, rlpCode);
     }
 
-    public ContractDetailsImpl(byte[] rlpCode) {
-        decode(rlpCode);
-    }
-
-    private ContractDetailsImpl(byte[] address, SecureTrie storageTrie, Map<ByteArrayWrapper, byte[]> codes) {
+    private ContractDetailsImpl( byte[] address, SecureTrie storageTrie, Map<ByteArrayWrapper, byte[]> codes) {
         this.address = address;
         this.storageTrie = storageTrie;
         setCodes(codes);
@@ -87,7 +86,7 @@ public class ContractDetailsImpl extends AbstractContractDetails {
     }
 
     @Override
-    public void decode(byte[] rlpCode) {
+    public void decode(SystemProperties config, byte[] rlpCode) {
         RLPList data = RLP.decode2(rlpCode);
         RLPList rlpList = (RLPList) data.get(0);
 
@@ -117,7 +116,7 @@ public class ContractDetailsImpl extends AbstractContractDetails {
             storageTrie.getCache().setDB(getExternalStorageDataSource());
         }
 
-        externalStorage = (storage.getRLPData().length > SystemProperties.CONFIG.detailsInMemoryStorageLimit())
+        externalStorage = (storage.getRLPData().length > config.detailsInMemoryStorageLimit())
                 || externalStorage;
 
         this.rlpEncoded = rlpCode;
@@ -228,7 +227,7 @@ public class ContractDetailsImpl extends AbstractContractDetails {
 
     private KeyValueDataSource getExternalStorageDataSource() {
         if (externalStorageDataSource == null) {
-            externalStorageDataSource = levelDbByName("details-storage/" + toHexString(address));
+//            externalStorageDataSource = levelDbByName("details-storage/" + toHexString(address));
         }
         return externalStorageDataSource;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/db/ContractDetailsImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/ContractDetailsImpl.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
 
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
+import static org.ethereum.datasource.DataSourcePool.getDataSourceFromPool;
 import static org.ethereum.util.ByteUtil.*;
 
 /**
@@ -227,7 +228,7 @@ public class ContractDetailsImpl extends AbstractContractDetails {
 
     private KeyValueDataSource getExternalStorageDataSource() {
         if (externalStorageDataSource == null) {
-//            externalStorageDataSource = levelDbByName("details-storage/" + toHexString(address));
+            externalStorageDataSource = getDataSourceFromPool("details-storage/" + toHexString(address));
         }
         return externalStorageDataSource;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/db/DetailsDataStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/DetailsDataStore.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
@@ -27,6 +28,12 @@ public class DetailsDataStore {
         this.db = db;
     }
 
+    SystemProperties config;
+
+    public DetailsDataStore(SystemProperties config) {
+        this.config = config;
+    }
+
     public ContractDetails get(byte[] key) {
 
         ByteArrayWrapper wrappedKey = wrap(key);
@@ -38,7 +45,7 @@ public class DetailsDataStore {
             byte[] data = db.get(key);
             if (data == null) return null;
 
-            details = new ContractDetailsImpl(data);
+            details = new ContractDetailsImpl(config, data);
             cache.put(wrappedKey, details);
 
             float out = ((float) data.length) / 1048576;

--- a/ethereumj-core/src/main/java/org/ethereum/db/HashStoreImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/HashStoreImpl.java
@@ -2,18 +2,20 @@ package org.ethereum.db;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.datasource.mapdb.MapDBFactory;
 import org.ethereum.util.FastByteComparisons;
 import org.mapdb.DB;
 import org.mapdb.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * @author Mikhail Kalinin
@@ -34,6 +36,13 @@ public class HashStoreImpl implements HashStore {
     private final ReentrantLock initLock = new ReentrantLock();
     private final Condition init = initLock.newCondition();
 
+    @Autowired
+    SystemProperties config;
+
+    public HashStoreImpl(SystemProperties config) {
+        this.config = config;
+    }
+
     @Override
     public void open() {
         new Thread(new Runnable() {
@@ -47,7 +56,7 @@ public class HashStoreImpl implements HashStore {
                             .valueSerializer(Serializer.BYTE_ARRAY)
                             .makeOrGet();
 
-                    if(CONFIG.databaseReset()) {
+                    if(config.databaseReset()) {
                         hashes.clear();
                         db.commit();
                     }

--- a/ethereumj-core/src/main/java/org/ethereum/db/HeaderStoreImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/HeaderStoreImpl.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeaderWrapper;
 import org.ethereum.datasource.mapdb.MapDBFactory;
 import org.ethereum.datasource.mapdb.Serializers;
@@ -9,12 +10,13 @@ import org.mapdb.DB;
 import org.mapdb.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * @author Mikhail Kalinin
@@ -37,6 +39,13 @@ public class HeaderStoreImpl implements HeaderStore {
 
     private final Object mutex = new Object();
 
+    @Autowired
+    SystemProperties config;
+
+    public HeaderStoreImpl(SystemProperties config) {
+        this.config = config;
+    }
+
     @Override
     public void open() {
         new Thread(new Runnable() {
@@ -50,7 +59,7 @@ public class HeaderStoreImpl implements HeaderStore {
                             .valueSerializer(Serializers.BLOCK_HEADER_WRAPPER)
                             .makeOrGet();
 
-                    if(CONFIG.databaseReset()) {
+                    if(config.databaseReset()) {
                         headers.clear();
                         db.commit();
                     }

--- a/ethereumj-core/src/main/java/org/ethereum/db/RepositoryDummy.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/RepositoryDummy.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
@@ -29,8 +30,8 @@ public class RepositoryDummy extends RepositoryImpl {
     private Map<ByteArrayWrapper, AccountState> worldState = new HashMap<>();
     private Map<ByteArrayWrapper, ContractDetails> detailsDB = new HashMap<>();
 
-    public RepositoryDummy() {
-        super(false);
+    public RepositoryDummy(SystemProperties config) {
+        super(config);
     }
 
     @Override
@@ -117,7 +118,7 @@ public class RepositoryDummy extends RepositoryImpl {
 
     @Override
     public Repository startTracking() {
-        return new RepositoryTrack(this);
+        return new RepositoryTrack(this, config);
     }
 
     @Override
@@ -262,7 +263,7 @@ public class RepositoryDummy extends RepositoryImpl {
 
     @Override
     public AccountState createAccount(byte[] addr) {
-        AccountState accountState = new AccountState();
+        AccountState accountState = new AccountState(config.getBlockchainConfig());
         worldState.put(wrap(addr), accountState);
 
         ContractDetails contractDetails = new ContractDetailsImpl();
@@ -289,7 +290,7 @@ public class RepositoryDummy extends RepositoryImpl {
         ContractDetails details = getContractDetails(addr);
 
         if (account == null)
-            account = new AccountState();
+            account = new AccountState(config.getBlockchainConfig());
         else
             account = account.clone();
 

--- a/ethereumj-core/src/main/java/org/ethereum/db/RepositoryTrack.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/RepositoryTrack.java
@@ -49,6 +49,11 @@ public class RepositoryTrack implements Repository {
     @Autowired
     SystemProperties config;
 
+    // used by Spring wiring
+    public RepositoryTrack(Repository repository) {
+        this.repository = repository;
+    }
+
     public RepositoryTrack(Repository repository, SystemProperties config) {
         this.repository = repository;
         this.config = config;

--- a/ethereumj-core/src/main/java/org/ethereum/db/RepositoryVMTestDummy.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/RepositoryVMTestDummy.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
@@ -26,8 +27,8 @@ public class RepositoryVMTestDummy extends RepositoryImpl{
     private Map<ByteArrayWrapper, AccountState> worldState = new HashMap<>();
     private Map<ByteArrayWrapper, ContractDetails> detailsDB = new HashMap<>();
 
-    public RepositoryVMTestDummy() {
-        super(false);
+    public RepositoryVMTestDummy(SystemProperties config) {
+        super(config);
     }
 
     @Override
@@ -113,7 +114,7 @@ public class RepositoryVMTestDummy extends RepositoryImpl{
 
     @Override
     public Repository startTracking() {
-        return new RepositoryTrack(this);
+        return new RepositoryTrack(this, config);
     }
 
     @Override
@@ -263,7 +264,7 @@ public class RepositoryVMTestDummy extends RepositoryImpl{
 
     @Override
     public AccountState createAccount(byte[] addr) {
-        AccountState accountState = new AccountState();
+        AccountState accountState = new AccountState(config.getBlockchainConfig());
         worldState.put(wrap(addr), accountState);
 
         ContractDetails contractDetails = new ContractDetailsImpl();
@@ -290,7 +291,7 @@ public class RepositoryVMTestDummy extends RepositoryImpl{
         ContractDetails details = getContractDetails(addr);
 
         if (account == null)
-            account = new AccountState();
+            account = new AccountState(config.getBlockchainConfig());
         else
             account = account.clone();
 

--- a/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -280,7 +280,7 @@ public class EthereumImpl implements Ethereum {
 
         try {
             org.ethereum.core.TransactionExecutor executor = new org.ethereum.core.TransactionExecutor
-                    (tx, block.getCoinbase(), repository, worldManager.getBlockStore(),
+                    (config, tx, block.getCoinbase(), repository, worldManager.getBlockStore(),
                             programInvokeFactory, block)
                     .setLocalCall(true);
 

--- a/ethereumj-core/src/main/java/org/ethereum/json/JSONHelper.java
+++ b/ethereumj-core/src/main/java/org/ethereum/json/JSONHelper.java
@@ -1,5 +1,7 @@
 package org.ethereum.json;
 
+import org.ethereum.config.BlockchainNetConfig;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Block;
 import org.ethereum.db.ByteArrayWrapper;
@@ -46,7 +48,7 @@ import java.util.List;
 public class JSONHelper {
 
     @SuppressWarnings("uncheked")
-    public static void dumpState(ObjectNode statesNode, String address, AccountState state, ContractDetails details) {
+    public static void dumpState(BlockchainNetConfig config, ObjectNode statesNode, String address, AccountState state, ContractDetails details) {
 
         List<DataWord> storageKeys = new ArrayList<>(details.getStorage().keySet());
         Collections.sort(storageKeys);
@@ -60,7 +62,7 @@ public class JSONHelper {
         }
 
         if (state == null)
-            state = AccountState.EMPTY;
+            state = new AccountState(config);
 
         account.put("balance", state.getBalance() == null ? "0" : state.getBalance().toString());
 //        account.put("codeHash", details.getCodeHash() == null ? "0x" : "0x" + Hex.toHexString(details.getCodeHash()));
@@ -72,7 +74,7 @@ public class JSONHelper {
         statesNode.set(address, account);
     }
 
-    public static void dumpBlock(ObjectNode blockNode, Block block,
+    public static void dumpBlock(BlockchainNetConfig config, ObjectNode blockNode, Block block,
                                  long gasUsed, byte[] state, List<ByteArrayWrapper> keys,
                                  Repository repository) {
 
@@ -89,7 +91,7 @@ public class JSONHelper {
             byte[] keyBytes = key.getData();
             AccountState accountState = repository.getAccountState(keyBytes);
             ContractDetails details = repository.getContractDetails(keyBytes);
-            dumpState(statesNode, Hex.toHexString(keyBytes), accountState, details);
+            dumpState(config, statesNode, Hex.toHexString(keyBytes), accountState, details);
         }
         blockNode.set("state", statesNode);
 

--- a/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpcImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpcImpl.java
@@ -236,8 +236,8 @@ public class JsonRpcImpl implements JsonRpc {
 
     public String web3_clientVersion() {
 
-        String s = "EthereumJ" + "/v" + SystemProperties.CONFIG.projectVersion() + "/" +
-                System.getProperty("os.name") + "/Java1.7/" + SystemProperties.CONFIG.projectVersionModifier();
+        String s = "EthereumJ" + "/v" + SystemProperties.projectVersion() + "/" +
+                System.getProperty("os.name") + "/Java1.7/" + SystemProperties.projectVersionModifier();
         if (logger.isDebugEnabled()) logger.debug("web3_clientVersion(): " + s);
         return s;
     };

--- a/ethereumj-core/src/main/java/org/ethereum/jsontestsuite/JSONReader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/jsontestsuite/JSONReader.java
@@ -28,17 +28,19 @@ import org.slf4j.LoggerFactory;
 public class JSONReader {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
+    
+    private static SystemProperties CONFIG = SystemProperties.getDefault();
 
     public static String loadJSON(String filename) {
         String json = "";
-        if (!SystemProperties.CONFIG.vmTestLoadLocal())
+        if (!CONFIG.vmTestLoadLocal())
             json = getFromUrl("https://raw.githubusercontent.com/ethereum/tests/develop/" + filename);
         return json.isEmpty() ? getFromLocal(filename) : json;
     }
 
     public static String loadJSONFromCommit(String filename, String shacommit) {
         String json = "";
-        if (!SystemProperties.CONFIG.vmTestLoadLocal())
+        if (!CONFIG.vmTestLoadLocal())
             json = getFromUrl("https://raw.githubusercontent.com/ethereum/tests/" + shacommit + "/" + filename);
         if (!json.isEmpty()) json = json.replaceAll("//", "data");
         return json.isEmpty() ? getFromLocal(filename) : json;

--- a/ethereumj-core/src/main/java/org/ethereum/jsontestsuite/builder/AccountBuilder.java
+++ b/ethereumj-core/src/main/java/org/ethereum/jsontestsuite/builder/AccountBuilder.java
@@ -1,5 +1,6 @@
 package org.ethereum.jsontestsuite.builder;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.AccountState;
 import org.ethereum.db.ContractDetailsImpl;
 import org.ethereum.jsontestsuite.model.AccountTck;
@@ -16,13 +17,13 @@ import static org.ethereum.util.Utils.unifiedNumericToBigInteger;
 
 public class AccountBuilder {
 
-    public static StateWrap build(AccountTck account) {
+    public static StateWrap build(SystemProperties config, AccountTck account) {
 
         ContractDetailsImpl details = new ContractDetailsImpl();
         details.setCode(parseData(account.getCode()));
         details.setStorage(convertStorage(account.getStorage()));
 
-        AccountState state = new AccountState();
+        AccountState state = new AccountState(config.getBlockchainConfig());
 
         state.addToBalance(unifiedNumericToBigInteger(account.getBalance()));
         state.setNonce(unifiedNumericToBigInteger(account.getNonce()));

--- a/ethereumj-core/src/main/java/org/ethereum/jsontestsuite/builder/RepositoryBuilder.java
+++ b/ethereumj-core/src/main/java/org/ethereum/jsontestsuite/builder/RepositoryBuilder.java
@@ -1,5 +1,6 @@
 package org.ethereum.jsontestsuite.builder;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.AccountState;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.*;
@@ -14,14 +15,14 @@ import static org.ethereum.util.ByteUtil.wrap;
 
 public class RepositoryBuilder {
 
-    public static Repository build(Map<String, AccountTck> accounts){
+    public static Repository build(SystemProperties config, Map<String, AccountTck> accounts){
         HashMap<ByteArrayWrapper, AccountState> stateBatch = new HashMap<>();
         HashMap<ByteArrayWrapper, ContractDetails> detailsBatch = new HashMap<>();
 
         for (String address : accounts.keySet()) {
 
             AccountTck accountTCK = accounts.get(address);
-            AccountBuilder.StateWrap stateWrap = AccountBuilder.build(accountTCK);
+            AccountBuilder.StateWrap stateWrap = AccountBuilder.build(config, accountTCK);
 
             AccountState state = stateWrap.getAccountState();
             ContractDetails details = stateWrap.getContractDetails();
@@ -34,7 +35,7 @@ public class RepositoryBuilder {
             detailsBatch.put(wrap(parseData(address)), detailsCache);
         }
 
-        RepositoryImpl repositoryDummy = new RepositoryImpl(new HashMapDB().setClearOnClose(false),
+        RepositoryImpl repositoryDummy = new RepositoryImpl(config, new HashMapDB().setClearOnClose(false),
                 new HashMapDB().setClearOnClose(false));
         Repository track = repositoryDummy.startTracking();
         track.updateBatch(stateBatch, detailsBatch);

--- a/ethereumj-core/src/main/java/org/ethereum/mine/Ethash.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/Ethash.java
@@ -35,13 +35,19 @@ public class Ethash {
 
     public static boolean fileCacheEnabled = true;
 
+    SystemProperties config;
+
+    public static Ethash getForBlock(long blockNumber) {
+        return getForBlock(blockNumber, SystemProperties.getDefault());
+    }
+
     /**
      * Returns instance for the specified block number either from cache or calculates a new one
      */
-    public static Ethash getForBlock(long blockNumber) {
+    public static Ethash getForBlock(long blockNumber, SystemProperties config) {
         long epoch = blockNumber / ethashParams.getEPOCH_LENGTH();
         if (cachedInstance == null || epoch != cachedBlockEpoch) {
-            cachedInstance = new Ethash(blockNumber);
+            cachedInstance = new Ethash(blockNumber, config);
             cachedBlockEpoch = epoch;
         }
         return cachedInstance;
@@ -53,13 +59,14 @@ public class Ethash {
     private int[] cacheLight = null;
     private int[] fullData = null;
 
-    public Ethash(long blockNumber) {
+    public Ethash(long blockNumber, SystemProperties config) {
         this.blockNumber = blockNumber;
+        this.config = config;
     }
 
     public synchronized int[] getCacheLight() {
         if (cacheLight == null) {
-            File file = new File(SystemProperties.CONFIG.databaseDir(), "mine-dag-light.dat");
+            File file = new File(config.databaseDir(), "mine-dag-light.dat");
             if (fileCacheEnabled && file.canRead()) {
                 try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
                     logger.info("Loading light dataset from " + file.getAbsolutePath());
@@ -98,7 +105,7 @@ public class Ethash {
 
     public synchronized int[] getFullDataset() {
         if (fullData == null) {
-            File file = new File(SystemProperties.CONFIG.databaseDir(), "mine-dag.dat");
+            File file = new File(config.databaseDir(), "mine-dag.dat");
             if (fileCacheEnabled && file.canRead()) {
                 try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
                     logger.info("Loading dataset from " + file.getAbsolutePath());

--- a/ethereumj-core/src/main/java/org/ethereum/mine/EthashMiner.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/EthashMiner.java
@@ -36,6 +36,6 @@ public class EthashMiner implements MinerIfc {
 
     @Override
     public boolean validate(BlockHeader blockHeader) {
-        return Ethash.getForBlock(blockHeader.getNumber()).validate(blockHeader);
+        return Ethash.getForBlock(blockHeader.getNumber(), config).validate(blockHeader);
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/mine/EthashMiner.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/EthashMiner.java
@@ -30,8 +30,8 @@ public class EthashMiner implements MinerIfc {
     @Override
     public ListenableFuture<Long> mine(Block block) {
         return fullMining ?
-                Ethash.getForBlock(block.getNumber()).mine(block, cpuThreads) :
-                Ethash.getForBlock(block.getNumber()).mineLight(block, cpuThreads);
+                Ethash.getForBlock(block.getNumber(), config).mine(block, cpuThreads) :
+                Ethash.getForBlock(block.getNumber(), config).mineLight(block, cpuThreads);
     }
 
     @Override

--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/DiscoveryChannel.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/DiscoveryChannel.java
@@ -5,6 +5,7 @@ import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.MessageQueue;
 import org.ethereum.net.client.Capability;
@@ -24,7 +25,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * This class creates the connection to an remote address using the Netty framework
@@ -60,6 +61,9 @@ public class DiscoveryChannel {
     @Autowired
     ApplicationContext ctx;
 
+    @Autowired
+    SystemProperties config;
+
 
     public DiscoveryChannel() {
 
@@ -77,7 +81,7 @@ public class DiscoveryChannel {
 
             b.option(ChannelOption.SO_KEEPALIVE, true);
             b.option(ChannelOption.MESSAGE_SIZE_ESTIMATOR, DefaultMessageSizeEstimator.DEFAULT);
-            b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONFIG.peerConnectionTimeout());
+            b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, config.peerConnectionTimeout());
             b.remoteAddress(host, port);
 
 
@@ -102,7 +106,7 @@ public class DiscoveryChannel {
                             logger.info("Open connection, channel: {}", ch.toString());
 
                             ch.pipeline().addLast("readTimeoutHandler",
-                                    new ReadTimeoutHandler(CONFIG.peerChannelReadTimeout(), TimeUnit.SECONDS));
+                                    new ReadTimeoutHandler(config.peerChannelReadTimeout(), TimeUnit.SECONDS));
 //                            ch.pipeline().addLast("initiator", decoder.getInitiator());
                             ch.pipeline().addLast("messageCodec", decoder);
                             ch.pipeline().addLast(Capability.P2P, p2pHandler);

--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerDiscovery.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerDiscovery.java
@@ -1,5 +1,6 @@
 package org.ethereum.net.peerdiscovery;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.net.p2p.Peer;
 
 import org.slf4j.Logger;
@@ -26,7 +27,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * @author Roman Mandeleil
@@ -47,6 +48,8 @@ public class PeerDiscovery {
     @Autowired
     private ApplicationContext ctx;
 
+    @Autowired
+    SystemProperties config;
 
     private final AtomicBoolean started = new AtomicBoolean(false);
 
@@ -59,7 +62,7 @@ public class PeerDiscovery {
         threadFactory = Executors.defaultThreadFactory();
 
         // creating the ThreadPoolExecutor
-        executorPool = new ThreadPoolExecutor(CONFIG.peerDiscoveryWorkers(), CONFIG.peerDiscoveryWorkers(), 10,
+        executorPool = new ThreadPoolExecutor(config.peerDiscoveryWorkers(), config.peerDiscoveryWorkers(), 10,
                 TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1000), threadFactory, rejectionHandler);
 
         // start the monitoring thread
@@ -68,7 +71,7 @@ public class PeerDiscovery {
         monitorThread.start();
 
         // Initialize PeerData
-        List<PeerInfo> peerDataList = parsePeerDiscoveryIpList(CONFIG.peerDiscoveryIPList());
+        List<PeerInfo> peerDataList = parsePeerDiscoveryIpList(config.peerDiscoveryIPList());
         addPeers(peerDataList);
 
         for (PeerInfo peerData : this.peers) {

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -22,7 +22,7 @@ import java.net.InetSocketAddress;
 import java.util.*;
 
 import static java.lang.Math.min;
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * The central class for Peer Discovery machinery.
@@ -56,7 +56,7 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
     EthereumListener ethereumListener;
 
     @Autowired
-    SystemProperties config = SystemProperties.CONFIG;
+    SystemProperties config;
 
     Functional.Consumer<DiscoveryEvent> messageSender;
 
@@ -149,7 +149,7 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
     private void dbRead() {
         try {
             db = mapDBFactory.createTransactionalDB("network/discovery");
-            if (SystemProperties.CONFIG.databaseReset()) {
+            if (config.databaseReset()) {
                 logger.info("Resetting DB Node statistics...");
                 db.delete("nodeStats");
             }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/PeerConnectionTester.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/PeerConnectionTester.java
@@ -30,7 +30,7 @@ public class PeerConnectionTester {
     private WorldManager worldManager;
 
     @Autowired
-    SystemProperties config = SystemProperties.CONFIG;
+    SystemProperties config;
 
     // NodeHandler instance should be unique per Node instance
     private Map<NodeHandler, ?> connectedCandidates = Collections.synchronizedMap(new IdentityHashMap());

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/UDPListener.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/UDPListener.java
@@ -29,7 +29,7 @@ public class UDPListener {
     private NodeManager nodeManager;
 
     @Autowired
-    SystemProperties config = SystemProperties.CONFIG;
+    SystemProperties config;
 
     public UDPListener() {
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/swarm/Hive.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/swarm/Hive.java
@@ -26,9 +26,16 @@ public class Hive {
     private PeerAddress thisAddress;
     protected NodeTable nodeTable;
 
+    private NetStore netStore;
+
+    public void setNetStore(NetStore netStore) {
+        this.netStore = netStore;
+    }
+
     private Map<Node, BzzProtocol> connectedPeers = new IdentityHashMap<>();
 
-    public Hive(PeerAddress thisAddress) {
+    public Hive(NetStore netStore, PeerAddress thisAddress) {
+        this.netStore = netStore;
         this.thisAddress = thisAddress;
         nodeTable = new NodeTable(thisAddress.toNode());
     }
@@ -82,7 +89,7 @@ public class Hive {
                 if (--maxCount == 0) break;
             } else {
                 LOG.info("Hive connects to node " + node);
-                NetStore.getInstance().worldManager.getActivePeer().connect(node.getHost(), node.getPort(), Hex.toHexString(node.getId()));
+                netStore.worldManager.getActivePeer().connect(node.getHost(), node.getPort(), Hex.toHexString(node.getId()));
             }
         }
         return ret;

--- a/ethereumj-core/src/main/java/org/ethereum/net/swarm/LocalStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/swarm/LocalStore.java
@@ -8,6 +8,7 @@ package org.ethereum.net.swarm;
  *
  * Created by Anton Nashatyrev on 18.06.2015.
  */
+
 public class LocalStore implements ChunkStore {
 
     public ChunkStore dbStore;

--- a/ethereumj-core/src/main/java/org/ethereum/samples/PrivateMinerSample.java
+++ b/ethereumj-core/src/main/java/org/ethereum/samples/PrivateMinerSample.java
@@ -89,7 +89,7 @@ public class PrivateMinerSample {
                 logger.info("Generating Full Dataset (may take up to 10 min if not cached)...");
                 // calling this just for indication of the dataset generation
                 // basically this is not required
-                Ethash ethash = Ethash.getForBlock(ethereum.getBlockchain().getBestBlock().getNumber());
+                Ethash ethash = Ethash.getForBlock(ethereum.getBlockchain().getBestBlock().getNumber(), config);
                 ethash.getFullDataset();
                 logger.info("Full dataset generated (loaded).");
             }

--- a/ethereumj-core/src/main/java/org/ethereum/samples/PrivateMinerSample.java
+++ b/ethereumj-core/src/main/java/org/ethereum/samples/PrivateMinerSample.java
@@ -66,7 +66,7 @@ public class PrivateMinerSample {
          */
         @Bean
         public SystemProperties systemProperties() {
-            SystemProperties props = new SystemProperties();
+            SystemProperties props = SystemProperties.getDefault();
             props.overrideParams(ConfigFactory.parseString(config.replaceAll("'", "\"")));
             return props;
         }
@@ -155,7 +155,7 @@ public class PrivateMinerSample {
          */
         @Bean
         public SystemProperties systemProperties() {
-            SystemProperties props = new SystemProperties();
+            SystemProperties props = SystemProperties.getDefault();
             props.overrideParams(ConfigFactory.parseString(config.replaceAll("'", "\"")));
             return props;
         }

--- a/ethereumj-core/src/main/java/org/ethereum/samples/StandaloneBlockchainSample.java
+++ b/ethereumj-core/src/main/java/org/ethereum/samples/StandaloneBlockchainSample.java
@@ -36,10 +36,12 @@ public class StandaloneBlockchainSample {
             "  }" +
             "}";
 
+    private static SystemProperties CONFIG = SystemProperties.getDefault();
+
     public static void main(String[] args) throws Exception {
         // need to modify the default Frontier settings to keep the blocks difficulty
         // low to not waste a lot of time for block mining
-        SystemProperties.CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+        CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
             @Override
             public BigInteger getMINIMUM_DIFFICULTY() {
                 return BigInteger.ONE;
@@ -48,7 +50,7 @@ public class StandaloneBlockchainSample {
 
         // Creating a blockchain which generates a new block for each transaction
         // just not to call createBlock() after each call transaction
-        StandaloneBlockchain bc = new StandaloneBlockchain().withAutoblock(true);
+        StandaloneBlockchain bc = new StandaloneBlockchain(CONFIG).withAutoblock(true);
         System.out.println("Creating first empty block (need some time to generate DAG)...");
         // warning up the block miner just to understand how long
         // the initial miner dataset is generated

--- a/ethereumj-core/src/main/java/org/ethereum/samples/TestNetSample.java
+++ b/ethereumj-core/src/main/java/org/ethereum/samples/TestNetSample.java
@@ -46,7 +46,7 @@ public class TestNetSample extends BasicSample {
 
         @Bean
         public SystemProperties systemProperties() {
-            SystemProperties props = new SystemProperties();
+            SystemProperties props = SystemProperties.getDefault();
             props.overrideParams(ConfigFactory.parseString(config.replaceAll("'", "\"")));
             return props;
         }

--- a/ethereumj-core/src/main/java/org/ethereum/tck/RunTck.java
+++ b/ethereumj-core/src/main/java/org/ethereum/tck/RunTck.java
@@ -1,5 +1,6 @@
 package org.ethereum.tck;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.jsontestsuite.*;
 import org.ethereum.jsontestsuite.runners.StateTestRunner;
 import org.json.simple.JSONObject;
@@ -50,7 +51,7 @@ public class RunTck {
             logger.info(" Test case: {}", testName);
 
             StateTestCase stateTestCase = testCases.get(testName);
-            List<String> result = StateTestRunner.run(stateTestCase);
+            List<String> result = StateTestRunner.run(SystemProperties.getDefault(), stateTestCase);
 
             if (!result.isEmpty())
                 summary.put(testName, false);

--- a/ethereumj-core/src/main/java/org/ethereum/util/AdvancedDeviceUtils.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/AdvancedDeviceUtils.java
@@ -4,17 +4,15 @@ import org.apache.log4j.PropertyConfigurator;
 
 import java.net.URL;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
-
 /**
  * @author Roman Mandeleil
  * @since 25.07.2014
  */
 public class AdvancedDeviceUtils {
 
-    public static void adjustDetailedTracing(long blockNum) {
+    public static void adjustDetailedTracing(long blockNum, Integer traceStartBlock) {
         // here we can turn on the detail tracing in the middle of the chain
-        if (blockNum >= CONFIG.traceStartBlock() && CONFIG.traceStartBlock() != -1) {
+        if (blockNum >= traceStartBlock && traceStartBlock != -1) {
             URL configFile = ClassLoader.getSystemResource("log4j-detailed.properties");
             PropertyConfigurator.configure(configFile);
         }

--- a/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
@@ -73,7 +73,7 @@ public class StandaloneBlockchain implements LocalBlockchain {
 
     public StandaloneBlockchain(SystemProperties config) {
         this.config = config;
-        withGenesis(GenesisLoader.loadGenesis(
+        withGenesis(GenesisLoader.loadGenesis(config,
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
         withGasPrice(50_000_000_000L);
         withGasLimit(5_000_000L);

--- a/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
@@ -2,6 +2,7 @@ package org.ethereum.util.blockchain;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.config.CommonConfig;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.core.genesis.GenesisLoader;
 import org.ethereum.crypto.ECKey;
@@ -68,7 +69,10 @@ public class StandaloneBlockchain implements LocalBlockchain {
 
     List<PendingTx> submittedTxes = new ArrayList<>();
 
-    public StandaloneBlockchain() {
+    SystemProperties config;
+
+    public StandaloneBlockchain(SystemProperties config) {
+        this.config = config;
         withGenesis(GenesisLoader.loadGenesis(
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
         withGasPrice(50_000_000_000L);
@@ -149,7 +153,7 @@ public class StandaloneBlockchain implements LocalBlockchain {
                 txes.add(transaction);
             }
             Block b = getBlockchain().createNewBlock(parent, txes, Collections.EMPTY_LIST);
-            Ethash.getForBlock(b.getNumber()).mineLight(b).get();
+            Ethash.getForBlock(b.getNumber(), config).mineLight(b).get();
             ImportResult importResult = getBlockchain().tryToConnect(b);
             if (importResult != ImportResult.IMPORTED_BEST && importResult != ImportResult.IMPORTED_NOT_BEST) {
                 throw new RuntimeException("Invalid block import result " + importResult + " for block " + b);
@@ -253,19 +257,19 @@ public class StandaloneBlockchain implements LocalBlockchain {
         IndexedBlockStore blockStore = new IndexedBlockStore();
         blockStore.init(new HashMapDB(), new HashMapDB());
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = new RepositoryImpl(config, new HashMapDB(), new HashMapDB());
 
         ProgramInvokeFactoryImpl programInvokeFactory = new ProgramInvokeFactoryImpl();
         EthereumListenerAdapter listener = new EthereumListenerAdapter();
 
-        BlockchainImpl blockchain = new BlockchainImpl(blockStore, repository);
+        BlockchainImpl blockchain = new BlockchainImpl(config, blockStore, repository);
         blockchain.setParentHeaderValidator(new DependentBlockHeaderRuleAdapter());
         blockchain.setProgramInvokeFactory(programInvokeFactory);
         programInvokeFactory.setBlockchain(blockchain);
 
         blockchain.byTest = true;
 
-        PendingStateImpl pendingState = new PendingStateImpl(listener, blockchain);
+        PendingStateImpl pendingState = new PendingStateImpl(config, listener, blockchain);
 
         pendingState.init();
 
@@ -345,7 +349,7 @@ public class StandaloneBlockchain implements LocalBlockchain {
 
             try {
                 org.ethereum.core.TransactionExecutor executor = new org.ethereum.core.TransactionExecutor
-                        (tx, callBlock.getCoinbase(), repository, getBlockchain().getBlockStore(),
+                        (config, tx, callBlock.getCoinbase(), repository, getBlockchain().getBlockStore(),
                                 getBlockchain().getProgramInvokeFactory(), callBlock)
                         .setLocalCall(true);
 

--- a/ethereumj-core/src/main/java/org/ethereum/validator/BestNumberRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/BestNumberRule.java
@@ -3,9 +3,6 @@ package org.ethereum.validator;
 import org.ethereum.config.Constants;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeader;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import javax.annotation.PostConstruct;
 
 /**
  * Checks diff between number of some block and number of our best block. <br>
@@ -16,13 +13,10 @@ import javax.annotation.PostConstruct;
  */
 public class BestNumberRule extends DependentBlockHeaderRule {
 
-    @Autowired
-    SystemProperties config;
+    private final int BEST_NUMBER_DIFF_LIMIT;
 
-    private int BEST_NUMBER_DIFF_LIMIT;
-    @PostConstruct
-    private void populateFromConfig() {
-        BEST_NUMBER_DIFF_LIMIT = config.getBlockchainConfig().
+    public BestNumberRule(SystemProperties config) {
+        this.BEST_NUMBER_DIFF_LIMIT = config.getBlockchainConfig().
                 getCommonConstants().getBEST_NUMBER_DIFF_LIMIT();
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/validator/BestNumberRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/BestNumberRule.java
@@ -3,6 +3,9 @@ package org.ethereum.validator;
 import org.ethereum.config.Constants;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeader;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Checks diff between number of some block and number of our best block. <br>
@@ -13,8 +16,15 @@ import org.ethereum.core.BlockHeader;
  */
 public class BestNumberRule extends DependentBlockHeaderRule {
 
-    private static int BEST_NUMBER_DIFF_LIMIT = SystemProperties.CONFIG.getBlockchainConfig().
-            getCommonConstants().getBEST_NUMBER_DIFF_LIMIT();
+    @Autowired
+    SystemProperties config;
+
+    private int BEST_NUMBER_DIFF_LIMIT;
+    @PostConstruct
+    private void populateFromConfig() {
+        BEST_NUMBER_DIFF_LIMIT = config.getBlockchainConfig().
+                getCommonConstants().getBEST_NUMBER_DIFF_LIMIT();
+    }
 
     @Override
     public boolean validate(BlockHeader header, BlockHeader bestHeader) {

--- a/ethereumj-core/src/main/java/org/ethereum/validator/DifficultyRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/DifficultyRule.java
@@ -1,5 +1,7 @@
 package org.ethereum.validator;
 
+import org.ethereum.config.BlockchainNetConfig;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeader;
 
 import java.math.BigInteger;
@@ -13,13 +15,17 @@ import static org.ethereum.util.BIUtil.isEqual;
  * @since 02.09.2015
  */
 public class DifficultyRule extends DependentBlockHeaderRule {
+    BlockchainNetConfig config;
+    public DifficultyRule(BlockchainNetConfig config) {
+        this.config = config;
+    }
 
     @Override
     public boolean validate(BlockHeader header, BlockHeader parent) {
 
         errors.clear();
 
-        BigInteger calcDifficulty = header.calcDifficulty(parent);
+        BigInteger calcDifficulty = header.calcDifficulty(config, parent);
         BigInteger difficulty = header.getDifficultyBI();
 
         if (!isEqual(difficulty, calcDifficulty)) {

--- a/ethereumj-core/src/main/java/org/ethereum/validator/ExtraDataRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/ExtraDataRule.java
@@ -3,9 +3,6 @@ package org.ethereum.validator;
 import org.ethereum.config.Constants;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeader;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import javax.annotation.PostConstruct;
 
 /**
  * Checks {@link BlockHeader#extraData} size against {@link Constants#getMAXIMUM_EXTRA_DATA_SIZE}
@@ -15,13 +12,10 @@ import javax.annotation.PostConstruct;
  */
 public class ExtraDataRule extends BlockHeaderRule {
 
-    @Autowired
-    SystemProperties config;
+    private final int MAXIMUM_EXTRA_DATA_SIZE;
 
-    private int MAXIMUM_EXTRA_DATA_SIZE;
-    @PostConstruct
-    private void populateFromConfig() {
-        MAXIMUM_EXTRA_DATA_SIZE = config.getBlockchainConfig().
+    public ExtraDataRule(SystemProperties config) {
+        this.MAXIMUM_EXTRA_DATA_SIZE = config.getBlockchainConfig().
                 getCommonConstants().getMAXIMUM_EXTRA_DATA_SIZE();
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/validator/ExtraDataRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/ExtraDataRule.java
@@ -3,6 +3,9 @@ package org.ethereum.validator;
 import org.ethereum.config.Constants;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeader;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Checks {@link BlockHeader#extraData} size against {@link Constants#getMAXIMUM_EXTRA_DATA_SIZE}
@@ -12,8 +15,15 @@ import org.ethereum.core.BlockHeader;
  */
 public class ExtraDataRule extends BlockHeaderRule {
 
-    private static int MAXIMUM_EXTRA_DATA_SIZE = SystemProperties.CONFIG.getBlockchainConfig().
-            getCommonConstants().getMAXIMUM_EXTRA_DATA_SIZE();
+    @Autowired
+    SystemProperties config;
+
+    private int MAXIMUM_EXTRA_DATA_SIZE;
+    @PostConstruct
+    private void populateFromConfig() {
+        MAXIMUM_EXTRA_DATA_SIZE = config.getBlockchainConfig().
+                getCommonConstants().getMAXIMUM_EXTRA_DATA_SIZE();
+    }
 
     @Override
     public boolean validate(BlockHeader header) {

--- a/ethereumj-core/src/main/java/org/ethereum/validator/GasLimitRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/GasLimitRule.java
@@ -3,9 +3,7 @@ package org.ethereum.validator;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.config.Constants;
 import org.ethereum.core.BlockHeader;
-import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 
 /**
@@ -18,13 +16,10 @@ import java.math.BigInteger;
  */
 public class GasLimitRule extends BlockHeaderRule {
 
-    @Autowired
-    SystemProperties config;
+    private final int MIN_GAS_LIMIT;
 
-    private int MIN_GAS_LIMIT;
-    @PostConstruct
-    private void populateFromConfig() {
-        MIN_GAS_LIMIT = config.getBlockchainConfig().
+    public GasLimitRule(SystemProperties config) {
+        this.MIN_GAS_LIMIT = config.getBlockchainConfig().
                 getCommonConstants().getMIN_GAS_LIMIT();
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/validator/GasLimitRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/GasLimitRule.java
@@ -3,7 +3,9 @@ package org.ethereum.validator;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.config.Constants;
 import org.ethereum.core.BlockHeader;
+import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 
 /**
@@ -16,8 +18,15 @@ import java.math.BigInteger;
  */
 public class GasLimitRule extends BlockHeaderRule {
 
-    private static int MIN_GAS_LIMIT = SystemProperties.CONFIG.getBlockchainConfig().
-            getCommonConstants().getMIN_GAS_LIMIT();
+    @Autowired
+    SystemProperties config;
+
+    private int MIN_GAS_LIMIT;
+    @PostConstruct
+    private void populateFromConfig() {
+        MIN_GAS_LIMIT = config.getBlockchainConfig().
+                getCommonConstants().getMIN_GAS_LIMIT();
+    }
 
     @Override
     public boolean validate(BlockHeader header) {

--- a/ethereumj-core/src/main/java/org/ethereum/validator/ParentGasLimitRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/ParentGasLimitRule.java
@@ -1,7 +1,9 @@
 package org.ethereum.validator;
 
+import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeader;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.math.BigInteger;
 
@@ -15,8 +17,13 @@ import java.math.BigInteger;
  */
 public class ParentGasLimitRule extends DependentBlockHeaderRule {
 
-    private static int GAS_LIMIT_BOUND_DIVISOR = SystemProperties.CONFIG.getBlockchainConfig().
-            getCommonConstants().getGAS_LIMIT_BOUND_DIVISOR();
+
+    private int GAS_LIMIT_BOUND_DIVISOR;
+
+    public ParentGasLimitRule(BlockchainNetConfig config) {
+        GAS_LIMIT_BOUND_DIVISOR = config.getCommonConstants().getGAS_LIMIT_BOUND_DIVISOR();
+    }
+
 
     @Override
     public boolean validate(BlockHeader header, BlockHeader parent) {

--- a/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm;
 
+import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.db.ContractDetails;
 import org.ethereum.vm.MessageCall.MsgType;
@@ -8,13 +9,15 @@ import org.ethereum.vm.program.Stack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
+import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.ethereum.crypto.HashUtil.sha3;
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
 import static org.ethereum.vm.OpCode.CALL;
@@ -74,8 +77,18 @@ public class VM {
     private int vmCounter = 0;
 
     private static VMHook vmHook;
-    private final static boolean vmTrace = CONFIG.vmTrace();
-    private final static long dumpBlock = CONFIG.dumpBlock();
+
+    SystemProperties config;
+
+    public VM(SystemProperties config) {
+        this.config = config;
+        vmTrace = config.vmTrace();
+        dumpBlock = config.dumpBlock();
+    }
+
+    private boolean vmTrace;
+    private long dumpBlock;
+
 
     public void step(Program program) {
 
@@ -90,7 +103,10 @@ public class VM {
             }
             if (op == DELEGATECALL) {
                 // opcode since Homestead release only
-                if (!SystemProperties.CONFIG.getBlockchainConfig().getConfigForBlock(program.getNumber().longValue()).
+                config.getBlockchainConfig();
+                program.getNumber();
+                program.getNumber().longValue();
+                if (!config.getBlockchainConfig().getConfigForBlock(program.getNumber().longValue()).
                         getConstants().hasDelegateCallOpcode()) {
                     throw Program.Exception.invalidOpCode(program.getCurrentOp());
                 }
@@ -1216,7 +1232,7 @@ public class VM {
                     gasBefore, gasCost, memWords)
      */
     private void dumpLine(OpCode op, long gasBefore, long gasCost, long memWords, Program program) {
-        if (CONFIG.dumpStyle().equals("standard+")) {
+        if (config.dumpStyle().equals("standard+")) {
             switch (op) {
                 case STOP:
                 case RETURN:
@@ -1241,7 +1257,7 @@ public class VM {
             String gasString = Hex.toHexString(program.getGas().getNoLeadZeroesData());
 
             dumpLogger.trace("{} {} {} {}", addressString, pcString, opString, gasString);
-        } else if (CONFIG.dumpStyle().equals("pretty")) {
+        } else if (config.dumpStyle().equals("pretty")) {
             dumpLogger.trace("    STACK");
             for (DataWord item : program.getStack()) {
                 dumpLogger.trace("{}", item);

--- a/ethereumj-core/src/main/java/org/ethereum/vm/VMUtils.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/VMUtils.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm;
 
+import org.ethereum.config.SystemProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,7 +14,7 @@ import static java.lang.String.format;
 import static java.lang.System.getProperty;
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 import static org.apache.commons.codec.binary.Base64.encodeBase64String;
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.springframework.util.StringUtils.isEmpty;
 
 public final class VMUtils {
@@ -33,12 +34,12 @@ public final class VMUtils {
         }
     }
 
-    private static File createProgramTraceFile(String txHash) {
+    private static File createProgramTraceFile(SystemProperties config , String txHash) {
         File result = null;
 
-        if (CONFIG.vmTrace() && !isEmpty(CONFIG.vmTraceDir())) {
+        if (config.vmTrace() && !isEmpty(config.vmTraceDir())) {
 
-            File file = new File(new File(CONFIG.databaseDir(), CONFIG.vmTraceDir()), txHash + ".json");
+            File file = new File(new File(config.databaseDir(), config.vmTraceDir()), txHash + ".json");
 
             if (file.exists()) {
                 if (file.isFile() && file.canWrite()) {
@@ -73,7 +74,7 @@ public final class VMUtils {
     }
 
     public static void saveProgramTraceFile(String txHash, String content) {
-        File file = createProgramTraceFile(txHash);
+        File file = createProgramTraceFile(SystemProperties.getDefault(), txHash);
         if (file != null) {
             writeStringToFile(file, content);
         }

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm.program.invoke;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Repository;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -35,7 +36,7 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     public ProgramInvokeMockImpl() {
 
 
-        this.repository = new RepositoryDummy();
+        this.repository = new RepositoryDummy(SystemProperties.getDefault());
         this.repository.createAccount(ownerAddress);
 
         this.repository.createAccount(contractAddress);

--- a/ethereumj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm.trace;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Repository;
 import org.ethereum.db.ContractDetails;
 import org.ethereum.db.RepositoryTrack;
@@ -16,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.ethereum.util.ByteUtil.toHexString;
 import static org.ethereum.vm.trace.Serializers.serializeFieldsOnly;
 
@@ -31,13 +32,15 @@ public class ProgramTrace {
     private boolean fullStorage;
     private int storageSize;
     private String contractAddress;
+    private SystemProperties config;
 
-    public ProgramTrace() {
-        this(null);
+    public ProgramTrace(SystemProperties config) {
+        this(config, null);
     }
 
-    public ProgramTrace(ProgramInvoke programInvoke) {
-        if (CONFIG.vmTrace() && programInvoke != null) {
+    public ProgramTrace(SystemProperties config, ProgramInvoke programInvoke) {
+        this.config = config;
+        if (config.vmTrace() && programInvoke != null) {
             contractAddress = Hex.toHexString(programInvoke.getOwnerAddress().getLast20Bytes());
 
             ContractDetails contractDetails = getContractDetails(programInvoke);
@@ -46,7 +49,7 @@ public class ProgramTrace {
                 fullStorage = true;
             } else {
                 storageSize = contractDetails.getStorageSize();
-                if (storageSize <= CONFIG.vmTraceInitStorageLimit()) {
+                if (storageSize <= config.vmTraceInitStorageLimit()) {
                     fullStorage = true;
 
                     String address = toHexString(programInvoke.getOwnerAddress().getLast20Bytes());

--- a/ethereumj-core/src/main/java/org/ethereum/vm/trace/ProgramTraceListener.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/trace/ProgramTraceListener.java
@@ -3,11 +3,15 @@ package org.ethereum.vm.trace;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.program.listener.ProgramListenerAdaptor;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 public class ProgramTraceListener extends ProgramListenerAdaptor {
 
-    private final boolean enabled = CONFIG.vmTrace();
+    private boolean enabled;
+    public ProgramTraceListener(boolean enabled) {
+        this.enabled = enabled;
+    }
+
     private OpActions actions = new OpActions();
 
     @Override

--- a/ethereumj-core/src/test/java/org/ethereum/TestContext.java
+++ b/ethereumj-core/src/test/java/org/ethereum/TestContext.java
@@ -21,6 +21,7 @@ public class TestContext {
 
     private static final Logger logger = LoggerFactory.getLogger("test");
 
+    private SystemProperties config = SystemProperties.getDefault();
 
     @Bean
     public SessionFactory sessionFactory() throws SQLException {
@@ -39,7 +40,7 @@ public class TestContext {
 
         Properties prop = new Properties();
 
-        if (SystemProperties.CONFIG.databaseReset())
+        if (config.databaseReset())
             prop.put("hibernate.hbm2ddl.auto", "create");
 
         prop.put("hibernate.format_sql", "true");
@@ -74,8 +75,8 @@ public class TestContext {
                 String.format("jdbc:hsqldb:file:./%s/blockchain/blockchain.db;" +
                                 "create=%s;hsqldb.default_table_type=cached",
 
-                        SystemProperties.CONFIG.databaseDir(),
-                        SystemProperties.CONFIG.databaseReset());
+                        config.databaseDir(),
+                        config.databaseReset());
 
         DriverManagerDataSource ds = new DriverManagerDataSource();
         ds.setDriverClassName("org.hsqldb.jdbcDriver");

--- a/ethereumj-core/src/test/java/org/ethereum/config/ConfigTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/ConfigTest.java
@@ -60,7 +60,7 @@ public class ConfigTest {
 
     @Test
     public void ethereumjConfTest() {
-        System.out.println("'" + SystemProperties.CONFIG.databaseDir() + "'");
-        System.out.println(SystemProperties.CONFIG.peerActive());
+        System.out.println("'" + SystemProperties.getDefault().databaseDir() + "'");
+        System.out.println(SystemProperties.getDefault().peerActive());
     }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
@@ -9,9 +9,10 @@ import org.junit.Test;
 public class SystemPropertiesTest {
     @Test
     public void punchBindIpTest() {
-        SystemProperties.CONFIG.overrideParams("peer.bind.ip", "");
+        SystemProperties config = SystemProperties.getDefault();
+        config.overrideParams("peer.bind.ip", "");
         long st = System.currentTimeMillis();
-        String ip = SystemProperties.CONFIG.bindIp();
+        String ip = config.bindIp();
         long t = System.currentTimeMillis() - st;
         System.out.println(ip + " in " + t + " msec");
         Assert.assertTrue(t < 10 * 1000);
@@ -20,9 +21,10 @@ public class SystemPropertiesTest {
 
     @Test
     public void externalIpTest() {
-        SystemProperties.CONFIG.overrideParams("peer.discovery.external.ip", "");
+        SystemProperties config = SystemProperties.getDefault();
+        config.overrideParams("peer.discovery.external.ip", "");
         long st = System.currentTimeMillis();
-        String ip = SystemProperties.CONFIG.externalIp();
+        String ip = config.externalIp();
         long t = System.currentTimeMillis() - st;
         System.out.println(ip + " in " + t + " msec");
         Assert.assertTrue(t < 10 * 1000);

--- a/ethereumj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
@@ -33,10 +33,10 @@ public class SystemPropertiesTest {
 
     @Test
     public void blockchainNetConfigTest() {
-        SystemProperties systemProperties1 = new SystemProperties();
+        SystemProperties systemProperties1 = SystemProperties.getDefault();
         systemProperties1.overrideParams("blockchain.config.name", "olympic");
         BlockchainNetConfig blockchainConfig1 = systemProperties1.getBlockchainConfig();
-        SystemProperties systemProperties2 = new SystemProperties();
+        SystemProperties systemProperties2 = SystemProperties.getDefault();
         systemProperties2.overrideParams("blockchain.config.name", "morden");
         BlockchainNetConfig blockchainConfig2= systemProperties2.getBlockchainConfig();
         Assert.assertNotEquals(blockchainConfig1.getClass(), blockchainConfig2.getClass());

--- a/ethereumj-core/src/test/java/org/ethereum/core/BlockTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/BlockTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.core;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.genesis.GenesisLoader;
 import org.ethereum.trie.SecureTrie;
 import org.ethereum.trie.Trie;
@@ -16,7 +17,7 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Set;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -117,18 +118,16 @@ public class BlockTest {
     @Test
     public void testFrontierGenesis(){
 
-        String prev = CONFIG.genesisInfo();
-        CONFIG.setGenesisInfo("frontier.json");
+        SystemProperties config = SystemProperties.getDefault();
+        config.setGenesisInfo("frontier.json");
 
-        Block genesis = GenesisLoader.loadGenesis();
+        Block genesis = GenesisLoader.loadGenesis(config);
 
         String hash = Hex.toHexString(genesis.getHash());
         String root = Hex.toHexString(genesis.getStateRoot());
 
         assertEquals("d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544", root);
         assertEquals("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", hash);
-
-        CONFIG.setGenesisInfo(prev);
     }
 
 

--- a/ethereumj-core/src/test/java/org/ethereum/core/BlockTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/BlockTest.java
@@ -121,7 +121,7 @@ public class BlockTest {
         SystemProperties config = SystemProperties.getDefault();
         config.setGenesisInfo("frontier.json");
 
-        Block genesis = GenesisLoader.loadGenesis(config);
+        Block genesis = GenesisLoader.loadGenesis(config, getClass().getClassLoader());
 
         String hash = Hex.toHexString(genesis.getHash());
         String root = Hex.toHexString(genesis.getStateRoot());

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -93,7 +93,7 @@ public class ImportLightTest {
     public void invalidBlockTest() throws Exception {
         // testing that bad block import effort doesn't affect the repository state
 
-        BlockchainImpl blockchain = createBlockchain(GenesisLoader.loadGenesis(
+        BlockchainImpl blockchain = createBlockchain(SystemProperties.getDefault(), GenesisLoader.loadGenesis(
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
         blockchain.setMinerCoinbase(Hex.decode("ee0250c19ad59305b2bdb61f34b45b72fe37154f"));
         Block parent = blockchain.getBestBlock();

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -93,7 +93,7 @@ public class ImportLightTest {
     public void invalidBlockTest() throws Exception {
         // testing that bad block import effort doesn't affect the repository state
 
-        BlockchainImpl blockchain = createBlockchain(SystemProperties.getDefault(), GenesisLoader.loadGenesis(
+        BlockchainImpl blockchain = createBlockchain(config, GenesisLoader.loadGenesis(
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
         blockchain.setMinerCoinbase(Hex.decode("ee0250c19ad59305b2bdb61f34b45b72fe37154f"));
         Block parent = blockchain.getBestBlock();

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -32,9 +32,11 @@ import java.util.Collections;
  */
 public class ImportLightTest {
 
+    static SystemProperties config = SystemProperties.getDefault();
+
     @BeforeClass
     public static void setup() {
-        SystemProperties.CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+        config.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
             @Override
             public BigInteger getMINIMUM_DIFFICULTY() {
                 return BigInteger.ONE;
@@ -42,15 +44,10 @@ public class ImportLightTest {
         }));
     }
 
-    @AfterClass
-    public static void cleanup() {
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-    }
-
     @Test
     public void createFork() throws Exception {
         // importing forked chain
-        BlockchainImpl blockchain = createBlockchain(GenesisLoader.loadGenesis(
+        BlockchainImpl blockchain = createBlockchain(config, GenesisLoader.loadGenesis(
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
         blockchain.setMinerCoinbase(Hex.decode("ee0250c19ad59305b2bdb61f34b45b72fe37154f"));
         Block parent = blockchain.getBestBlock();
@@ -96,7 +93,7 @@ public class ImportLightTest {
     public void doubleTransactionTest() throws Exception {
         // Testing that blocks containing tx with invalid nonce are rejected
 
-        BlockchainImpl blockchain = createBlockchain(GenesisLoader.loadGenesis(
+        BlockchainImpl blockchain = createBlockchain(config, GenesisLoader.loadGenesis(
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
         blockchain.setMinerCoinbase(Hex.decode("ee0250c19ad59305b2bdb61f34b45b72fe37154f"));
         Block parent = blockchain.getBestBlock();
@@ -209,7 +206,7 @@ public class ImportLightTest {
                 "  }" +
                 "}";
 
-        StandaloneBlockchain bc = new StandaloneBlockchain();
+        StandaloneBlockchain bc = new StandaloneBlockchain(config);
         SolidityContract parent = bc.submitNewContract(contractSrc, "Parent");
         Block b1 = bc.createBlock();
         Block b2 = bc.createBlock();
@@ -242,7 +239,7 @@ public class ImportLightTest {
                 "}";
 
         {
-            StandaloneBlockchain bc = new StandaloneBlockchain();
+            StandaloneBlockchain bc = new StandaloneBlockchain(config);
             Block b1 = bc.createBlock();
             Block b2 = bc.createBlock();
             SolidityContract a = bc.submitNewContract(contractSrc, "A");
@@ -275,7 +272,7 @@ public class ImportLightTest {
                 "        child = (new B).value(20)();" +
                 "    }" +
                 "}";
-        StandaloneBlockchain bc = new StandaloneBlockchain().withAutoblock(true);
+        StandaloneBlockchain bc = new StandaloneBlockchain(config).withAutoblock(true);
         SolidityContract a = bc.submitNewContract(contract, "A");
         bc.sendEther(a.getAddress(), BigInteger.valueOf(10000));
         a.callFunction(10, "create");
@@ -301,7 +298,7 @@ public class ImportLightTest {
                 "  }" +
                 "}";
 
-        StandaloneBlockchain bc = new StandaloneBlockchain();
+        StandaloneBlockchain bc = new StandaloneBlockchain(config);
         Block b1 = bc.createBlock();
         SolidityContract a = bc.submitNewContract(contractA);
         Block b2 = bc.createBlock();
@@ -330,7 +327,7 @@ public class ImportLightTest {
                 "  }" +
                 "}";
 
-        StandaloneBlockchain bc = new StandaloneBlockchain().withGasPrice(1);
+        StandaloneBlockchain bc = new StandaloneBlockchain(config).withGasPrice(1);
         SolidityContract a = bc.submitNewContract(contractA, "A");
         bc.createBlock();
         BigInteger balance1 = bc.getBlockchain().getRepository().getBalance(bc.getSender().getAddress());
@@ -342,24 +339,24 @@ public class ImportLightTest {
     }
 
 
-    public static BlockchainImpl createBlockchain(Genesis genesis) {
+    public static BlockchainImpl createBlockchain(SystemProperties config, Genesis genesis) {
         IndexedBlockStore blockStore = new IndexedBlockStore();
         blockStore.init(new HashMapDB(), new HashMapDB());
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = new RepositoryImpl(config, new HashMapDB(), new HashMapDB());
 
         ProgramInvokeFactoryImpl programInvokeFactory = new ProgramInvokeFactoryImpl();
         EthereumListenerAdapter listener = new EthereumListenerAdapter();
 
-        BlockchainImpl blockchain = new BlockchainImpl(blockStore, repository)
-                .withParentBlockHeaderValidator(new CommonConfig().parentHeaderValidator());
+        BlockchainImpl blockchain = new BlockchainImpl(config, blockStore, repository)
+                .withParentBlockHeaderValidator(new CommonConfig(config, null, null).parentHeaderValidator());
         blockchain.setParentHeaderValidator(new DependentBlockHeaderRuleAdapter());
         blockchain.setProgramInvokeFactory(programInvokeFactory);
         programInvokeFactory.setBlockchain(blockchain);
 
         blockchain.byTest = true;
 
-        PendingStateImpl pendingState = new PendingStateImpl(listener, blockchain);
+        PendingStateImpl pendingState = new PendingStateImpl(config, listener, blockchain);
 
         pendingState.init();
 

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportTest.java
@@ -3,6 +3,7 @@ package org.ethereum.core;
 
 import org.ethereum.TestContext;
 import org.ethereum.config.NoAutoscan;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.IndexedBlockStore;
@@ -32,7 +33,7 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -41,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 public class ImportTest {
 
     private static final Logger logger = LoggerFactory.getLogger("test");
+    private SystemProperties config = SystemProperties.getDefault();
 
     @Configuration
     @ComponentScan(basePackages = "org.ethereum")
@@ -71,7 +73,7 @@ public class ImportTest {
     public void testScenario1() throws URISyntaxException, IOException {
 
         BlockchainImpl blockchain = (BlockchainImpl) worldManager.getBlockchain();
-        logger.info("Running as: {}", CONFIG.genesisInfo());
+        logger.info("Running as: {}", config.genesisInfo());
 
         URL scenario1 = ClassLoader
                 .getSystemResource("blockload/scenario1.dmp");
@@ -79,7 +81,7 @@ public class ImportTest {
         File file = new File(scenario1.toURI());
         List<String> strData = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
 
-        byte[] root = Genesis.getInstance().getStateRoot();
+        byte[] root = config.getGenesis().getStateRoot();
         for (String blockRLP : strData) {
             Block block = new Block(
                     Hex.decode(blockRLP));

--- a/ethereumj-core/src/test/java/org/ethereum/core/PendingStateTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/PendingStateTest.java
@@ -1,6 +1,7 @@
 package org.ethereum.core;
 
 import org.ethereum.config.CommonConfig;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.genesis.GenesisLoader;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.datasource.HashMapDB;
@@ -35,16 +36,18 @@ public class PendingStateTest {
 
     private Repository repository;
 
+    private SystemProperties config;
     @Before
     public void setUp() {
+        config = SystemProperties.getDefault();
         IndexedBlockStore blockStore = new IndexedBlockStore();
         blockStore.init(new HashMapDB(), new HashMapDB());
 
-        repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        repository = new RepositoryImpl(config, new HashMapDB(), new HashMapDB());
 
-        blockchain = new BlockchainImpl(blockStore, repository)
-                .withParentBlockHeaderValidator(new CommonConfig().parentHeaderValidator());
-        PendingStateImpl pendingState = new PendingStateImpl(new EthereumListenerAdapter(), (BlockchainImpl) blockchain);
+        blockchain = new BlockchainImpl(config, blockStore, repository)
+                .withParentBlockHeaderValidator(new CommonConfig(config, null, null).parentHeaderValidator());
+        PendingStateImpl pendingState = new PendingStateImpl(config, new EthereumListenerAdapter(), (BlockchainImpl) blockchain);
         pendingState.setBlockchain(blockchain);
         pendingState.init();
 
@@ -98,11 +101,11 @@ public class PendingStateTest {
         // testing that PendingState correctly handles situation when the best fork switches
         // and the new block contains another set of transactions
 
-        BlockchainImpl blockchain = ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(
+        BlockchainImpl blockchain = ImportLightTest.createBlockchain(SystemProperties.getDefault(), GenesisLoader.loadGenesis(
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
         blockchain.setMinerCoinbase(Hex.decode("ee0250c19ad59305b2bdb61f34b45b72fe37154f"));
 
-        PendingStateImpl pendingState = new PendingStateImpl(new EthereumListenerAdapter(), blockchain);
+        PendingStateImpl pendingState = new PendingStateImpl(config, new EthereumListenerAdapter(), blockchain);
         pendingState.setBlockchain(blockchain);
         pendingState.init();
 

--- a/ethereumj-core/src/test/java/org/ethereum/core/StateTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/StateTest.java
@@ -1,6 +1,7 @@
 package org.ethereum.core;
 
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.ByteArrayWrapper;
@@ -115,7 +116,7 @@ public class StateTest {
     private Trie generateGenesisState() {
 
         Trie trie = new TrieImpl(new HashMapDB());
-        Genesis genesis = (Genesis)Genesis.getInstance();
+        Genesis genesis = SystemProperties.getDefault().getGenesis();
         for (ByteArrayWrapper key : genesis.getPremine().keySet()) {
             trie.update(key.getData(), genesis.getPremine().get(key).getEncoded());
         }

--- a/ethereumj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -403,7 +403,7 @@ public class TransactionTest {
 
         StateTestSuite stateTestSuite = new StateTestSuite(json.replaceAll("'", "\""));
 
-        List<String> res = new StateTestRunner(stateTestSuite.getTestCases().get("test1")) {
+        List<String> res = new StateTestRunner(SystemProperties.getDefault(), stateTestSuite.getTestCases().get("test1")) {
             @Override
             protected ProgramResult executeTransaction(Transaction tx) {
                 // first emulating the constant call (Ethereum.callConstantFunction)
@@ -419,7 +419,7 @@ public class TransactionTest {
                     Block bestBlock = block;
 
                     TransactionExecutor executor = new TransactionExecutor
-                            (txConst, bestBlock.getCoinbase(), track, new BlockStoreDummy(),
+                            (SystemProperties.getDefault(), txConst, bestBlock.getCoinbase(), track, new BlockStoreDummy(),
                                     invokeFactory, bestBlock)
                             .setLocalCall(true);
 
@@ -520,13 +520,11 @@ public class TransactionTest {
 
         System.out.println(json.replaceAll("'", "\""));
 
-        try {
-            SystemProperties.CONFIG.setBlockchainConfig(new HomesteadConfig());
-            List<String> res = new StateTestRunner(stateTestSuite.getTestCases().get("test1")).runImpl();
-            if (!res.isEmpty()) throw new RuntimeException("Test failed: " + res);
-        } finally {
-            SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-        }
+        SystemProperties config =  SystemProperties.getDefault();
+        config.setBlockchainConfig(new HomesteadConfig());
+        List<String> res = new StateTestRunner(config, stateTestSuite.getTestCases().get("test1")).runImpl();
+        if (!res.isEmpty()) throw new RuntimeException("Test failed: " + res);
+
     }
 
     @Test
@@ -549,7 +547,7 @@ public class TransactionTest {
         System.out.println(res.errors);
         CompilationResult cres = CompilationResult.parse(res.output);
 
-        BlockchainImpl blockchain = ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(
+        BlockchainImpl blockchain = ImportLightTest.createBlockchain(SystemProperties.getDefault(), GenesisLoader.loadGenesis(
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
 
         ECKey sender = ECKey.fromPrivate(Hex.decode("3ec771c31cac8c0dba77a69e503765701d3c2bb62435888d4ffa38fed60c445c"));
@@ -592,7 +590,7 @@ public class TransactionTest {
 
     public ProgramResult executeTransaction(BlockchainImpl blockchain, Transaction tx) {
         Repository track = blockchain.getRepository().startTracking();
-        TransactionExecutor executor = new TransactionExecutor(tx, new byte[32], blockchain.getRepository(),
+        TransactionExecutor executor = new TransactionExecutor(SystemProperties.getDefault(), tx, new byte[32], blockchain.getRepository(),
                 blockchain.getBlockStore(), blockchain.getProgramInvokeFactory(), blockchain.getBestBlock());
 
         executor.init();

--- a/ethereumj-core/src/test/java/org/ethereum/datasource/AbstractRedisTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/datasource/AbstractRedisTest.java
@@ -3,6 +3,7 @@ package org.ethereum.datasource;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.config.NoAutoscan;
 import org.ethereum.datasource.redis.RedisConnection;
+import org.ethereum.datasource.redis.RedisConnectionImpl;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.InMemoryBlockStore;
 import org.ethereum.manager.WorldManager;
@@ -34,11 +35,6 @@ public abstract class AbstractRedisTest {
     @ComponentScan(basePackages = "org.ethereum")
     @NoAutoscan
     static class ContextConfiguration extends TestContext {
-        static {
-            SystemProperties.CONFIG.setDataBaseDir("test_db/" + "RedisAll");
-            SystemProperties.CONFIG.setDatabaseReset(true);
-        }
-
         @Bean
         @Transactional(propagation = Propagation.SUPPORTS)
         public BlockStore blockStore(SessionFactory sessionFactory){
@@ -46,7 +42,6 @@ public abstract class AbstractRedisTest {
         }
     }
 
-    @Autowired
     private RedisConnection redisConnection;
 
     @Autowired
@@ -61,6 +56,14 @@ public abstract class AbstractRedisTest {
     private Boolean connected;
 
     protected RedisConnection getRedisConnection() {
+        if (redisConnection == null) {
+            SystemProperties config = SystemProperties.getDefault();
+            config.setDataBaseDir("test_db/" + "RedisAll");
+            config.setDatabaseReset(true);
+
+            redisConnection = new RedisConnectionImpl(config);
+        }
+
         return redisConnection;
     }
 
@@ -76,7 +79,7 @@ public abstract class AbstractRedisTest {
                 System.out.printf("Cannot connect to '%s' Redis cloud.\n", url);
             }
 
-            assertFalse(connected ^ redisConnection.isAvailable());
+            assertFalse(connected ^ getRedisConnection().isAvailable());
         }
 
         return connected;

--- a/ethereumj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.datasource;
 
+import org.ethereum.config.SystemProperties;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -15,7 +16,7 @@ public class LevelDbDataSourceTest {
 
     @Test
     public void testBatchUpdating() {
-        LevelDbDataSource dataSource = new LevelDbDataSource("test");
+        LevelDbDataSource dataSource = new LevelDbDataSource(SystemProperties.getDefault(), "test");
         dataSource.init();
 
         final int batchSize = 100;
@@ -30,7 +31,7 @@ public class LevelDbDataSourceTest {
 
     @Test
     public void testPutting() {
-        LevelDbDataSource dataSource = new LevelDbDataSource("test");
+        LevelDbDataSource dataSource = new LevelDbDataSource(SystemProperties.getDefault(), "test");
         dataSource.init();
 
         byte[] key = randomBytes(32);

--- a/ethereumj-core/src/test/java/org/ethereum/db/BlockQueueTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/BlockQueueTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockWrapper;
@@ -29,7 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 import static org.junit.Assert.*;
 
 /**
@@ -54,7 +55,8 @@ public class BlockQueueTest {
         File file = new File(scenario1.toURI());
         List<String> strData = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
 
-        Block genesis = Genesis.getInstance();
+        SystemProperties config = SystemProperties.getDefault();
+        Block genesis = config.getGenesis();
         blocks.add(genesis);
 
         for (String blockRLP : strData) {
@@ -75,11 +77,12 @@ public class BlockQueueTest {
 
         BigInteger bi = new BigInteger(32, new Random());
         testDb = "test_db_" + bi;
-        CONFIG.setDataBaseDir(testDb);
-        CONFIG.setDatabaseReset(false);
 
-        MapDBFactory mapDBFactory = new MapDBFactoryImpl();
-        blockQueue = new BlockQueueImpl();
+        config.setDataBaseDir(testDb);
+        config.setDatabaseReset(false);
+
+        MapDBFactory mapDBFactory = new MapDBFactoryImpl(config);
+        blockQueue = new BlockQueueImpl(config);
         ((BlockQueueImpl)blockQueue).setMapDBFactory(mapDBFactory);
         blockQueue.open();
 

--- a/ethereumj-core/src/test/java/org/ethereum/db/BlockStressTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/BlockStressTest.java
@@ -41,11 +41,14 @@ public class BlockStressTest {
     private MapDBFactory mapDBFactory;
     private byte[] nodeId = new byte[64];
 
+    private SystemProperties config;
+
     @Before
     public void setup() {
-        SystemProperties.CONFIG.setDataBaseDir(TEST_DB_DIR);
+        config = SystemProperties.getDefault();
+        config.setDataBaseDir(TEST_DB_DIR);
 
-        mapDBFactory = new MapDBFactoryImpl();
+        mapDBFactory = new MapDBFactoryImpl(config);
         blockSourceDB = mapDBFactory.createDB(BLOCK_SOURCE);
         blockSource = blockSourceDB.hashMapCreate(BLOCK_SOURCE)
                 .keySerializer(Serializer.BYTE_ARRAY)
@@ -116,7 +119,7 @@ public class BlockStressTest {
     public void testBlockQueue() {
         long start, end;
 
-        BlockQueue blockQueue = new BlockQueueImpl();
+        BlockQueue blockQueue = new BlockQueueImpl(config);
         ((BlockQueueImpl)blockQueue).setMapDBFactory(mapDBFactory);
         blockQueue.open();
 
@@ -155,7 +158,7 @@ public class BlockStressTest {
         long start, end;
         int threadsCount = 5;
 
-        BlockQueue blockQueue = new BlockQueueImpl();
+        BlockQueue blockQueue = new BlockQueueImpl(config);
         ((BlockQueueImpl)blockQueue).setMapDBFactory(mapDBFactory);
         blockQueue.open();
 

--- a/ethereumj-core/src/test/java/org/ethereum/db/ContractDetailsTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/ContractDetailsTest.java
@@ -19,8 +19,9 @@ import static org.junit.Assert.assertTrue;
 
 public class ContractDetailsTest {
 
-    private static final int IN_MEMORY_STORAGE_LIMIT = SystemProperties.CONFIG.detailsInMemoryStorageLimit();
+    private static final int IN_MEMORY_STORAGE_LIMIT = SystemProperties.getDefault().detailsInMemoryStorageLimit();
 
+    private SystemProperties config = SystemProperties.getDefault();
     @Test
     public void test_1(){
 
@@ -39,7 +40,7 @@ public class ContractDetailsTest {
 
         byte[] data = contractDetails.getEncoded();
 
-        ContractDetailsImpl contractDetails_ = new ContractDetailsImpl(data);
+        ContractDetailsImpl contractDetails_ = new ContractDetailsImpl(config, data);
 
         assertEquals(Hex.toHexString(code),
             Hex.toHexString(contractDetails_.getCode()));
@@ -120,7 +121,7 @@ public class ContractDetailsTest {
 
         byte[] data = contractDetails.getEncoded();
 
-        ContractDetailsImpl contractDetails_ = new ContractDetailsImpl(data);
+        ContractDetailsImpl contractDetails_ = new ContractDetailsImpl(config, data);
 
         assertEquals(Hex.toHexString(code),
                 Hex.toHexString(contractDetails_.getCode()));
@@ -196,7 +197,7 @@ public class ContractDetailsTest {
 
         ContractDetailsImpl deserialized = new ContractDetailsImpl();
         deserialized.setExternalStorageDataSource(externalStorage);
-        deserialized.decode(rlp);
+        deserialized.decode(config, rlp);
 
         assertEquals(toHexString(address), toHexString(deserialized.getAddress()));
         assertEquals(toHexString(code), toHexString(deserialized.getCode()));
@@ -260,10 +261,10 @@ public class ContractDetailsTest {
         }
     }
 
-    private static ContractDetails deserialize(byte[] rlp, KeyValueDataSource externalStorage) {
+    private ContractDetails deserialize(byte[] rlp, KeyValueDataSource externalStorage) {
         ContractDetailsImpl result = new ContractDetailsImpl();
         result.setExternalStorageDataSource(externalStorage);
-        result.decode(rlp);
+        result.decode(config, rlp);
         
         return result;
     }

--- a/ethereumj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
@@ -5,10 +5,13 @@ import org.ethereum.datasource.DataSourcePool;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.vm.DataWord;
+import org.junit.Before;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 import static org.ethereum.TestUtils.*;
@@ -17,11 +20,18 @@ import static org.junit.Assert.*;
 
 public class DetailsDataStoreTest {
 
+    SystemProperties config;
+
+    @Before
+    public void setup() {
+        this.config = SystemProperties.getDefault();
+    }
+
     @Test
     public void test1(){
 
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore();
+        DetailsDataStore dds = new DetailsDataStore(config);
         dds.setDB(db);
 
         byte[] c_key = Hex.decode("1a2b");
@@ -54,7 +64,7 @@ public class DetailsDataStoreTest {
     public void test2(){
 
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore();
+        DetailsDataStore dds = new DetailsDataStore(config);
         dds.setDB(db);
 
         byte[] c_key = Hex.decode("1a2b");
@@ -91,7 +101,7 @@ public class DetailsDataStoreTest {
     public void test3(){
 
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore();
+        DetailsDataStore dds = new DetailsDataStore(config);
         dds.setDB(db);
 
         byte[] c_key = Hex.decode("1a2b");
@@ -130,7 +140,7 @@ public class DetailsDataStoreTest {
     public void test4() {
 
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore();
+        DetailsDataStore dds = new DetailsDataStore(config);
         dds.setDB(db);
 
         byte[] c_key = Hex.decode("1a2b");
@@ -142,12 +152,12 @@ public class DetailsDataStoreTest {
     @Test
     public void testExternalStorage() throws InterruptedException {
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore();
+        DetailsDataStore dds = new DetailsDataStore(config);
         dds.setDB(db);
 
         byte[] addrWithExternalStorage = randomAddress();
         byte[] addrWithInternalStorage = randomAddress();
-        final int inMemoryStorageLimit = SystemProperties.CONFIG.detailsInMemoryStorageLimit();
+        final int inMemoryStorageLimit = config.detailsInMemoryStorageLimit();
 
         HashMapDB externalStorage =
             (HashMapDB)
@@ -179,7 +189,7 @@ public class DetailsDataStoreTest {
         byte[] withExternalStorageRlp = detailsWithExternalStorage.getEncoded();
         ContractDetailsImpl decoded = new ContractDetailsImpl();
         decoded.setExternalStorageDataSource(externalStorage);
-        decoded.decode(withExternalStorageRlp);
+        decoded.decode(config, withExternalStorageRlp);
 
         assertEquals(inMemoryStorageLimit / 64 + 10, decoded.getStorage().size());
         assertTrue(withExternalStorageRlp.length < detailsWithInternalStorage.getEncoded().length);

--- a/ethereumj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
@@ -5,6 +5,7 @@ import org.ethereum.datasource.DataSourcePool;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.vm.DataWord;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
@@ -25,6 +26,17 @@ public class DetailsDataStoreTest {
     @Before
     public void setup() {
         this.config = SystemProperties.getDefault();
+        DataSourcePool.setDataSourceMaker(new DataSourcePool.DataSourceMaker() {
+            @Override
+            public KeyValueDataSource makeDataSource() {
+                return new HashMapDB();
+            }
+        });
+    }
+
+    @After
+    public void cleanup() {
+        DataSourcePool.setDefaultDataSourceMaker();
     }
 
     @Test
@@ -161,7 +173,7 @@ public class DetailsDataStoreTest {
 
         HashMapDB externalStorage =
             (HashMapDB)
-                    DataSourcePool.hashMapDBByName("details-storage/" + toHexString(addrWithExternalStorage));
+                    DataSourcePool.getDataSourceFromPool("details-storage/" + toHexString(addrWithExternalStorage));
 
         HashMapDB internalStorage = new HashMapDB();
 

--- a/ethereumj-core/src/test/java/org/ethereum/db/HashStoreTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/HashStoreTest.java
@@ -42,12 +42,13 @@ public class HashStoreTest {
 
         BigInteger bi = new BigInteger(32, new Random());
         testDb = "test_db_" + bi;
-        SystemProperties.CONFIG.setDataBaseDir(testDb);
-        SystemProperties.CONFIG.setDatabaseReset(false);
-//        SystemProperties.CONFIG.overrideParams(SystemProperties.PROPERTY_DB_DIR, testDb);
+        SystemProperties config = SystemProperties.getDefault();
 
-        MapDBFactory mapDBFactory = new MapDBFactoryImpl();
-        hashStore = new HashStoreImpl();
+        config.setDataBaseDir(testDb);
+        config.setDatabaseReset(false);
+
+        MapDBFactory mapDBFactory = new MapDBFactoryImpl(config);
+        hashStore = new HashStoreImpl(config);
         ((HashStoreImpl)hashStore).setMapDBFactory(mapDBFactory);
         hashStore.open();
     }

--- a/ethereumj-core/src/test/java/org/ethereum/db/HeaderStoreTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/HeaderStoreTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockHeaderWrapper;
 import org.ethereum.datasource.mapdb.MapDBFactoryImpl;
@@ -19,7 +20,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 /**
  * Created by Anton Nashatyrev on 25.12.2015.
@@ -44,11 +45,12 @@ public class HeaderStoreTest {
     public void setup() throws InstantiationException, IllegalAccessException, URISyntaxException, IOException {
         BigInteger bi = new BigInteger(32, new Random());
         testDb = "test_db_" + bi;
-        CONFIG.setDataBaseDir(testDb);
-        CONFIG.setDatabaseReset(false);
+        SystemProperties config = SystemProperties.getDefault();
+        config.setDataBaseDir(testDb);
+        config.setDatabaseReset(false);
 
-        hs = new HeaderStoreImpl();
-        hs.setMapDBFactory(new MapDBFactoryImpl());
+        hs = new HeaderStoreImpl(config);
+        hs.setMapDBFactory(new MapDBFactoryImpl(config));
         hs.open();
     }
 

--- a/ethereumj-core/src/test/java/org/ethereum/db/RepositoryTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/RepositoryTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Genesis;
 import org.ethereum.crypto.HashUtil;
 
@@ -31,10 +32,12 @@ import static org.junit.Assert.*;
 public class RepositoryTest {
 
 
+    SystemProperties config = SystemProperties.getDefault();
+
     @Test
     public void test1() {
 
-        RepositoryImpl repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        RepositoryImpl repository = getRepository();
 
         byte[] cow   = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -54,11 +57,15 @@ public class RepositoryTest {
         repository.close();
     }
 
+    private RepositoryImpl getRepository() {
+        return new RepositoryImpl(config, new HashMapDB(), new HashMapDB());
+    }
+
 
     @Test
     public void test2() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -76,7 +83,7 @@ public class RepositoryTest {
     @Test
     public void test3() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -96,7 +103,7 @@ public class RepositoryTest {
     @Test
     public void test4() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -122,7 +129,7 @@ public class RepositoryTest {
     @Test
     public void test5() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         Repository track = repository.startTracking();
 
@@ -153,7 +160,7 @@ public class RepositoryTest {
     @Test
     public void test6() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -186,7 +193,7 @@ public class RepositoryTest {
     @Test
     public void test7() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -210,7 +217,7 @@ public class RepositoryTest {
     @Test
     public void test8() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -233,7 +240,7 @@ public class RepositoryTest {
     @Test
     public void test7_1() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track1 = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -267,7 +274,7 @@ public class RepositoryTest {
     @Test
     public void test7_2() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track1 = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -302,7 +309,7 @@ public class RepositoryTest {
     @Test
     public void test9() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -331,7 +338,7 @@ public class RepositoryTest {
     @Test
     public void test10() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -361,7 +368,7 @@ public class RepositoryTest {
     @Test
     public void test11() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -388,7 +395,7 @@ public class RepositoryTest {
     @Test
     public void test12() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -414,10 +421,10 @@ public class RepositoryTest {
     @Test  // Let's upload genesis pre-mine just like in the real world
     public void test13() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
-        Genesis genesis = (Genesis)Genesis.getInstance();
+        Genesis genesis = (Genesis)config.getGenesis();
         for (ByteArrayWrapper key : genesis.getPremine().keySet()) {
             repository.createAccount(key.getData());
             repository.addBalance(key.getData(), genesis.getPremine().get(key).getBalance());
@@ -425,7 +432,7 @@ public class RepositoryTest {
 
         track.commit();
 
-        assertArrayEquals(Genesis.getInstance().getStateRoot(), repository.getRoot());
+        assertArrayEquals(config.getGenesis().getStateRoot(), repository.getRoot());
 
         repository.close();
     }
@@ -434,7 +441,7 @@ public class RepositoryTest {
     @Test
     public void test14() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -471,7 +478,7 @@ public class RepositoryTest {
     @Test
     public void test15() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -506,7 +513,7 @@ public class RepositoryTest {
     @Test
     public void test16() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -566,7 +573,7 @@ public class RepositoryTest {
     @Test
     public void test16_2() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -621,7 +628,7 @@ public class RepositoryTest {
     @Test
     public void test16_3() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -676,7 +683,7 @@ public class RepositoryTest {
     @Test
     public void test16_4() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -721,7 +728,7 @@ public class RepositoryTest {
     @Test
     public void test16_5() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -765,7 +772,7 @@ public class RepositoryTest {
     @Test
     public void test17() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
 
@@ -792,7 +799,7 @@ public class RepositoryTest {
     @Test
     public void test18() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository repoTrack2 = repository.startTracking(); //track
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -817,7 +824,7 @@ public class RepositoryTest {
     @Test
     public void test19() {
 
-        Repository repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        Repository repository = getRepository();
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -863,7 +870,7 @@ public class RepositoryTest {
     @Test // testing for snapshot
     public void test20() {
 
-        RepositoryImpl repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        RepositoryImpl repository = getRepository();
         byte[] root = repository.getRoot();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -923,7 +930,7 @@ public class RepositoryTest {
     @Test // testing for snapshot
     @Ignore
     public void testMultiThread() throws InterruptedException {
-        final RepositoryImpl repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
+        final RepositoryImpl repository = getRepository();
 
         final byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
 

--- a/ethereumj-core/src/test/java/org/ethereum/db/TrackDatabaseTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/TrackDatabaseTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.db;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.LevelDbDataSource;
 
@@ -25,7 +26,7 @@ public class TrackDatabaseTest {
     @Test
     public void test1() {
 
-        KeyValueDataSource keyValueDataSource = new LevelDbDataSource("temp");
+        KeyValueDataSource keyValueDataSource = new LevelDbDataSource(SystemProperties.getDefault(), "temp");
         keyValueDataSource.init();
 
         DatabaseImpl db1 = new DatabaseImpl(keyValueDataSource);

--- a/ethereumj-core/src/test/java/org/ethereum/db/TransactionStoreTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/TransactionStoreTest.java
@@ -23,9 +23,12 @@ import java.math.BigInteger;
  */
 public class TransactionStoreTest {
 
+    private static SystemProperties config;
+
     @BeforeClass
     public static void setup() {
-        SystemProperties.CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+        config = SystemProperties.getDefault();
+        config.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
             @Override
             public BigInteger getMINIMUM_DIFFICULTY() {
                 return BigInteger.ONE;
@@ -35,7 +38,7 @@ public class TransactionStoreTest {
 
     @AfterClass
     public static void cleanup() {
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
+        config.setBlockchainConfig(MainNetConfig.INSTANCE);
     }
 
     @Test
@@ -46,7 +49,7 @@ public class TransactionStoreTest {
                 "}";
         HashMapDB txDb = new HashMapDB();
 
-        StandaloneBlockchain bc = new StandaloneBlockchain();
+        StandaloneBlockchain bc = new StandaloneBlockchain(config);
         bc.getBlockchain().withTransactionStore(new TransactionStore(new CachingDataSource(txDb)));
         SolidityContract contract = bc.submitNewContract(contractSrc);
         bc.createBlock();

--- a/ethereumj-core/src/test/java/org/ethereum/jsonrpc/JsonRpcTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsonrpc/JsonRpcTest.java
@@ -58,9 +58,9 @@ public class JsonRpcTest {
          */
         @Bean
         public SystemProperties systemProperties() {
-            SystemProperties props = new SystemProperties();
+            SystemProperties props = SystemProperties.getDefault();
             props.overrideParams(ConfigFactory.parseString(config.replaceAll("'", "\"")));
-            SystemProperties.CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+            props.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
                 @Override
                 public BigInteger getMINIMUM_DIFFICULTY() {
                     return BigInteger.ONE;

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
@@ -27,15 +27,8 @@ public class GitHubBasicTest {
     private static final Logger logger = LoggerFactory.getLogger("TCK-Test");
     public String shacommit = "99afe8f5aad7bca5d0f1b1685390a4dea32d73c3";
 
-    @After
-    public void recover() {
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-    }
-
     @Test
     public void runDifficultyTest() throws IOException, ParseException {
-
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
 
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficulty.json", shacommit);
 
@@ -48,14 +41,12 @@ public class GitHubBasicTest {
             BlockHeader current = testCase.getCurrent();
             BlockHeader parent = testCase.getParent();
 
-            assertEquals(testCase.getExpectedDifficulty(), current.calcDifficulty(parent));
+            assertEquals(testCase.getExpectedDifficulty(), current.calcDifficulty(MainNetConfig.INSTANCE, parent));
         }
     }
 
     @Test
     public void runDifficultyFrontierTest() throws IOException, ParseException {
-
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
 
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficultyFrontier.json", shacommit);
 
@@ -68,15 +59,12 @@ public class GitHubBasicTest {
             BlockHeader current = testCase.getCurrent();
             BlockHeader parent = testCase.getParent();
 
-            assertEquals(testCase.getExpectedDifficulty(), current.calcDifficulty(parent));
+            assertEquals(testCase.getExpectedDifficulty(), current.calcDifficulty(MainNetConfig.INSTANCE, parent));
         }
     }
 
     @Test
     public void runDifficultyHomesteadTest() throws IOException, ParseException {
-
-        SystemProperties.CONFIG.setBlockchainConfig(new HomesteadConfig());
-
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficultyHomestead.json", shacommit);
 
         DifficultyTestSuite testSuite = new DifficultyTestSuite(json);
@@ -88,7 +76,7 @@ public class GitHubBasicTest {
             BlockHeader current = testCase.getCurrent();
             BlockHeader parent = testCase.getParent();
 
-            assertEquals(testCase.getExpectedDifficulty(), current.calcDifficulty(parent));
+            assertEquals(testCase.getExpectedDifficulty(), current.calcDifficulty(new HomesteadConfig(), parent));
         }
     }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBlockTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBlockTest.java
@@ -12,7 +12,7 @@ import org.junit.runners.MethodSorters;
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.ethereum.config.SystemProperties.CONFIG;
+
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class GitHubBlockTest {
@@ -23,26 +23,24 @@ public class GitHubBlockTest {
     @Ignore // test for conveniently running a single test
     @Test
     public void runSingleTest() throws ParseException, IOException {
-        CONFIG.setGenesisInfo("frontier.json");
-        SystemProperties.CONFIG.setBlockchainConfig(new HomesteadConfig());
+        SystemProperties config = SystemProperties.getDefault();
+        config.setGenesisInfo("frontier.json");
+        config.setBlockchainConfig(new HomesteadConfig());
 
         String json = JSONReader.loadJSONFromCommit("BlockchainTests/Homestead/bcTotalDifficultyTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonSingleBlockTest(json, "sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4");
+        new GitHubJSONTestSuite(config).runGitHubJsonSingleBlockTest(json, "sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4");
     }
 
     private void runFrontier(String name) throws IOException, ParseException {
         String json = JSONReader.loadJSONFromCommit("BlockchainTests/" + name + ".json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonBlockTest(json, Collections.EMPTY_SET);
+        new GitHubJSONTestSuite(SystemProperties.getDefault()).runGitHubJsonBlockTest(json, Collections.EMPTY_SET);
     }
 
     private void runHomestead(String name) throws IOException, ParseException {
         String json = JSONReader.loadJSONFromCommit("BlockchainTests/Homestead/" + name + ".json", shacommit);
-        SystemProperties.CONFIG.setBlockchainConfig(new HomesteadConfig());
-        try {
-            GitHubJSONTestSuite.runGitHubJsonBlockTest(json, Collections.EMPTY_SET);
-        } finally {
-            SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-        }
+        SystemProperties config = SystemProperties.getDefault();
+        config.setBlockchainConfig(new HomesteadConfig());
+        new GitHubJSONTestSuite(config).runGitHubJsonBlockTest(json, Collections.EMPTY_SET);
     }
 
     private void run(String name, boolean frontier, boolean homestead) throws IOException, ParseException {
@@ -79,7 +77,7 @@ public class GitHubBlockTest {
 
     @Test
     public void runBCValidBlockTest() throws ParseException, IOException {
-        CONFIG.setGenesisInfo("frontier.json");
+//        CONFIG.setGenesisInfo("frontier.json");
         run("bcValidBlockTest", true, true);
     }
 

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubJSONTestSuite.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubJSONTestSuite.java
@@ -1,5 +1,6 @@
 package org.ethereum.jsontestsuite;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.jsontestsuite.runners.StateTestRunner;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -26,8 +27,13 @@ public class GitHubJSONTestSuite {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
 
+    private SystemProperties config;
 
-    protected static void runGitHubJsonVMTest(String json, String testName) throws ParseException {
+    public GitHubJSONTestSuite(SystemProperties config) {
+        this.config = config;
+    }
+
+    protected void runGitHubJsonVMTest(String json, String testName) throws ParseException {
         Assume.assumeFalse("Online test is not available", json.equals(""));
 
         JSONParser parser = new JSONParser();
@@ -48,7 +54,7 @@ public class GitHubJSONTestSuite {
 
             TestCase testCase = testIterator.next();
             if (testName.equals((testCase.getName()))) {
-                TestRunner runner = new TestRunner();
+                TestRunner runner = new TestRunner(config);
                 List<String> result = runner.runTestCase(testCase);
                 Assert.assertTrue(result.isEmpty());
                 return;
@@ -56,13 +62,13 @@ public class GitHubJSONTestSuite {
         }
     }
 
-    protected static void runGitHubJsonVMTest(String json) throws ParseException {
+    protected void runGitHubJsonVMTest(String json) throws ParseException {
         Set<String> excluded = new HashSet<>();
         runGitHubJsonVMTest(json, excluded);
     }
 
 
-    protected static void runGitHubJsonVMTest(String json, Set<String> excluded) throws ParseException {
+    protected void runGitHubJsonVMTest(String json, Set<String> excluded) throws ParseException {
         Assume.assumeFalse("Online test is not available", json.equals(""));
 
         JSONParser parser = new JSONParser();
@@ -86,14 +92,14 @@ public class GitHubJSONTestSuite {
             if (excluded.contains(testCase.getName()))
                 continue;
 
-            TestRunner runner = new TestRunner();
+            TestRunner runner = new TestRunner(config);
             List<String> result = runner.runTestCase(testCase);
             Assert.assertTrue(result.isEmpty());
         }
     }
 
 
-    protected static void runGitHubJsonSingleBlockTest(String json, String testName) throws ParseException, IOException {
+    protected void runGitHubJsonSingleBlockTest(String json, String testName) throws ParseException, IOException {
 
         BlockTestSuite testSuite = new BlockTestSuite(json);
         Set<String> testCollection = testSuite.getTestCases().keySet();
@@ -109,7 +115,7 @@ public class GitHubJSONTestSuite {
     }
 
 
-    protected static void runGitHubJsonBlockTest(String json, Set<String> excluded) throws ParseException, IOException {
+    protected void runGitHubJsonBlockTest(String json, Set<String> excluded) throws ParseException, IOException {
         Assume.assumeFalse("Online test is not available", json.equals(""));
 
         BlockTestSuite testSuite = new BlockTestSuite(json);
@@ -160,15 +166,15 @@ public class GitHubJSONTestSuite {
 
     }
 
-    protected static void runGitHubJsonBlockTest(String json) throws ParseException, IOException {
+    protected void runGitHubJsonBlockTest(String json) throws ParseException, IOException {
         Set<String> excluded = new HashSet<>();
         runGitHubJsonBlockTest(json, excluded);
     }
 
-    private static List<String> runSingleBlockTest(BlockTestSuite testSuite, String testName){
+    private List<String> runSingleBlockTest(BlockTestSuite testSuite, String testName){
 
         BlockTestCase blockTestCase =  testSuite.getTestCases().get(testName);
-        TestRunner runner = new TestRunner();
+        TestRunner runner = new TestRunner(config);
 
         logger.info("\n\n ***************** Running test: {} ***************************** \n\n", testName);
         List<String> result = runner.runTestCase(blockTestCase);
@@ -183,12 +189,12 @@ public class GitHubJSONTestSuite {
     }
 
 
-    public static void runStateTest(String jsonSuite) throws IOException {
+    public void runStateTest(String jsonSuite) throws IOException {
         runStateTest(jsonSuite, new HashSet<String>());
     }
 
 
-    public static void runStateTest(String jsonSuite, String testName) throws IOException {
+    public void runStateTest(String jsonSuite, String testName) throws IOException {
 
         StateTestSuite stateTestSuite = new StateTestSuite(jsonSuite);
         Map<String, StateTestCase> testCases = stateTestSuite.getTestCases();
@@ -208,7 +214,7 @@ public class GitHubJSONTestSuite {
             logger.info(line);
             logger.info(output);
             logger.info(line);
-            List<String> fails = StateTestRunner.run(testCases.get(testName));
+            List<String> fails = StateTestRunner.run(config, testCases.get(testName));
 
             Assert.assertTrue(fails.isEmpty());
 
@@ -217,7 +223,7 @@ public class GitHubJSONTestSuite {
         }
     }
 
-    public static void runStateTest(String jsonSuite, Set<String> excluded) throws IOException {
+    public void runStateTest(String jsonSuite, Set<String> excluded) throws IOException {
 
         StateTestSuite stateTestSuite = new StateTestSuite(jsonSuite);
         Map<String, StateTestCase> testCases = stateTestSuite.getTestCases();
@@ -242,7 +248,7 @@ public class GitHubJSONTestSuite {
             logger.info(output);
             logger.info(line);
 
-            List<String> result = StateTestRunner.run(testCases.get(testName));
+            List<String> result = StateTestRunner.run(config, testCases.get(testName));
             if (!result.isEmpty())
                 summary.put(testName, false);
             else

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
@@ -24,28 +24,27 @@ public class GitHubStateTest {
     public String shacommit = "f28ac81493281feec0b17290565cf74042893677";
 
 
+    private static SystemProperties config = SystemProperties.getDefault();
     private long oldForkValue;
+    private GitHubJSONTestSuite gitHubJSONTestSuite;
 
     @Before
     public void setup() {
         // TODO remove this after Homestead launch and shacommit update with actual block number
         // for this JSON test commit the Homestead block was defined as 900000
-        SystemProperties.CONFIG.setBlockchainConfig(new AbstractNetConfig() {{
+        config.setBlockchainConfig(new AbstractNetConfig() {{
             add(0, new FrontierConfig());
             add(1_150_000, new HomesteadConfig());
         }});
+        this.gitHubJSONTestSuite = new GitHubJSONTestSuite(config);
     }
 
-    @After
-    public void clean() {
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-    }
 
     @Ignore
     @Test // this method is mostly for hands-on convenient testing
     public void stSingleTest() throws ParseException, IOException {
         String json = JSONReader.loadJSONFromCommit("StateTests/stSystemOperationsTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, "suicideSendEtherPostDeath");
+        gitHubJSONTestSuite.runStateTest(json, "suicideSendEtherPostDeath");
     }
 
     @Test
@@ -53,7 +52,7 @@ public class GitHubStateTest {
 
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/stExample.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -61,10 +60,10 @@ public class GitHubStateTest {
 
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/stCallCodes.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
 
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stCallCodes.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -72,7 +71,7 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stCallDelegateCodes.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -80,7 +79,7 @@ public class GitHubStateTest {
 
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stCallDelegateCodesCallCode.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -88,7 +87,7 @@ public class GitHubStateTest {
 
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stHomeSteadSpecific.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -96,10 +95,10 @@ public class GitHubStateTest {
 
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/stCallCreateCallCodeTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
 
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stCallCreateCallCodeTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -107,25 +106,25 @@ public class GitHubStateTest {
 
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/stDelegatecallTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
     public void stInitCodeTest() throws ParseException, IOException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/stInitCodeTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stInitCodeTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
     public void stLogTests() throws ParseException, IOException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/stLogTests.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stLogTests.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -133,9 +132,9 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/stPreCompiledContracts.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stPreCompiledContracts.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -145,9 +144,9 @@ public class GitHubStateTest {
         excluded.add("mload32bitBound_return"); // The test extends memory to 4Gb which can't be handled with Java arrays
         excluded.add("mload32bitBound_Msize"); // The test extends memory to 4Gb which can't be handled with Java arrays
         String json = JSONReader.loadJSONFromCommit("StateTests/stMemoryStressTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stMemoryStressTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -155,10 +154,10 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/stMemoryTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
 
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stMemoryTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -167,26 +166,26 @@ public class GitHubStateTest {
 
         // leaving only Homestead version since the test runs too long
 //        String json = JSONReader.loadJSONFromCommit("StateTests/stQuadraticComplexityTest.json", shacommit);
-//        GitHubJSONTestSuite.runStateTest(json, excluded);
+//        gitHubJSONTestSuite.runStateTest(json, excluded);
 
         String json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stQuadraticComplexityTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
     public void stSolidityTest() throws ParseException, IOException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/stSolidityTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
     public void stRecursiveCreate() throws ParseException, IOException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("StateTests/stRecursiveCreate.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stRecursiveCreate.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -194,9 +193,9 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/stRefundTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stRefundTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -204,15 +203,15 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/stSpecialTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stSpecialTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
     public void stBlockHashTest() throws ParseException, IOException {
         String json = JSONReader.loadJSONFromCommit("StateTests/stBlockHashTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json);
+        gitHubJSONTestSuite.runStateTest(json);
     }
 
     @Test
@@ -220,10 +219,10 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/stSystemOperationsTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
 
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stSystemOperationsTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -231,10 +230,10 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/stTransactionTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
 
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stTransactionTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -242,7 +241,7 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/stTransitionTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test
@@ -250,10 +249,10 @@ public class GitHubStateTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("StateTests/stWalletTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
 
         json = JSONReader.loadJSONFromCommit("StateTests/Homestead/stWalletTest.json", shacommit);
-        GitHubJSONTestSuite.runStateTest(json, excluded);
+        gitHubJSONTestSuite.runStateTest(json, excluded);
     }
 
     @Test // testing full suite
@@ -272,7 +271,7 @@ public class GitHubStateTest {
             if (includedFiles.contains(fileName)) {
               System.out.println("Running: " + fileName);
               String json = JSONReader.loadJSON("StateTests//RandomTests/" + fileName);
-              GitHubJSONTestSuite.runStateTest(json);
+              gitHubJSONTestSuite.runStateTest(json);
             }
         }
 

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubVMTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubVMTest.java
@@ -1,6 +1,8 @@
 package org.ethereum.jsontestsuite;
 
+import org.ethereum.config.SystemProperties;
 import org.json.simple.parser.ParseException;
+import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -19,11 +21,17 @@ public class GitHubVMTest {
 
     //SHACOMMIT of tested commit, ethereum/tests.git
     public String shacommit = "f28ac81493281feec0b17290565cf74042893677";
+    private GitHubJSONTestSuite gitHubJSONTestSuite;
+
+    @Before
+    public void setup() {
+        this.gitHubJSONTestSuite = new GitHubJSONTestSuite(SystemProperties.getDefault());
+    }
 
     @Test
     public void runSingle() throws ParseException {
         String json = JSONReader.loadJSONFromCommit("VMTests/vmEnvironmentalInfoTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, "balance0");
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, "balance0");
     }
 
     @Test
@@ -32,35 +40,35 @@ public class GitHubVMTest {
         // TODO: these are excluded due to bad wrapping behavior in ADDMOD/DataWord.add
         String json = JSONReader.loadJSONFromCommit("VMTests/vmArithmeticTest.json", shacommit);
         //String json = JSONReader.getTestBlobForTreeSha(shacommit, "vmArithmeticTest.json");
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testBitwiseLogicOperationFromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmBitwiseLogicOperationTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testBlockInfoFromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmBlockInfoTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testEnvironmentalInfoFromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmEnvironmentalInfoTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testIOandFlowOperationsFromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmIOandFlowOperationsTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Ignore  //FIXME - 60M - need new fast downloader
@@ -68,7 +76,7 @@ public class GitHubVMTest {
     public void testvmInputLimitsTest1FromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmInputLimits1.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Ignore //FIXME - 50M - need to handle large filesizes
@@ -76,7 +84,7 @@ public class GitHubVMTest {
     public void testvmInputLimitsTest2FromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmInputLimits2.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Ignore //FIXME - 20M - possibly provide percentage indicator
@@ -84,35 +92,35 @@ public class GitHubVMTest {
     public void testvmInputLimitsLightTestFromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmInputLimitsLight.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testVMLogGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmLogTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testPerformanceFromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmPerformanceTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testPushDupSwapFromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmPushDupSwapTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testShaFromGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmSha3Test.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Ignore // // FIXME: as soon as possible
@@ -121,14 +129,14 @@ public class GitHubVMTest {
         Set<String> excluded = new HashSet<>();
 
         String json = JSONReader.loadJSONFromCommit("VMTests/vmSystemOperationsTest.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
     public void testVMGitHub() throws ParseException {
         Set<String> excluded = new HashSet<>();
         String json = JSONReader.loadJSONFromCommit("VMTests/vmtests.json", shacommit);
-        GitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
+        gitHubJSONTestSuite.runGitHubJsonVMTest(json, excluded);
     }
 
     @Test // testing full suite
@@ -146,7 +154,7 @@ public class GitHubVMTest {
             if (excludedFiles.contains(fileName)) continue;
             System.out.println("Running: " + fileName);
             String json = JSONReader.loadJSON("VMTests//RandomTests/" + fileName);
-            GitHubJSONTestSuite.runGitHubJsonVMTest(json);
+            gitHubJSONTestSuite.runGitHubJsonVMTest(json);
         }
 
     }

--- a/ethereumj-core/src/test/java/org/ethereum/miner/EthashTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/miner/EthashTest.java
@@ -25,9 +25,11 @@ import static org.junit.Assert.assertArrayEquals;
  * Created by Anton Nashatyrev on 02.12.2015.
  */
 public class EthashTest {
+
+    private static SystemProperties config = SystemProperties.getDefault();
     @BeforeClass
     public static void setup() {
-        SystemProperties.CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+        config.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
             @Override
             public BigInteger getMINIMUM_DIFFICULTY() {
                 return BigInteger.ONE;
@@ -35,10 +37,6 @@ public class EthashTest {
         }));
     }
 
-    @AfterClass
-    public static void cleanup() {
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-    }
 
 
     @Test // check exact values

--- a/ethereumj-core/src/test/java/org/ethereum/miner/MineBlock.java
+++ b/ethereumj-core/src/test/java/org/ethereum/miner/MineBlock.java
@@ -24,9 +24,11 @@ import java.util.List;
  */
 public class MineBlock {
 
+    private static SystemProperties config = SystemProperties.getDefault();
+
     @BeforeClass
     public static void setup() {
-        SystemProperties.CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+        config.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
             @Override
             public BigInteger getMINIMUM_DIFFICULTY() {
                 return BigInteger.ONE;
@@ -34,15 +36,10 @@ public class MineBlock {
         }));
     }
 
-    @AfterClass
-    public static void cleanup() {
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-    }
-
 
     @Test
     public void mine1() throws Exception {
-        BlockchainImpl blockchain = ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(
+        BlockchainImpl blockchain = ImportLightTest.createBlockchain(config, GenesisLoader.loadGenesis(
                 getClass().getResourceAsStream("/genesis/genesis-light.json")));
         blockchain.setMinerCoinbase(Hex.decode("ee0250c19ad59305b2bdb61f34b45b72fe37154f"));
         Block parent = blockchain.getBestBlock();
@@ -59,9 +56,9 @@ public class MineBlock {
         Block b = blockchain.createNewBlock(parent, pendingTx, Collections.EMPTY_LIST);
 
         System.out.println("Mining...");
-        Ethash.getForBlock(b.getNumber()).mineLight(b).get();
+        Ethash.getForBlock(b.getNumber(), config).mineLight(b).get();
         System.out.println("Validating...");
-        boolean valid = Ethash.getForBlock(b.getNumber()).validate(b.getHeader());
+        boolean valid = Ethash.getForBlock(b.getNumber(), config).validate(b.getHeader());
         Assert.assertTrue(valid);
 
         System.out.println("Connecting...");

--- a/ethereumj-core/src/test/java/org/ethereum/miner/MinerTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/miner/MinerTest.java
@@ -47,7 +47,7 @@ public class MinerTest {
     public static class SysPropConfig1 {
         static Eth62 testHandler = null;
 
-        static SystemProperties props = new SystemProperties();;
+        static SystemProperties props = SystemProperties.getDefault();;
         @Bean
         public SystemProperties systemProperties() {
             return props;
@@ -59,7 +59,7 @@ public class MinerTest {
     public static class SysPropConfig2 {
         static Eth62 testHandler = null;
 
-        static SystemProperties props = new SystemProperties();;
+        static SystemProperties props = SystemProperties.getDefault();;
         @Bean
         public SystemProperties systemProperties() {
             return props;

--- a/ethereumj-core/src/test/java/org/ethereum/net/TwoPeerTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/TwoPeerTest.java
@@ -56,7 +56,7 @@ public class TwoPeerTest {
 //            return new Eth62();
         }
 
-        static SystemProperties props = new SystemProperties();;
+        static SystemProperties props = SystemProperties.getDefault();;
         @Bean
         public SystemProperties systemProperties() {
             return props;
@@ -65,7 +65,7 @@ public class TwoPeerTest {
     @Configuration
     @NoAutoscan
     public static class SysPropConfig2 {
-        static SystemProperties props= new SystemProperties();
+        static SystemProperties props= SystemProperties.getDefault();
         @Bean
         public SystemProperties systemProperties() {
             return props;

--- a/ethereumj-core/src/test/java/org/ethereum/net/rlpx/FramingTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/rlpx/FramingTest.java
@@ -65,12 +65,12 @@ public class FramingTest {
 
     @Test
     public void testTest() throws FileNotFoundException, InterruptedException {
-        SysPropConfig1.props = new SystemProperties();
+        SysPropConfig1.props = SystemProperties.getDefault();
         SysPropConfig1.props.overrideParams(
                 "peer.listen.port", "30334",
                 "peer.privateKey", "ba43d10d069f0c41a8914849c1abeeac2a681b21ae9b60a6a2362c06e6eb1bc8",
                 "database.dir", "testDB-1");
-        SysPropConfig2.props = new SystemProperties();
+        SysPropConfig2.props = SystemProperties.getDefault();
         SysPropConfig2.props.overrideParams(
                 "peer.listen.port", "30335",
                 "peer.privateKey", "d3a4a240b107ab443d46187306d0b947ce3d6b6ed95aead8c4941afcebde43d2",

--- a/ethereumj-core/src/test/java/org/ethereum/net/swarm/BzzProtocolTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/swarm/BzzProtocolTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.net.swarm;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.net.rlpx.Node;
 import org.ethereum.net.swarm.bzz.BzzMessage;
 import org.ethereum.net.swarm.bzz.BzzProtocol;
@@ -25,6 +26,9 @@ import static org.ethereum.crypto.HashUtil.sha3;
 public class BzzProtocolTest {
 
     interface Predicate<T> { boolean test(T t);}
+
+    SystemProperties config = SystemProperties.getDefault();
+
 
     public static class FilterPrinter extends PrintWriter {
         String filter;
@@ -183,7 +187,7 @@ public class BzzProtocolTest {
 //        NodeTable nodeTable;
 
         public SimpleHive(PeerAddress thisAddress) {
-            super(thisAddress);
+            super(new NetStore(SystemProperties.getDefault()), thisAddress);
 //            this.thisAddress = thisAddress;
 //            nodeTable = new NodeTable(thisAddress.toNode());
         }
@@ -280,7 +284,7 @@ public class BzzProtocolTest {
             this.peerAddress = peerAddress;
             localStore = new LocalStore(new MemStore(), new MemStore());
             hive = new SimpleHive(peerAddress).setThisPeer(this);
-            netStore = new NetStore(localStore, hive);
+            netStore = new NetStore(SystemProperties.getDefault(), localStore, hive);
 
             netStore.start(peerAddress);
 
@@ -565,8 +569,8 @@ public class BzzProtocolTest {
         LocalStore localStore2 = new LocalStore(new MemStore(), new MemStore());
         Hive hive1 = new SimpleHive(peerAddress1);
         Hive hive2 = new SimpleHive(peerAddress2);
-        NetStore netStore1 = new NetStore(localStore1, hive1);
-        NetStore netStore2 = new NetStore(localStore2, hive2);
+        NetStore netStore1 = new NetStore(config, localStore1, hive1);
+        NetStore netStore2 = new NetStore(config, localStore2, hive2);
 
 
         netStore1.start(peerAddress1);

--- a/ethereumj-core/src/test/java/org/ethereum/net/swarm/GoPeerTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/swarm/GoPeerTest.java
@@ -1,6 +1,7 @@
 package org.ethereum.net.swarm;
 
 import org.ethereum.Start;
+import org.ethereum.config.SystemProperties;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -25,6 +26,6 @@ public class GoPeerTest {
 //            stdout.setFilter(Hex.toHexString(key.getBytes()));
         Chunk chunk = new Chunk(key, new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 77, 88});
 
-        NetStore.getInstance().put(chunk);
+        new NetStore(SystemProperties.getDefault()).put(chunk);
     }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/sync/LongSyncTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/sync/LongSyncTest.java
@@ -56,15 +56,21 @@ public class LongSyncTest {
     private String testDbA;
     private String testDbB;
 
-    @BeforeClass
-    public static void setup() throws IOException, URISyntaxException {
-
-        SystemProperties.CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+    private static SystemProperties getConfig() {
+        SystemProperties config = SystemProperties.getDefault();
+        config.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
             @Override
             public BigInteger getMINIMUM_DIFFICULTY() {
                 return BigInteger.ONE;
             }
         }));
+
+        return config;
+    }
+
+    @BeforeClass
+    public static void setup() throws IOException, URISyntaxException {
+
 
         nodeA = new Node("enode://3973cb86d7bef9c96e5d589601d788370f9e24670dcba0480c0b3b1b0647d13d0f0fffed115dd2d4b5ca1929287839dcd4e77bdc724302b44ae48622a8766ee6@localhost:30334");
 
@@ -113,11 +119,6 @@ public class LongSyncTest {
         }
 
         return blocks;
-    }
-
-    @AfterClass
-    public static void cleanup() {
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
     }
 
     @Before
@@ -544,7 +545,7 @@ public class LongSyncTest {
     @Configuration
     @NoAutoscan
     public static class SysPropConfigA {
-        static SystemProperties props = new SystemProperties();
+        static SystemProperties props = getConfig();
         static Eth62 eth62 = null;
 
         @Bean
@@ -563,7 +564,7 @@ public class LongSyncTest {
     @Configuration
     @NoAutoscan
     public static class SysPropConfigB {
-        static SystemProperties props = new SystemProperties();
+        static SystemProperties props = getConfig();
 
         @Bean
         public SystemProperties systemProperties() {

--- a/ethereumj-core/src/test/java/org/ethereum/sync/ShortSyncTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/sync/ShortSyncTest.java
@@ -62,17 +62,20 @@ public class ShortSyncTest {
     private EthHandler ethA;
     private String testDbA;
     private String testDbB;
-
-    @BeforeClass
-    public static void setup() throws IOException, URISyntaxException {
-
-        SystemProperties.CONFIG.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+    private static SystemProperties getConfig() {
+        SystemProperties config = SystemProperties.getDefault();
+        config.setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
             @Override
             public BigInteger getMINIMUM_DIFFICULTY() {
                 return BigInteger.ONE;
             }
         }));
 
+        return config;
+    }
+
+    @BeforeClass
+    public static void setup() throws IOException, URISyntaxException {
         nodeA = new Node("enode://3973cb86d7bef9c96e5d589601d788370f9e24670dcba0480c0b3b1b0647d13d0f0fffed115dd2d4b5ca1929287839dcd4e77bdc724302b44ae48622a8766ee6@localhost:30334");
 
         SysPropConfigA.props.overrideParams(
@@ -108,11 +111,6 @@ public class ShortSyncTest {
         }
 
         return blocks;
-    }
-
-    @AfterClass
-    public static void cleanup() {
-        SystemProperties.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
     }
 
     @Before
@@ -1044,7 +1042,7 @@ public class ShortSyncTest {
     @Configuration
     @NoAutoscan
     public static class SysPropConfigA {
-        static SystemProperties props = new SystemProperties();
+        static SystemProperties props = getConfig();
         static Eth62 eth62 = null;
 
         @Bean
@@ -1063,7 +1061,7 @@ public class ShortSyncTest {
     @Configuration
     @NoAutoscan
     public static class SysPropConfigB {
-        static SystemProperties props = new SystemProperties();
+        static SystemProperties props = getConfig();
 
         @Bean
         public SystemProperties systemProperties() {

--- a/ethereumj-core/src/test/java/org/ethereum/trie/TrieTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/trie/TrieTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.trie;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.AccountState;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.LevelDbDataSource;
@@ -869,7 +870,7 @@ public class TrieTest {
         JSONParser parser = new JSONParser();
         JSONArray dbDumpJSONArray = (JSONArray) parser.parse(testSrc);
 
-        KeyValueDataSource keyValueDataSource = new LevelDbDataSource("testState");
+        KeyValueDataSource keyValueDataSource = new LevelDbDataSource(SystemProperties.getDefault(), "testState");
         keyValueDataSource.init();
 
         DatabaseImpl db = new DatabaseImpl(keyValueDataSource);

--- a/ethereumj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.util.ByteUtil;
 
 import org.ethereum.vm.program.Program;
@@ -20,7 +21,7 @@ public class ProgramMemoryTest {
 
     @Before
     public void createProgram() {
-        program = new Program(ByteUtil.EMPTY_BYTE_ARRAY, pi);
+        program = new Program(SystemProperties.getDefault(), ByteUtil.EMPTY_BYTE_ARRAY, pi);
     }
 
     @Test

--- a/ethereumj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.AccountState;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.core.Repository;
@@ -27,7 +28,8 @@ import static org.junit.Assert.assertEquals;
 public class VMComplexTest {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
-
+    private SystemProperties config = SystemProperties.getDefault();
+    
     @Ignore //TODO #POC9
     @Test // contract call recursive
     public void test1() {
@@ -62,7 +64,7 @@ public class VMComplexTest {
         byte[] codeB = Hex.decode(code);
 
         byte[] codeKey = HashUtil.sha3(codeB);
-        AccountState accountState = new AccountState();
+        AccountState accountState = new AccountState(BigInteger.ZERO, BigInteger.ZERO);
         accountState.setCodeHash(codeKey);
 
         ProgramInvokeMockImpl pi = new ProgramInvokeMockImpl();
@@ -77,8 +79,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM();
-        Program program = new Program(codeB, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -99,6 +101,10 @@ public class VMComplexTest {
 
         repository.close();
         assertEquals(expectedGas, program.getResult().getGasUsed());
+    }
+
+    private VM newVM() {
+        return new VM(config);
     }
 
     @Ignore //TODO #POC9
@@ -161,8 +167,8 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM();
-        Program program = new Program(codeB, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -249,8 +255,8 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM();
-        Program program = new Program(codeB, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -327,8 +333,8 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM();
-        Program program = new Program(codeA, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeA, pi);
 
         try {
             while (!program.isStopped())
@@ -399,8 +405,8 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM();
-        Program program = new Program(codeB, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -448,7 +454,7 @@ public class VMComplexTest {
         byte[] codeB = Hex.decode(code);
 
         byte[] codeKey = HashUtil.sha3(codeB);
-        AccountState accountState = new AccountState();
+        AccountState accountState = new AccountState(BigInteger.ZERO, BigInteger.ZERO);
         accountState.setCodeHash(codeKey);
 
         ProgramInvokeMockImpl pi = new ProgramInvokeMockImpl();
@@ -463,8 +469,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM();
-        Program program = new Program(codeB, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -507,7 +513,7 @@ public class VMComplexTest {
         byte[] codeB = Hex.decode(code);
 
         byte[] codeKey = HashUtil.sha3(codeB);
-        AccountState accountState = new AccountState();
+        AccountState accountState = new AccountState(BigInteger.ZERO, BigInteger.ZERO);
         accountState.setCodeHash(codeKey);
 
         ProgramInvokeMockImpl pi = new ProgramInvokeMockImpl();
@@ -522,8 +528,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM();
-        Program program = new Program(codeB, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -566,7 +572,7 @@ public class VMComplexTest {
         byte[] codeB = Hex.decode(code);
 
         byte[] codeKey = HashUtil.sha3(codeB);
-        AccountState accountState = new AccountState();
+        AccountState accountState = new AccountState(BigInteger.ZERO, BigInteger.ZERO);
         accountState.setCodeHash(codeKey);
 
         ProgramInvokeMockImpl pi = new ProgramInvokeMockImpl();
@@ -581,8 +587,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM();
-        Program program = new Program(codeB, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -625,7 +631,7 @@ public class VMComplexTest {
         byte[] codeB = Hex.decode(code);
 
         byte[] codeKey = HashUtil.sha3(codeB);
-        AccountState accountState = new AccountState();
+        AccountState accountState = new AccountState(BigInteger.ZERO, BigInteger.ZERO);
         accountState.setCodeHash(codeKey);
 
         ProgramInvokeMockImpl pi = new ProgramInvokeMockImpl();
@@ -640,8 +646,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM();
-        Program program = new Program(codeB, pi);
+        VM vm = newVM();
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())

--- a/ethereumj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.Program.OutOfGasException;
 import org.ethereum.vm.program.Program.StackTooSmallException;
@@ -27,6 +28,7 @@ public class VMCustomTest {
 
     private ProgramInvokeMockImpl invoke;
     private Program program;
+    private SystemProperties config = SystemProperties.getDefault();
 
     @Before
     public void setup() {
@@ -49,8 +51,8 @@ public class VMCustomTest {
     @Test // CALLDATASIZE OP
     public void testCALLDATASIZE_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("36"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("36"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000040";
 
         vm.step(program);
@@ -63,9 +65,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("600035"), invoke);
+                new Program(config, Hex.decode("600035"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000A1";
 
         vm.step(program);
@@ -78,9 +80,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_2() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("600235"), invoke);
+                new Program(config, Hex.decode("600235"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000A10000";
 
         vm.step(program);
@@ -94,9 +96,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_3() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("602035"), invoke);
+                new Program(config, Hex.decode("602035"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000B1";
 
         vm.step(program);
@@ -110,9 +112,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_4() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("602335"), invoke);
+                new Program(config, Hex.decode("602335"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000B1000000";
 
         vm.step(program);
@@ -125,9 +127,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_5() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("603F35"), invoke);
+                new Program(config, Hex.decode("603F35"), invoke);
         String s_expected_1 = "B100000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -140,9 +142,9 @@ public class VMCustomTest {
     @Test(expected = RuntimeException.class) // CALLDATALOAD OP mal
     public void testCALLDATALOAD_6() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("35"), invoke);
+                new Program(config, Hex.decode("35"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -153,9 +155,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("60206000600037"), invoke);
+                new Program(config, Hex.decode("60206000600037"), invoke);
         String m_expected = "00000000000000000000000000000000000000000000000000000000000000A1";
 
         vm.step(program);
@@ -169,9 +171,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_2() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("60406000600037"), invoke);
+                new Program(config, Hex.decode("60406000600037"), invoke);
         String m_expected = "00000000000000000000000000000000000000000000000000000000000000A1" +
                 "00000000000000000000000000000000000000000000000000000000000000B1";
 
@@ -187,9 +189,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_3() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("60406004600037"), invoke);
+                new Program(config, Hex.decode("60406004600037"), invoke);
         String m_expected = "000000000000000000000000000000000000000000000000000000A100000000" +
                 "000000000000000000000000000000000000000000000000000000B100000000";
 
@@ -205,9 +207,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_4() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("60406000600437"), invoke);
+                new Program(config, Hex.decode("60406000600437"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "000000A100000000000000000000000000000000000000000000000000000000" +
                 "000000B100000000000000000000000000000000000000000000000000000000";
@@ -223,9 +225,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_5() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("60406000600437"), invoke);
+                new Program(config, Hex.decode("60406000600437"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "000000A100000000000000000000000000000000000000000000000000000000" +
                 "000000B100000000000000000000000000000000000000000000000000000000";
@@ -242,9 +244,9 @@ public class VMCustomTest {
     @Test(expected = StackTooSmallException.class) // CALLDATACOPY OP mal
     public void testCALLDATACOPY_6() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("6040600037"), invoke);
+                new Program(config, Hex.decode("6040600037"), invoke);
 
         try {
             vm.step(program);
@@ -258,9 +260,9 @@ public class VMCustomTest {
     @Test(expected = OutOfGasException.class) // CALLDATACOPY OP mal
     public void testCALLDATACOPY_7() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("6020600073CC0929EB16730E7C14FEFC63006AC2D794C5795637"), invoke);
+                new Program(config, Hex.decode("6020600073CC0929EB16730E7C14FEFC63006AC2D794C5795637"), invoke);
 
         try {
             vm.step(program);
@@ -275,8 +277,8 @@ public class VMCustomTest {
     @Test // ADDRESS OP
     public void testADDRESS_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("30"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("30"), invoke);
         String s_expected_1 = "00000000000000000000000077045E71A7A2C50903D88E564CD72FAB11E82051";
 
         vm.step(program);
@@ -289,9 +291,9 @@ public class VMCustomTest {
     @Test // BALANCE OP
     public void testBALANCE_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("3031"), invoke);
+                new Program(config, Hex.decode("3031"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000003E8";
 
         vm.step(program);
@@ -304,9 +306,9 @@ public class VMCustomTest {
     @Test // ORIGIN OP
     public void testORIGIN_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("32"), invoke);
+                new Program(config, Hex.decode("32"), invoke);
         String s_expected_1 = "00000000000000000000000013978AEE95F38490E9769C39B2773ED763D9CD5F";
 
         vm.step(program);
@@ -318,9 +320,9 @@ public class VMCustomTest {
     @Test // CALLER OP
     public void testCALLER_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("33"), invoke);
+                new Program(config, Hex.decode("33"), invoke);
         String s_expected_1 = "000000000000000000000000885F93EED577F2FC341EBB9A5C9B2CE4465D96C4";
 
         vm.step(program);
@@ -332,9 +334,9 @@ public class VMCustomTest {
     @Test // CALLVALUE OP
     public void testCALLVALUE_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("34"), invoke);
+                new Program(config, Hex.decode("34"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000DE0B6B3A7640000";
 
         vm.step(program);
@@ -346,9 +348,9 @@ public class VMCustomTest {
     @Test // SHA3 OP
     public void testSHA3_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("60016000536001600020"), invoke);
+                new Program(config, Hex.decode("60016000536001600020"), invoke);
         String s_expected_1 = "5FE7F977E71DBA2EA1A68E21057BEEBB9BE2AC30C6410AA38D4F3FBE41DCFFD2";
 
         vm.step(program);
@@ -365,9 +367,9 @@ public class VMCustomTest {
     @Test // SHA3 OP
     public void testSHA3_2() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("6102016000526002601E20"), invoke);
+                new Program(config, Hex.decode("6102016000526002601E20"), invoke);
         String s_expected_1 = "114A3FE82A0219FCC31ABD15617966A125F12B0FD3409105FC83B487A9D82DE4";
 
         vm.step(program);
@@ -384,9 +386,9 @@ public class VMCustomTest {
     @Test(expected = StackTooSmallException.class) // SHA3 OP mal
     public void testSHA3_3() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("610201600052600220"), invoke);
+                new Program(config, Hex.decode("610201600052600220"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -401,9 +403,9 @@ public class VMCustomTest {
     @Test // BLOCKHASH OP
     public void testBLOCKHASH_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("600140"), invoke);
+                new Program(config, Hex.decode("600140"), invoke);
         String s_expected_1 = "C89EFDAA54C0F20C7ADF612882DF0950F5A951637E0307CDCB4C672F298B8BC6";
 
         vm.step(program);
@@ -416,9 +418,9 @@ public class VMCustomTest {
     @Test // COINBASE OP
     public void testCOINBASE_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("41"), invoke);
+                new Program(config, Hex.decode("41"), invoke);
         String s_expected_1 = "000000000000000000000000E559DE5527492BCB42EC68D07DF0742A98EC3F1E";
 
         vm.step(program);
@@ -430,9 +432,9 @@ public class VMCustomTest {
     @Test // TIMESTAMP OP
     public void testTIMESTAMP_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("42"), invoke);
+                new Program(config, Hex.decode("42"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000005387FE24";
 
         vm.step(program);
@@ -444,9 +446,9 @@ public class VMCustomTest {
     @Test // NUMBER OP
     public void testNUMBER_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("43"), invoke);
+                new Program(config, Hex.decode("43"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000021";
 
         vm.step(program);
@@ -458,9 +460,9 @@ public class VMCustomTest {
     @Test // DIFFICULTY OP
     public void testDIFFICULTY_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("44"), invoke);
+                new Program(config, Hex.decode("44"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000003ED290";
 
         vm.step(program);
@@ -472,9 +474,9 @@ public class VMCustomTest {
     @Test // GASPRICE OP
     public void testGASPRICE_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("3A"), invoke);
+                new Program(config, Hex.decode("3A"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000009184E72A000";
 
         vm.step(program);
@@ -487,9 +489,9 @@ public class VMCustomTest {
     @Test // GAS OP
     public void testGAS_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("5A"), invoke);
+                new Program(config, Hex.decode("5A"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000F423F";
 
         vm.step(program);
@@ -501,9 +503,9 @@ public class VMCustomTest {
     @Test // GASLIMIT OP
     public void testGASLIMIT_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("45"), invoke);
+                new Program(config, Hex.decode("45"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000F4240";
 
         vm.step(program);
@@ -512,11 +514,15 @@ public class VMCustomTest {
         assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
     }
 
+    private VM newVM() {
+        return new VM(config);
+    }
+
     @Test(expected = Program.IllegalOperationException.class) // INVALID OP
     public void testINVALID_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60012F6002"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60012F6002"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         try {

--- a/ethereumj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm;
 
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Repository;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.program.Program;
@@ -26,6 +27,7 @@ public class VMTest {
 
     private ProgramInvokeMockImpl invoke;
     private Program program;
+    private SystemProperties config = SystemProperties.getDefault();
 
     @Before
     public void setup() {
@@ -40,8 +42,8 @@ public class VMTest {
     @Test  // PUSH1 OP
     public void testPUSH1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60A0"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60A0"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000A0";
 
         program.fullTrace();
@@ -50,11 +52,15 @@ public class VMTest {
         assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
+    private VM newVM() {
+        return new VM(config);
+    }
+
     @Test  // PUSH2 OP
     public void testPUSH2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61A0B0"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61A0B0"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000A0B0";
 
         program.fullTrace();
@@ -66,8 +72,8 @@ public class VMTest {
     @Test  // PUSH3 OP
     public void testPUSH3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("62A0B0C0"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("62A0B0C0"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000A0B0C0";
 
         program.fullTrace();
@@ -79,8 +85,8 @@ public class VMTest {
     @Test  // PUSH4 OP
     public void testPUSH4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("63A0B0C0D0"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("63A0B0C0D0"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000A0B0C0D0";
 
         program.fullTrace();
@@ -92,8 +98,8 @@ public class VMTest {
     @Test  // PUSH5 OP
     public void testPUSH5() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("64A0B0C0D0E0"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("64A0B0C0D0E0"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000A0B0C0D0E0";
 
         program.fullTrace();
@@ -105,8 +111,8 @@ public class VMTest {
     @Test  // PUSH6 OP
     public void testPUSH6() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("65A0B0C0D0E0F0"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("65A0B0C0D0E0F0"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000A0B0C0D0E0F0";
 
         program.fullTrace();
@@ -118,8 +124,8 @@ public class VMTest {
     @Test  // PUSH7 OP
     public void testPUSH7() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("66A0B0C0D0E0F0A1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("66A0B0C0D0E0F0A1"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000A0B0C0D0E0F0A1";
 
         program.fullTrace();
@@ -131,8 +137,8 @@ public class VMTest {
     @Test  // PUSH8 OP
     public void testPUSH8() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("67A0B0C0D0E0F0A1B1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("67A0B0C0D0E0F0A1B1"), invoke);
         String expected = "000000000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1";
 
         program.fullTrace();
@@ -144,8 +150,8 @@ public class VMTest {
     @Test  // PUSH9 OP
     public void testPUSH9() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("68A0B0C0D0E0F0A1B1C1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("68A0B0C0D0E0F0A1B1C1"), invoke);
         String expected = "0000000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1";
 
         program.fullTrace();
@@ -158,8 +164,8 @@ public class VMTest {
     @Test  // PUSH10 OP
     public void testPUSH10() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("69A0B0C0D0E0F0A1B1C1D1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("69A0B0C0D0E0F0A1B1C1D1"), invoke);
         String expected = "00000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1";
 
         program.fullTrace();
@@ -171,8 +177,8 @@ public class VMTest {
     @Test  // PUSH11 OP
     public void testPUSH11() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6AA0B0C0D0E0F0A1B1C1D1E1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6AA0B0C0D0E0F0A1B1C1D1E1"), invoke);
         String expected = "000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1";
 
         program.fullTrace();
@@ -184,8 +190,8 @@ public class VMTest {
     @Test  // PUSH12 OP
     public void testPUSH12() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6BA0B0C0D0E0F0A1B1C1D1E1F1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6BA0B0C0D0E0F0A1B1C1D1E1F1"), invoke);
         String expected = "0000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1";
 
         program.fullTrace();
@@ -197,8 +203,8 @@ public class VMTest {
     @Test  // PUSH13 OP
     public void testPUSH13() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6CA0B0C0D0E0F0A1B1C1D1E1F1A2"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6CA0B0C0D0E0F0A1B1C1D1E1F1A2"), invoke);
         String expected = "00000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2";
 
         program.fullTrace();
@@ -210,8 +216,8 @@ public class VMTest {
     @Test  // PUSH14 OP
     public void testPUSH14() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6DA0B0C0D0E0F0A1B1C1D1E1F1A2B2"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6DA0B0C0D0E0F0A1B1C1D1E1F1A2B2"), invoke);
         String expected = "000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2";
 
         program.fullTrace();
@@ -223,8 +229,8 @@ public class VMTest {
     @Test  // PUSH15 OP
     public void testPUSH15() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2"), invoke);
         String expected = "0000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2";
 
         program.fullTrace();
@@ -236,8 +242,8 @@ public class VMTest {
     @Test  // PUSH16 OP
     public void testPUSH16() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2"), invoke);
         String expected = "00000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2";
 
         program.fullTrace();
@@ -249,8 +255,8 @@ public class VMTest {
     @Test  // PUSH17 OP
     public void testPUSH17() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("70A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("70A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2"), invoke);
         String expected = "000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2";
 
         program.fullTrace();
@@ -262,8 +268,8 @@ public class VMTest {
     @Test  // PUSH18 OP
     public void testPUSH18() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("71A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("71A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2"), invoke);
         String expected = "0000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2";
 
         program.fullTrace();
@@ -275,8 +281,8 @@ public class VMTest {
     @Test  // PUSH19 OP
     public void testPUSH19() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("72A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("72A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3"), invoke);
         String expected = "00000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3";
 
         program.fullTrace();
@@ -288,8 +294,8 @@ public class VMTest {
     @Test  // PUSH20 OP
     public void testPUSH20() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("73A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("73A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3"), invoke);
         String expected = "000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3";
 
         program.fullTrace();
@@ -301,8 +307,8 @@ public class VMTest {
     @Test  // PUSH21 OP
     public void testPUSH21() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("74A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("74A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3"), invoke);
         String expected = "0000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3";
 
         program.fullTrace();
@@ -314,8 +320,8 @@ public class VMTest {
     @Test  // PUSH22 OP
     public void testPUSH22() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("75A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("75A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3"), invoke);
         String expected = "00000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3";
 
         program.fullTrace();
@@ -327,8 +333,8 @@ public class VMTest {
     @Test  // PUSH23 OP
     public void testPUSH23() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("76A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("76A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3"), invoke);
         String expected = "000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3";
 
         program.fullTrace();
@@ -340,8 +346,8 @@ public class VMTest {
     @Test  // PUSH24 OP
     public void testPUSH24() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("77A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("77A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3"), invoke);
         String expected = "0000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3";
 
         program.fullTrace();
@@ -353,8 +359,8 @@ public class VMTest {
     @Test  // PUSH25 OP
     public void testPUSH25() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("78A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("78A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4"), invoke);
         String expected = "00000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4";
 
         program.fullTrace();
@@ -366,8 +372,8 @@ public class VMTest {
     @Test  // PUSH26 OP
     public void testPUSH26() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("79A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("79A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4"), invoke);
         String expected = "000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4";
 
         program.fullTrace();
@@ -379,8 +385,8 @@ public class VMTest {
     @Test  // PUSH27 OP
     public void testPUSH27() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7AA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7AA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4"), invoke);
         String expected = "0000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4";
 
         program.fullTrace();
@@ -392,8 +398,8 @@ public class VMTest {
     @Test  // PUSH28 OP
     public void testPUSH28() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7BA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7BA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4"), invoke);
         String expected = "00000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4";
 
         program.fullTrace();
@@ -405,8 +411,8 @@ public class VMTest {
     @Test  // PUSH29 OP
     public void testPUSH29() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7CA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7CA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4"), invoke);
         String expected = "000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4";
 
         program.fullTrace();
@@ -418,8 +424,8 @@ public class VMTest {
     @Test  // PUSH30 OP
     public void testPUSH30() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7DA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7DA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4"), invoke);
         String expected = "0000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4";
 
         program.fullTrace();
@@ -431,8 +437,8 @@ public class VMTest {
     @Test  // PUSH31 OP
     public void testPUSH31() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1"), invoke);
         String expected = "00A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1";
 
         program.fullTrace();
@@ -444,8 +450,8 @@ public class VMTest {
     @Test  // PUSH32 OP
     public void testPUSH32() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1"), invoke);
         String expected = "A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1";
 
         program.fullTrace();
@@ -457,8 +463,8 @@ public class VMTest {
     @Test // PUSHN OP not enough data
     public void testPUSHN_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61AA"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61AA"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000AA00";
 
         program.fullTrace();
@@ -471,8 +477,8 @@ public class VMTest {
     @Test // PUSHN OP not enough data
     public void testPUSHN_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7fAABB"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7fAABB"), invoke);
         String expected = "AABB000000000000000000000000000000000000000000000000000000000000";
 
         program.fullTrace();
@@ -485,8 +491,8 @@ public class VMTest {
     @Test  // AND OP
     public void testAND_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600A600A16"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600A600A16"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000000A";
 
         vm.step(program);
@@ -499,8 +505,8 @@ public class VMTest {
     @Test  // AND OP
     public void testAND_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60C0600A16"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60C0600A16"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -513,8 +519,8 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // AND OP mal data
     public void testAND_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60C016"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60C016"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -527,8 +533,8 @@ public class VMTest {
     @Test  // OR OP
     public void testOR_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60F0600F17"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60F0600F17"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -541,8 +547,8 @@ public class VMTest {
     @Test  // OR OP
     public void testOR_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60C3603C17"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60C3603C17"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -555,8 +561,8 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // OR OP mal data
     public void testOR_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60C017"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60C017"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -569,8 +575,8 @@ public class VMTest {
     @Test  // XOR OP
     public void testXOR_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60FF60FF18"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60FF60FF18"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -583,8 +589,8 @@ public class VMTest {
     @Test  // XOR OP
     public void testXOR_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600F60F018"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600F60F018"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -598,8 +604,8 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // XOR OP mal data
     public void testXOR_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60C018"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60C018"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -612,8 +618,8 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("65AABBCCDDEEFF601E1A"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("65AABBCCDDEEFF601E1A"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000EE";
 
         vm.step(program);
@@ -626,8 +632,8 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("65AABBCCDDEEFF60201A"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("65AABBCCDDEEFF60201A"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -640,8 +646,8 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("65AABBCCDDEE3A601F1A"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("65AABBCCDDEE3A601F1A"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000003A";
 
         vm.step(program);
@@ -655,8 +661,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // BYTE OP mal data
     public void testBYTE_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("65AABBCCDDEE3A1A"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("65AABBCCDDEE3A1A"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -669,8 +675,8 @@ public class VMTest {
     @Test  // ISZERO OP
     public void testISZERO_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600015"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600015"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -682,8 +688,8 @@ public class VMTest {
     @Test  // ISZERO OP
     public void testISZERO_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602A15"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602A15"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -695,8 +701,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // ISZERO OP mal data
     public void testISZERO_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("15"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("15"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -709,8 +715,8 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602A602A14"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602A602A14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -723,8 +729,8 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("622A3B4C622A3B4C14"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("622A3B4C622A3B4C14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -737,8 +743,8 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("622A3B5C622A3B4C14"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("622A3B5C622A3B4C14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -751,8 +757,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // EQ OP mal data
     public void testEQ_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("622A3B4C14"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("622A3B4C14"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -765,8 +771,8 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6001600211"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6001600211"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -779,8 +785,8 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6001610F0011"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6001610F0011"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -793,8 +799,8 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6301020304610F0011"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6301020304610F0011"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -807,8 +813,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // GT OP mal data
     public void testGT_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("622A3B4C11"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("622A3B4C11"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -821,8 +827,8 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6001600213"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6001600213"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -835,8 +841,8 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "13"), invoke);
 
@@ -852,8 +858,8 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
                 "13"), invoke);
 
@@ -869,8 +875,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SGT OP mal
     public void testSGT_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "13"), invoke);
         try {
             vm.step(program);
@@ -884,8 +890,8 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6001600210"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6001600210"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -898,8 +904,8 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6001610F0010"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6001610F0010"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -912,8 +918,8 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6301020304610F0010"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6301020304610F0010"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -926,8 +932,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // LT OP mal data
     public void testLT_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("622A3B4C10"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("622A3B4C10"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -940,8 +946,8 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6001600212"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6001600212"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -954,8 +960,8 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "12"), invoke);
 
@@ -971,8 +977,8 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
                 "12"), invoke);
 
@@ -988,8 +994,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SLT OP mal
     public void testSLT_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "12"), invoke);
         try {
             vm.step(program);
@@ -1003,8 +1009,8 @@ public class VMTest {
     @Test  // NOT OP
     public void testNOT_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600119"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600119"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE";
 
         vm.step(program);
@@ -1016,8 +1022,8 @@ public class VMTest {
     @Test  // NOT OP
     public void testNOT_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61A00319"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61A00319"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5FFC";
 
         vm.step(program);
@@ -1030,8 +1036,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // BNOT OP
     public void testBNOT_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("1a"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("1a"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1043,8 +1049,8 @@ public class VMTest {
     @Test  // NOT OP test from real failure
     public void testNOT_5() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600019"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600019"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
         vm.step(program);
@@ -1057,8 +1063,8 @@ public class VMTest {
     @Test // POP OP
     public void testPOP_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61000060016200000250"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61000060016200000250"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -1072,8 +1078,8 @@ public class VMTest {
     @Test // POP OP
     public void testPOP_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6100006001620000025050"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6100006001620000025050"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1088,8 +1094,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // POP OP mal data
     public void testPOP_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61000060016200000250505050"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61000060016200000250505050"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1117,13 +1123,13 @@ public class VMTest {
      */
     private void testDUPN_1(int n) {
 
-        VM vm = new VM();
+        VM vm = newVM();
         byte operation = (byte) (OpCode.DUP1.val() + n - 1);
         String programCode = "";
         for (int i = 0; i < n; i++) {
             programCode += "60" + (12 + i);
         }
-        program = new Program(ByteUtil.appendByte(Hex.decode(programCode.getBytes()), operation), invoke);
+        program = new Program(config, ByteUtil.appendByte(Hex.decode(programCode.getBytes()), operation), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000012";
         int expectedLen = n + 1;
 
@@ -1142,8 +1148,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // DUPN OP mal data
     public void testDUPN_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("80"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("80"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -1165,7 +1171,7 @@ public class VMTest {
      */
     private void testSWAPN_1(int n) {
 
-        VM vm = new VM();
+        VM vm = newVM();
         byte operation = (byte) (OpCode.SWAP1.val() + n - 1);
 
         String programCode = "";
@@ -1177,7 +1183,7 @@ public class VMTest {
 
         programCode += Hex.toHexString(new byte[]{   (byte)(OpCode.SWAP1.val() + n - 1)   });
 
-        program = new Program(ByteUtil.appendByte(Hex.decode(programCode), operation), invoke);
+        program = new Program(config, ByteUtil.appendByte(Hex.decode(programCode), operation), invoke);
 
         for (int i = 0; i < n + 2; ++i) {
             vm.step(program);
@@ -1190,8 +1196,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SWAPN OP mal data
     public void testSWAPN_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("90"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("90"), invoke);
 
         try {
             vm.step(program);
@@ -1203,8 +1209,8 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("611234600052"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("611234600052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000001234";
 
         vm.step(program);
@@ -1218,8 +1224,8 @@ public class VMTest {
     @Test // LOG0 OP
     public void tesLog0() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123460005260206000A0"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123460005260206000A0"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1240,8 +1246,8 @@ public class VMTest {
     @Test // LOG1 OP
     public void tesLog1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123460005261999960206000A1"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123460005261999960206000A1"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1263,8 +1269,8 @@ public class VMTest {
     @Test // LOG2 OP
     public void tesLog2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123460005261999961666660206000A2"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123460005261999961666660206000A2"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1287,8 +1293,8 @@ public class VMTest {
     @Test // LOG3 OP
     public void tesLog3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123460005261999961666661333360206000A3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123460005261999961666661333360206000A3"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1313,8 +1319,8 @@ public class VMTest {
     @Test // LOG4 OP
     public void tesLog4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123460005261999961666661333361555560206000A4"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123460005261999961666661333361555560206000A4"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1340,8 +1346,8 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("611234600052615566602052"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("611234600052615566602052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000001234" +
                 "0000000000000000000000000000000000000000000000000000000000005566";
 
@@ -1358,8 +1364,8 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("611234600052615566602052618888600052"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("611234600052615566602052618888600052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000008888" +
                 "0000000000000000000000000000000000000000000000000000000000005566";
 
@@ -1379,8 +1385,8 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123460A052"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123460A052"), invoke);
         String expected = "" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
@@ -1399,8 +1405,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MSTORE OP
     public void testMSTORE_5() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123452"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123452"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1412,8 +1418,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600051"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1427,8 +1433,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602251"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602251"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1445,8 +1451,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602051"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1461,8 +1467,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("611234602052602051"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("611234602052602051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000001234";
@@ -1480,8 +1486,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_5() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("611234602052601F51"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("611234602052601F51"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000012";
@@ -1499,8 +1505,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MLOAD OP mal data
     public void testMLOAD_6() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("51"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("51"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -1511,8 +1517,8 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6011600053"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6011600053"), invoke);
         String m_expected = "1100000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1526,8 +1532,8 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6022600153"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6022600153"), invoke);
         String m_expected = "0022000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1540,8 +1546,8 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6022602153"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6022602153"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0022000000000000000000000000000000000000000000000000000000000000";
 
@@ -1555,8 +1561,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MSTORE8 OP mal
     public void testMSTORE8_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602253"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602253"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1568,9 +1574,9 @@ public class VMTest {
     @Test // SSTORE OP
     public void testSSTORE_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
 
-        program = new Program(Hex.decode("602260AA55"), invoke);
+        program = new Program(config, Hex.decode("602260AA55"), invoke);
         String s_expected_key = "00000000000000000000000000000000000000000000000000000000000000AA";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000022";
 
@@ -1588,9 +1594,9 @@ public class VMTest {
     @Test // SSTORE OP
     public void testSSTORE_2() {
 
-        VM vm = new VM();
+        VM vm = newVM();
 
-        program = new Program(Hex.decode("602260AA55602260BB55"), invoke);
+        program = new Program(config, Hex.decode("602260AA55602260BB55"), invoke);
         String s_expected_key = "00000000000000000000000000000000000000000000000000000000000000BB";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000022";
 
@@ -1611,8 +1617,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SSTORE OP
     public void testSSTORE_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602255"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602255"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1624,8 +1630,8 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60AA54"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60AA54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1637,8 +1643,8 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602260AA5560AA54"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602260AA5560AA54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000022";
 
         vm.step(program);
@@ -1653,8 +1659,8 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602260AA55603360CC5560CC54"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602260AA55603360CC5560CC54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000033";
 
         vm.step(program);
@@ -1672,8 +1678,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SLOAD OP
     public void testSLOAD_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("56"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("56"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -1684,8 +1690,8 @@ public class VMTest {
     @Test // PC OP
     public void testPC_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("58"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("58"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1697,8 +1703,8 @@ public class VMTest {
     @Test // PC OP
     public void testPC_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602260AA5260AA5458"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602260AA5260AA5458"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000008";
 
         vm.step(program);
@@ -1714,8 +1720,8 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMP_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60AA60BB600E5660CC60DD60EE5B60FF"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60AA60BB600E5660CC60DD60EE5B60FF"), invoke);
         String s_expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -1730,8 +1736,8 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMP_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600C600C905660CC60DD60EE60FF"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600C600C905660CC60DD60EE60FF"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1746,8 +1752,8 @@ public class VMTest {
     @Test // JUMPI OP
     public void testJUMPI_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60016005575B60CC"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60016005575B60CC"), invoke);
         String s_expected = "00000000000000000000000000000000000000000000000000000000000000CC";
 
         vm.step(program);
@@ -1763,8 +1769,8 @@ public class VMTest {
     @Test // JUMPI OP
     public void testJUMPI_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("630000000060445760CC60DD"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("630000000060445760CC60DD"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000DD";
         String s_expected_2 = "00000000000000000000000000000000000000000000000000000000000000CC";
 
@@ -1784,8 +1790,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // JUMPI OP mal
     public void testJUMPI_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600157"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600157"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1797,8 +1803,8 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMPI OP mal
     public void testJUMPI_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60016022909057"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60016022909057"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1813,8 +1819,8 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMPDEST_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602360085660015b600255"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602360085660015b600255"), invoke);
 
         String s_expected_key = "0000000000000000000000000000000000000000000000000000000000000002";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000023";
@@ -1836,8 +1842,8 @@ public class VMTest {
     @Test // JUMPDEST OP for JUMPI
     public void testJUMPDEST_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6023600160095760015b600255"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6023600160095760015b600255"), invoke);
 
         String s_expected_key = "0000000000000000000000000000000000000000000000000000000000000002";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000023";
@@ -1861,8 +1867,8 @@ public class VMTest {
     @Test // ADD OP mal
     public void testADD_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6002600201"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6002600201"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -1876,8 +1882,8 @@ public class VMTest {
     @Test // ADD OP
     public void testADD_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("611002600201"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("611002600201"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000001004";
 
         vm.step(program);
@@ -1891,8 +1897,8 @@ public class VMTest {
     @Test // ADD OP
     public void testADD_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6110026512345678900901"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6110026512345678900901"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000012345678A00B";
 
         vm.step(program);
@@ -1906,8 +1912,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // ADD OP mal
     public void testADD_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123401"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123401"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1918,8 +1924,8 @@ public class VMTest {
 
     @Test // ADDMOD OP mal
     public void testADDMOD_1() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("60026002600308"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60026002600308"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -1934,8 +1940,8 @@ public class VMTest {
 
     @Test // ADDMOD OP
     public void testADDMOD_2() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("6110006002611002086000"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6110006002611002086000"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -1950,8 +1956,8 @@ public class VMTest {
 
     @Test // ADDMOD OP
     public void testADDMOD_3() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("61100265123456789009600208"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61100265123456789009600208"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000000000093B";
 
         vm.step(program);
@@ -1966,8 +1972,8 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // ADDMOD OP mal
     public void testADDMOD_4() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123408"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123408"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1979,8 +1985,8 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6003600202"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6003600202"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000006";
 
         vm.step(program);
@@ -1994,8 +2000,8 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("62222222600302"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("62222222600302"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000666666";
 
         vm.step(program);
@@ -2009,8 +2015,8 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("622222226233333302"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("622222226233333302"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000006D3A05F92C6";
 
         vm.step(program);
@@ -2024,8 +2030,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MUL OP mal
     public void testMUL_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600102"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600102"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2036,8 +2042,8 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_1() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("60036002600409"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60036002600409"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2051,8 +2057,8 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_2() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("622222226003600409"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("622222226003600409"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000000000000C";
 
         vm.step(program);
@@ -2066,8 +2072,8 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_3() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("62222222623333336244444409"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("62222222623333336244444409"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2081,8 +2087,8 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // MULMOD OP mal
     public void testMULMOD_4() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("600109"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600109"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2094,8 +2100,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6002600404"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6002600404"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2109,8 +2115,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6033609904"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6033609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000003";
 
         vm.step(program);
@@ -2125,8 +2131,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6022609904"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6022609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -2140,8 +2146,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6015609904"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6015609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000007";
 
         vm.step(program);
@@ -2156,8 +2162,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_5() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6004600704"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6004600704"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2171,8 +2177,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // DIV OP
     public void testDIV_6() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600704"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600704"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2184,8 +2190,8 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6103E87FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC1805" +
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6103E87FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC1805" +
                 ""), invoke);
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
@@ -2200,8 +2206,8 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60FF60FF05"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60FF60FF05"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2215,8 +2221,8 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600060FF05"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600060FF05"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2230,8 +2236,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SDIV OP mal
     public void testSDIV_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60FF05"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60FF05"), invoke);
 
         try {
             vm.step(program);
@@ -2244,8 +2250,8 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6004600603"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6004600603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2259,8 +2265,8 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61444461666603"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61444461666603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000002222";
 
         vm.step(program);
@@ -2274,8 +2280,8 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("614444639999666603"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("614444639999666603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000099992222";
 
         vm.step(program);
@@ -2289,8 +2295,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SUB OP mal
     public void testSUB_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("639999666603"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("639999666603"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2302,8 +2308,8 @@ public class VMTest {
     @Test // MSIZE OP
     public void testMSIZE_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("59"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("59"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2315,8 +2321,8 @@ public class VMTest {
     @Test // MSIZE OP
     public void testMSIZE_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("602060305259"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("602060305259"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000060";
 
         vm.step(program);
@@ -2332,8 +2338,8 @@ public class VMTest {
     @Test // STOP OP
     public void testSTOP_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("60206030601060306011602300"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("60206030601060306011602300"), invoke);
         int expectedSteps = 7;
 
         int i = 0;
@@ -2349,8 +2355,8 @@ public class VMTest {
     @Test // EXP OP
     public void testEXP_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600360020a"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600360020a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000008";
 
         vm.step(program);
@@ -2368,8 +2374,8 @@ public class VMTest {
     @Test // EXP OP
     public void testEXP_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6000621234560a"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6000621234560a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2387,8 +2393,8 @@ public class VMTest {
     @Test // EXP OP
     public void testEXP_3() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61112260010a"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61112260010a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2406,8 +2412,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // EXP OP mal
     public void testEXP_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("621234560a"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("621234560a"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2419,8 +2425,8 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_1() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("61123460005260206000F3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61123460005260206000F3"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000001234";
 
         vm.step(program);
@@ -2438,8 +2444,8 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_2() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("6112346000526020601FF3"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6112346000526020601FF3"), invoke);
         String s_expected_1 = "3400000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2456,9 +2462,9 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_3() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206000F3"),
                         invoke);
         String s_expected_1 = "A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1";
@@ -2478,9 +2484,9 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_4() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206010F3"),
                         invoke);
         String s_expected_1 = "E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B100000000000000000000000000000000";
@@ -2500,9 +2506,9 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("60036007600039123456"), invoke);
+                new Program(config, Hex.decode("60036007600039123456"), invoke);
         String m_expected_1 = "1234560000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2519,9 +2525,9 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_2() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054"),
                         invoke);
         String m_expected_1 =
@@ -2545,9 +2551,9 @@ public class VMTest {
         // 94 - data copied
         // 95 - new bytes allocated
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
                         invoke);
 
@@ -2563,9 +2569,9 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_4() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
                         invoke);
 
@@ -2581,9 +2587,9 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_5() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("611234600054615566602054607060006020396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
                         invoke);
 
@@ -2605,9 +2611,9 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // CODECOPY OP mal
     public void testCODECOPY_6() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("605E6007396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
                         invoke);
         try {
@@ -2622,9 +2628,9 @@ public class VMTest {
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("60036007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C123456"), invoke);
+                new Program(config, Hex.decode("60036007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C123456"), invoke);
         String m_expected_1 = "6000600000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2639,9 +2645,9 @@ public class VMTest {
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_2() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("603E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054"),
                         invoke);
         String m_expected_1 =
@@ -2658,9 +2664,9 @@ public class VMTest {
 
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_3() {
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("605E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
                         invoke);
 
@@ -2678,9 +2684,9 @@ public class VMTest {
 
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_4() {
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("611234600054615566602054603E6000602073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
                         invoke);
 
@@ -2702,9 +2708,9 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // EXTCODECOPY OP mal
     public void testEXTCODECOPY_5() {
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode("605E600773471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C"),
+                new Program(config, Hex.decode("605E600773471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C"),
                         invoke);
         try {
             vm.step(program);
@@ -2720,9 +2726,9 @@ public class VMTest {
     @Test // CODESIZE OP
     public void testCODESIZE_1() {
 
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("385E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
                         invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000062";
@@ -2736,9 +2742,9 @@ public class VMTest {
     @Ignore // todo: test is not testing EXTCODESIZE
     @Test // EXTCODESIZE OP
     public void testEXTCODESIZE_1() {
-        VM vm = new VM();
+        VM vm = newVM();
         program =
-                new Program(Hex.decode
+                new Program(config, Hex.decode
                         ("73471FD3AD3E9EEADEEC4608B92D16CE6B500704CC395E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
                         invoke); // Push address on the stack and perform EXTCODECOPY
         String s_expected_1 = "000000000000000000000000471FD3AD3E9EEADEEC4608B92D16CE6B500704CC";
@@ -2751,8 +2757,8 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_1() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("6003600406"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6003600406"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2765,8 +2771,8 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_2() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("61012C6101F406"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("61012C6101F406"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000C8";
 
         vm.step(program);
@@ -2779,8 +2785,8 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_3() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("6004600206"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6004600206"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2794,8 +2800,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MOD OP mal
     public void testMOD_4() {
 
-        VM vm = new VM();
-        program = new Program(Hex.decode("600406"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("600406"), invoke);
 
         try {
             vm.step(program);
@@ -2808,8 +2814,8 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_1() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("6003600407"), invoke);
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("6003600407"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2822,8 +2828,8 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_2() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE2" + //  -30
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE2" + //  -30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "07"), invoke);
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEC";
@@ -2838,8 +2844,8 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_3() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "07"), invoke);
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEC";
@@ -2854,8 +2860,8 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // SMOD OP mal
     public void testSMOD_4() {
-        VM vm = new VM();
-        program = new Program(Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+        VM vm = newVM();
+        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "07"), invoke);
         try {
             vm.step(program);


### PR DESCRIPTION
NOTE: don't merge this yet. We still have a couple regressions to fix. Our intent is to give you a heads up a large incoming change and begin discussing any concerns.

`SystemProperties` was previously passed through DI in many, though not all, instances. With this change, `SystemProperties` is injected and the global instance has been removed. This gives users the ability to start multiple differently configured instances for unit testing purposes, or to better integrate with another configuration system for their app.