### PR TITLE
Bytes32Type.decode bug

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/solidity/SolidityType.java
+++ b/ethereumj-core/src/main/java/org/ethereum/solidity/SolidityType.java
@@ -292,7 +292,7 @@ public abstract class SolidityType {
 
         @Override
         public Object decode(byte[] encoded, int offset) {
-            return Arrays.copyOfRange(encoded, offset, getFixedSize());
+            return Arrays.copyOfRange(encoded, offset, offset + getFixedSize());
         }
     }
 


### PR DESCRIPTION
Arrays.copyOfRange takes `(array, from, to)`, not `(array, from, length)`