### PR TITLE
Fix eth_estimateGas() for simple txs

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -245,6 +245,8 @@ public class TransactionExecutor {
         if (!readyToExecute) return;
 
         // TODO: transaction call for pre-compiled  contracts
+        if (vm == null && program == null) return;
+
         try {
 
             // Charge basic cost of the transaction

--- a/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpc.java
+++ b/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpc.java
@@ -36,6 +36,7 @@ public interface JsonRpc {
         public String gasPrice;
         public String value;
         public String data; // compiledCode
+        public String nonce;
 
         @Override
         public String toString() {
@@ -46,6 +47,7 @@ public interface JsonRpc {
                     ", gasPrice='" + gasPrice + '\'' +
                     ", value='" + value + '\'' +
                     ", data='" + data + '\'' +
+                    ", nonce='" + nonce + '\'' +
                     '}';
         }
     }

--- a/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpcImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpcImpl.java
@@ -60,7 +60,10 @@ public class JsonRpcImpl implements JsonRpc {
         public long value;
         public byte[] data;
         public void setArguments(CallArguments args) throws Exception {
-            nonce =0;
+            nonce = 0;
+            if (args.nonce != null && args.nonce.length()!=0)
+                nonce = JSonHexToLong(args.nonce);
+
             gasPrice = 0;
             if (args.gasPrice != null && args.gasPrice.length()!=0)
                 gasPrice = JSonHexToLong(args.gasPrice);
@@ -506,7 +509,7 @@ public class JsonRpcImpl implements JsonRpc {
                 args.data = args.data.substring(2);
 
             Transaction tx = new Transaction(
-                    bigIntegerToBytes(pendingState.getRepository().getNonce(account.getAddress())),
+                    args.nonce != null ? StringHexToByteArray(args.nonce) : bigIntegerToBytes(pendingState.getRepository().getNonce(account.getAddress())),
                     args.gasPrice != null ? StringHexToByteArray(args.gasPrice) : EMPTY_BYTE_ARRAY,
                     args.gasLimit != null ? StringHexToByteArray(args.gasLimit) : EMPTY_BYTE_ARRAY,
                     args.to != null ? StringHexToByteArray(args.to) : EMPTY_BYTE_ARRAY,

--- a/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpcImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpcImpl.java
@@ -72,7 +72,9 @@ public class JsonRpcImpl implements JsonRpc {
             if (args.gasLimit != null && args.gasLimit.length()!=0)
                 gasLimit = JSonHexToLong(args.gasLimit);
 
-            toAddress = JSonHexToHex(args.to);
+            toAddress = null;
+            if (args.to != null && args.to.length()!=0)
+                toAddress = JSonHexToHex(args.to);
 
             value=0;
             if (args.value != null && args.value.length()!=0)

--- a/ethereumj-core/src/test/java/org/ethereum/core/PendingStateTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/PendingStateTest.java
@@ -31,7 +31,7 @@ public class PendingStateTest {
 
     private PendingState pendingState;
 
-    private Blockchain blockchain;
+    private BlockchainImpl blockchain;
 
     private Repository repository;
 
@@ -42,8 +42,13 @@ public class PendingStateTest {
 
         repository = new RepositoryImpl(new HashMapDB(), new HashMapDB());
 
-        blockchain = new BlockchainImpl(blockStore, repository)
+        ProgramInvokeFactoryImpl programInvokeFactory = new ProgramInvokeFactoryImpl();
+
+        blockchain = new BlockchainImpl( blockStore, repository)
                 .withParentBlockHeaderValidator(new CommonConfig().parentHeaderValidator());
+        blockchain.setProgramInvokeFactory(programInvokeFactory);
+        programInvokeFactory.setBlockchain(blockchain);
+
         PendingStateImpl pendingState = new PendingStateImpl(new EthereumListenerAdapter(), (BlockchainImpl) blockchain);
         pendingState.setBlockchain(blockchain);
         pendingState.init();

--- a/ethereumj-core/src/test/java/org/ethereum/jsonrpc/JsonRpcTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsonrpc/JsonRpcTest.java
@@ -155,6 +155,10 @@ public class JsonRpcTest {
             callArgs.data = compRes.code;
             callArgs.gasPrice = "0x10000000000";
             callArgs.gasLimit = "0x1000000";
+
+            String gasEstimate = jsonRpc.eth_estimateGas(callArgs);
+            assertTrue(TypeConverter.StringHexToBigInteger(gasEstimate).longValue() > 0);
+
             String txHash2 = jsonRpc.eth_sendTransaction(callArgs);
 
             String hash2 = mineBlock();

--- a/ethereumj-core/src/test/java/org/ethereum/jsonrpc/JsonRpcTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsonrpc/JsonRpcTest.java
@@ -100,8 +100,19 @@ public class JsonRpcTest {
             Object[] changes = jsonRpc.eth_getFilterChanges(pendingTxFilterId);
             assertEquals(0, changes.length);
 
-            String txHash1 = jsonRpc.eth_sendTransaction(cowAcct, "0x0000000000000000000000000000000000001234", "0x300000",
-                    "0x10000000000", "0x7777", "0x", "0x00");
+            JsonRpc.CallArguments simpleTxArgs = new JsonRpc.CallArguments();
+            simpleTxArgs.from = cowAcct;
+            simpleTxArgs.to = "0x0000000000000000000000000000000000001234";
+            simpleTxArgs.gasLimit = "0x300000";
+            simpleTxArgs.gasPrice = "0x10000000000";
+            simpleTxArgs.value = "0x7777";
+            simpleTxArgs.data = "0x";
+            simpleTxArgs.nonce = "0x00";
+
+            String simpleGas = jsonRpc.eth_estimateGas(simpleTxArgs);
+            assertEquals(new BigInteger("21000"), TypeConverter.StringHexToBigInteger(simpleGas));
+
+            String txHash1 = jsonRpc.eth_sendTransaction(simpleTxArgs);
             System.out.println("Tx hash: " + txHash1);
             assertTrue(TypeConverter.StringHexToBigInteger(txHash1).compareTo(BigInteger.ZERO) > 0);
 


### PR DESCRIPTION
I noticed that `eth_estimateGas()` was returning 0 for everything if you weren't calling a contract; I believe it should return 21000 instead, the standard tx cost.

In at attempt to fix it, I ended up removing some of the code that tries to short-circuit execution for simple value transfers - if I understand this correct, some of that code (e.g. making sure gas usage stays under the gas limit for the transaction) should apply even if you're not actually calling a contract.

I'm not sure if this is the right way to solve the problem, please just let me know if I should try another way.