### PR TITLE
Making ObjectDataSource threadsafe

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/datasource/ObjectDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/ObjectDataSource.java
@@ -3,12 +3,15 @@ package org.ethereum.datasource;
 import org.apache.commons.collections4.map.LRUMap;
 import org.ethereum.db.ByteArrayWrapper;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * Created by Anton Nashatyrev on 17.03.2016.
  */
 public class ObjectDataSource<V> implements Flushable{
     private KeyValueDataSource src;
-    private LRUMap<ByteArrayWrapper, V> cache = new LRUMap<>(256);
+    private Map<ByteArrayWrapper, V> cache = Collections.synchronizedMap(new LRUMap<ByteArrayWrapper, V>(256));
     Serializer<V, byte[]> serializer;
     boolean cacheOnWrite = true;
 

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/ObjectDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/ObjectDataSource.java
@@ -21,7 +21,7 @@ public class ObjectDataSource<V> implements Flushable{
     }
 
     public ObjectDataSource<V> withCacheSize(int cacheSize) {
-        cache = new LRUMap<>(cacheSize);
+        cache = Collections.synchronizedMap(new LRUMap<ByteArrayWrapper, V>(cacheSize));
         return this;
     }
 


### PR DESCRIPTION
We recently got a few errors that look like this:

```
java.lang.IllegalStateException: NPE, entry=f2902d0d07af564ff8acadf171b0a0f828fc8a7cc909a1c2e6c9cb89d06aa596=f904aaf901fda0f75eaf90c5f0ceadaa1bb68ad449b02a6f049fc61cb9d17adce8c605c7d26297a0d05399dd165c0437e78993918d98ef36be64db2b27a5712f4c40d69fa06efeb494f7f2a28e2e054f6ae297698c90178583bb9173fca0ccb27addd58e0605317b444f85b63d9710aa6dc3ef7b51c575458f5e2f05956ba03716a86202da9af126f813b651adeef6e43d6167e976b158164062215d551577a0ab0bfafa965ffff33af9dff659cf9e161bd58be6f4fc01d802a8772b713ec460b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008402d10b04830cb6cd8347e7c4827e17845720e08080a0058a8e701c35bd3b2ddbfcc4771d93da6cd3b65f6adbc507540a8467fcb3899a8841a497c62cd9bd8af88ef88c83105c8e850ba43b7400830f424094385bfb20b9b8cb39b7f7a1d744ae75ddd3adb87780a49859672600000000000000000000000000000000000000000000000000000001d34ce8001ca053247ccfc1fa73ec8850bfca27dbf83781dfc899c7e40278a63f077e71234817a04e2a9211db618f80a093cd2100169699c263998b4506d409812520222324b63ff90217f90214a0e7a099240e76ff9e893601a72584f85c4a18933d3e41d251da9764ec0757d7d4a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347946d1966ab3b5ff5d5cc42e637cb5ad9d85675615ca03cb1ce06c64321370d35a036772ffffe86cd8a7df1aa4c5dccb888eed85bb6baa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008402d2739b830cb6cb8347e7c480845720e03e99d883010305844765746887676f312e352e318664617277696ea0922717c3e1d4d4bf4fea10163cbb3e5ee949e7b7e03caaa8c6d6c8d082b1ad3e8841cc512f8b00f116
BlockData [ hash=f2902d0d07af564ff8acadf171b0a0f828fc8a7cc909a1c2e6c9cb89d06aa596
  parentHash=f75eaf90c5f0ceadaa1bb68ad449b02a6f049fc61cb9d17adce8c605c7d26297
  unclesHash=d05399dd165c0437e78993918d98ef36be64db2b27a5712f4c40d69fa06efeb4
  coinbase=f7f2a28e2e054f6ae297698c90178583bb9173fc
  stateRoot=ccb27addd58e0605317b444f85b63d9710aa6dc3ef7b51c575458f5e2f05956b
  txTrieHash=3716a86202da9af126f813b651adeef6e43d6167e976b158164062215d551577
  receiptsTrieHash=ab0bfafa965ffff33af9dff659cf9e161bd58be6f4fc01d802a8772b713ec460
  difficulty=02d10b04
  number=833229
  gasLimit=47e7c4
  gasUsed=32279
  timestamp=1461772416 (2016.04.27 15:53:36)
  extraData=
  mixHash=058a8e701c35bd3b2ddbfcc4771d93da6cd3b65f6adbc507540a8467fcb3899a
  nonce=41a497c62cd9bd8a
Uncles [
  parentHash=e7a099240e76ff9e893601a72584f85c4a18933d3e41d251da9764ec0757d7d4
  unclesHash=1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347
  coinbase=6d1966ab3b5ff5d5cc42e637cb5ad9d85675615c
  stateRoot=3cb1ce06c64321370d35a036772ffffe86cd8a7df1aa4c5dccb888eed85bb6ba
  txTrieHash=56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
  receiptsTrieHash=56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
  difficulty=02d2739b
  number=833227
  gasLimit=47e7c4
  gasUsed=0
  timestamp=1461772350 (2016.04.27 15:52:30)
  extraData=d883010305844765746887676f312e352e318664617277696e
  mixHash=922717c3e1d4d4bf4fea10163cbb3e5ee949e7b7e03caaa8c6d6c8d082b1ad3e
  nonce=41cc512f8b00f116

]
Txs [
TransactionData [hash=f5dfc7bd7f010f2fc9307d323719108681f6adbf483843227e11895ab46b652b  nonce=105c8e, gasPrice=0ba43b7400, gas=0f4240, receiveAddress=385bfb20b9b8cb39b7f7a1d744ae75ddd3adb877, value=, data=9859672600000000000000000000000000000000000000000000000000000001d34ce800, signatureV=28, signatureR=53247ccfc1fa73ec8850bfca27dbf83781dfc899c7e40278a63f077e71234817, signatureS=4e2a9211db618f80a093cd2100169699c263998b4506d409812520222324b63f]
]
] entryIsHeader=false key=3767909ca3dc3b0360cd80e84b67ba2d76e10f587cbe27a14f53649f8614f20b value=f90218f90213a0f9e142dff250c9cf3ffdcd123dfce94bf20536813132cf6937d160d81f11c0d5a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479463cf90d3f0410092fc0fca41846f596223979195a02b0be039a16aaadb7af124b3a88e26549501cb32b4b2fc748706b9dee9d96b79a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000837ae6818305ff1a832fefd8808456bc80ca99d883010303844765746887676f312e352e338664617277696ea0219643cda59c1aa43f187260320c9d908142bee54af7de025f044ddd6fdbb0178870d139d83bfc2120c0c0
BlockData [ hash=3767909ca3dc3b0360cd80e84b67ba2d76e10f587cbe27a14f53649f8614f20b
  parentHash=f9e142dff250c9cf3ffdcd123dfce94bf20536813132cf6937d160d81f11c0d5
  unclesHash=1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347
  coinbase=63cf90d3f0410092fc0fca41846f596223979195
  stateRoot=2b0be039a16aaadb7af124b3a88e26549501cb32b4b2fc748706b9dee9d96b79
  txTrieHash=56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
  receiptsTrieHash=56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
  difficulty=7ae681
  number=392986
  gasLimit=2fefd8
  gasUsed=0
  timestamp=1455194314 (2016.02.11 12:38:34)
  extraData=d883010303844765746887676f312e352e338664617277696e
  mixHash=219643cda59c1aa43f187260320c9d908142bee54af7de025f044ddd6fdbb017
  nonce=70d139d83bfc2120
Uncles []
Txs []
] size=256 maxSize=256 Please check that your keys are immutable, and that you have used synchronization properly. If so, then please report this to dev@commons.apache.org as a bug.
	at org.apache.commons.collections4.map.LRUMap.reuseMapping(LRUMap.java:324) ~[org.apache.commons.commons-collections4-4.0.jar:4.0]
	at org.apache.commons.collections4.map.LRUMap.addMapping(LRUMap.java:276) ~[org.apache.commons.commons-collections4-4.0.jar:4.0]
	at org.apache.commons.collections4.map.AbstractHashedMap.put(AbstractHashedMap.java:288) ~[org.apache.commons.commons-collections4-4.0.jar:4.0]
	at org.ethereum.datasource.ObjectDataSource.get(ObjectDataSource.java:56) ~[org.ethereum.gemini.ethereumj-core-1.2.3.5.jar:na]
	at org.ethereum.db.IndexedBlockStore.getBlockByHash(IndexedBlockStore.java:177) ~[org.ethereum.gemini.ethereumj-core-1.2.3.5.jar:na]
	at org.ethereum.core.BlockchainImpl.getBlockByHash(BlockchainImpl.java:227) ~[org.ethereum.gemini.ethereumj-core-1.2.3.5.jar:na]
	... 13 common frames omitted
```

So this change puts some synchronization around the Map that threw the NPE.  I checked the other `LRUMap` usages to see if this problem would crop up in other places, but the rest of the `LRUMap` usages seem fine - many are already wrapped in `Collections.synchronizedMap()`.