### PR TITLE
Make sure TransactionInfo objects can survive the RLP roundtrip

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/TransactionInfo.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/TransactionInfo.java
@@ -9,6 +9,8 @@ import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
 import org.ethereum.vm.LogInfo;
 
+import java.math.BigInteger;
+
 /**
  * Contains Transaction execution info:
  * its receipt and execution context
@@ -45,7 +47,7 @@ public class TransactionInfo {
         if (indexRLP.getRLPData() == null)
             index = 0;
         else
-            index = RLP.decodeInt(indexRLP.getRLPData(), 0);
+            index = new BigInteger(1, indexRLP.getRLPData()).intValue();
     }
 
     public void setTransaction(Transaction tx){

--- a/ethereumj-core/src/test/java/org/ethereum/db/TransactionStoreTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/TransactionStoreTest.java
@@ -67,5 +67,10 @@ public class TransactionStoreTest {
         TransactionInfo tx1Info_ = txStore.get(tx1.getHash());
         executionResult = tx1Info_.getReceipt().getExecutionResult();
         Assert.assertArrayEquals(new DataWord(777).getData(), executionResult);
+
+        TransactionInfo highIndex = new TransactionInfo(tx1Info.getReceipt(), tx1Info.getBlockHash(), 255);
+        TransactionInfo highIndexCopy = new TransactionInfo(highIndex.getEncoded());
+        Assert.assertArrayEquals(highIndex.getBlockHash(), highIndexCopy.getBlockHash());
+        Assert.assertEquals(highIndex.getIndex(), highIndexCopy.getIndex());
     }
 }


### PR DESCRIPTION
We've been hitting a bunch of `ArrayIndexOutOfBoundsException` and `RuntimeException("wrong decode attempt")` errors when trying to call `Blockchain.getTransactionInfo()`.  After investigating, it looks like `TransactionInfo.index` doesn't serialize and deserialize properly to RLP encoding.

The call to `RLP.decodeInt()` below was double-decoding the number, since `RLP.decode2()` already recursively traversed the whole data structure and decoded everything.  Since this is a fix on the decoding side, existing transaction stores should be fine to use.