### PR TITLE
Allow raw transactions to be submitted to `StandaloneBlockchain`

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/util/blockchain/EasyBlockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/blockchain/EasyBlockchain.java
@@ -1,6 +1,7 @@
 package org.ethereum.util.blockchain;
 
 import org.ethereum.core.Blockchain;
+import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 
 import java.math.BigInteger;
@@ -59,6 +60,12 @@ public interface EasyBlockchain {
      */
     SolidityContract createExistingContractFromABI(String ABI, byte[] contractAddress);
 
+    /**
+     * Takes a presigned Transaction object and submits it to the blockchain
+     * @param transaction
+     * @return transaction
+     */
+    Transaction submitTransaction(Transaction transaction);
     /**
      * Returns underlying Blockchain instance
      */


### PR DESCRIPTION
I have an application where I need to be able to test submitting regular transactions to `StandaloneBlockchain` as created from an external app.

Currently it only allows you to either sendEther, submit contracts or call contract functions.

There are no unit tests that I can find for StandaloneBlockchain and I'm not enough of a java programmer to make write new ones, but I have local unit tests in clojure that test it and it seems to work. 

I'm absolutely open to any suggestions on improving this. So please be brutal. 😄 