### PR TITLE
Fix for `org.ethereum.facade.Ethereum.getPendingState()`

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/db/RepositoryTrack.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/RepositoryTrack.java
@@ -10,12 +10,10 @@ import org.slf4j.LoggerFactory;
 
 import org.spongycastle.util.encoders.Hex;
 
+import javax.annotation.Nullable;
 import java.math.BigInteger;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.ethereum.crypto.HashUtil.EMPTY_DATA_HASH;
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
@@ -27,7 +25,7 @@ import static org.ethereum.util.ByteUtil.wrap;
  * @author Roman Mandeleil
  * @since 17.11.2014
  */
-public class RepositoryTrack implements Repository {
+public class RepositoryTrack implements Repository, org.ethereum.facade.Repository {
 
     private static final Logger logger = LoggerFactory.getLogger("repository");
 
@@ -262,6 +260,29 @@ public class RepositoryTrack implements Repository {
         }
     }
 
+    @Override
+    public int getStorageSize(byte[] addr) {
+        synchronized (repository) {
+            ContractDetails details = getContractDetails(addr);
+            return (details == null) ? 0 : details.getStorageSize();
+        }
+    }
+
+    @Override
+    public Set<DataWord> getStorageKeys(byte[] addr) {
+        synchronized (repository) {
+            ContractDetails details = getContractDetails(addr);
+            return (details == null) ? Collections.<DataWord>emptySet() : details.getStorageKeys();
+        }
+    }
+
+    @Override
+    public Map<DataWord, DataWord> getStorage(byte[] addr, @Nullable Collection<DataWord> keys) {
+        synchronized (repository) {
+            ContractDetails details = getContractDetails(addr);
+            return (details == null) ? Collections.<DataWord, DataWord>emptyMap() : details.getStorage(keys);
+        }
+    }
 
     @Override
     public Set<byte[]> getAccountsKeys() {


### PR DESCRIPTION
`org.ethereum.facade.Ethereum.getPendingState()` currently fails with a `ClassCastException`, because it returns a `RepositoryTrack` object and tries to cast it into a `org.ethereum.facade.Repository`.

This change makes `RepositoryTrack` extends `facade.Repository` so the cast will succeed.