### PR TITLE
[npe-fix-attempt] Issue #399, NPE on MessageCodec.getCode()

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodec.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodec.java
@@ -202,20 +202,22 @@ public class MessageCodec extends MessageToMessageCodec<Frame, Message> {
     private byte getCode(Enum msgCommand){
         byte code = 0;
 
-        if (msgCommand instanceof P2pMessageCodes){
-            code = messageCodesResolver.withP2pOffset(((P2pMessageCodes) msgCommand).asByte());
-        }
+        if (messageCodesResolver != null) {
+            if (msgCommand instanceof P2pMessageCodes) {
+                code = messageCodesResolver.withP2pOffset(((P2pMessageCodes) msgCommand).asByte());
+            }
 
-        if (msgCommand instanceof EthMessageCodes){
-            code = messageCodesResolver.withEthOffset(((EthMessageCodes) msgCommand).asByte());
-        }
+            if (msgCommand instanceof EthMessageCodes) {
+                code = messageCodesResolver.withEthOffset(((EthMessageCodes) msgCommand).asByte());
+            }
 
-        if (msgCommand instanceof ShhMessageCodes){
-            code = messageCodesResolver.withShhOffset(((ShhMessageCodes)msgCommand).asByte());
-        }
+            if (msgCommand instanceof ShhMessageCodes) {
+                code = messageCodesResolver.withShhOffset(((ShhMessageCodes) msgCommand).asByte());
+            }
 
-        if (msgCommand instanceof BzzMessageCodes){
-            code = messageCodesResolver.withBzzOffset(((BzzMessageCodes) msgCommand).asByte());
+            if (msgCommand instanceof BzzMessageCodes) {
+                code = messageCodesResolver.withBzzOffset(((BzzMessageCodes) msgCommand).asByte());
+            }
         }
 
         return code;


### PR DESCRIPTION
It seems that due to an unsupported protocol the MessageCodec's messageCodesResolver object
is not initialized. Then on that "hack" method getCodec() it blows up.

Sorry if this not the right fix, seems like a quick workaround though, perhaps the right fix has its roots somewhere at `P2pHandler::setHandshake`, but at least this could silence the NPE's reported on Issue #399 