### PR TITLE
Add TransactionExecutionSummary and miner rewards to the onBlock callback

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockSummary.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockSummary.java
@@ -1,0 +1,40 @@
+package org.ethereum.core;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public class BlockSummary {
+
+    private final Block block;
+    private final List<TransactionReceipt> txReceipts;
+    private final List<TransactionExecutionSummary> txSummaries;
+
+    public BlockSummary(Block block, List<TransactionReceipt> txReceipts, List<TransactionExecutionSummary> txSummaries) {
+        this.block = block;
+        this.txReceipts = txReceipts;
+        this.txSummaries = txSummaries;
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+
+    public List<TransactionReceipt> getTxReceipts() {
+        return txReceipts;
+    }
+
+    public List<TransactionExecutionSummary> getTxSummaries() {
+        return txSummaries;
+    }
+
+    /**
+     * The total of all transaction fees paid in this block - does not include mining or uncle inclusion rewards.
+     */
+    public BigInteger getTransactionFees() {
+        BigInteger total = BigInteger.ZERO;
+        for (TransactionExecutionSummary summary : txSummaries) {
+            total = total.add(summary.getFee());
+        }
+        return total;
+    }
+}

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockSummary.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockSummary.java
@@ -2,39 +2,38 @@ package org.ethereum.core;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Map;
 
 public class BlockSummary {
 
     private final Block block;
-    private final List<TransactionReceipt> txReceipts;
-    private final List<TransactionExecutionSummary> txSummaries;
+    private final Map<byte[], BigInteger> rewards;
+    private final List<TransactionReceipt> receipts;
+    private final List<TransactionExecutionSummary> summaries;
 
-    public BlockSummary(Block block, List<TransactionReceipt> txReceipts, List<TransactionExecutionSummary> txSummaries) {
+    public BlockSummary(Block block, Map<byte[], BigInteger> rewards, List<TransactionReceipt> receipts, List<TransactionExecutionSummary> summaries) {
         this.block = block;
-        this.txReceipts = txReceipts;
-        this.txSummaries = txSummaries;
+        this.rewards = rewards;
+        this.receipts = receipts;
+        this.summaries = summaries;
     }
 
     public Block getBlock() {
         return block;
     }
 
-    public List<TransactionReceipt> getTxReceipts() {
-        return txReceipts;
+    public List<TransactionReceipt> getReceipts() {
+        return receipts;
     }
 
-    public List<TransactionExecutionSummary> getTxSummaries() {
-        return txSummaries;
+    public List<TransactionExecutionSummary> getSummaries() {
+        return summaries;
     }
 
     /**
-     * The total of all transaction fees paid in this block - does not include mining or uncle inclusion rewards.
+     * All the mining rewards paid out for this block, including the main block rewards, uncle rewards, and transaction fees.
      */
-    public BigInteger getTransactionFees() {
-        BigInteger total = BigInteger.ZERO;
-        for (TransactionExecutionSummary summary : txSummaries) {
-            total = total.add(summary.getFee());
-        }
-        return total;
+    public Map<byte[], BigInteger> getRewards() {
+        return rewards;
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/core/Blockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Blockchain.java
@@ -7,7 +7,7 @@ public interface Blockchain {
 
     long getSize();
 
-    List<TransactionReceipt> add(Block block);
+    BlockSummary add(Block block);
 
     ImportResult tryToConnect(Block block);
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -298,8 +298,8 @@ public class TransactionExecutor {
         }
     }
 
-    public void finalization() {
-        if (!readyToExecute) return;
+    public TransactionExecutionSummary finalization() {
+        if (!readyToExecute) return null;
 
         String err = config.getBlockchainConfig().getConfigForBlock(currentBlock.getNumber()).
                 validateTransactionChanges(blockStore, currentBlock, (RepositoryTrack) cacheTrack);
@@ -307,7 +307,7 @@ public class TransactionExecutor {
             execError(err);
             m_endGas = toBI(tx.getGasLimit());
             cacheTrack.rollback();
-            return;
+            return null;
         }
 
         cacheTrack.commit();
@@ -380,6 +380,7 @@ public class TransactionExecutor {
             saveProgramTraceFile(config, txHash, trace);
             listener.onVMTraceCreated(txHash, trace);
         }
+        return summary;
     }
 
     public TransactionExecutor setLocalCall(boolean localCall) {

--- a/ethereumj-core/src/main/java/org/ethereum/listener/CompositeEthereumListener.java
+++ b/ethereumj-core/src/main/java/org/ethereum/listener/CompositeEthereumListener.java
@@ -40,12 +40,12 @@ public class CompositeEthereumListener implements EthereumListener {
     }
 
     @Override
-    public void onBlock(final Block block, final List<TransactionReceipt> receipts) {
+    public void onBlock(final BlockSummary blockSummary) {
         for (final EthereumListener listener : listeners) {
             EventDispatchThread.invokeLater(new Runnable() {
                 @Override
                 public void run() {
-                    listener.onBlock(block, receipts);
+                    listener.onBlock(blockSummary);
                 }
             });
         }

--- a/ethereumj-core/src/main/java/org/ethereum/listener/EthereumListener.java
+++ b/ethereumj-core/src/main/java/org/ethereum/listener/EthereumListener.java
@@ -64,7 +64,7 @@ public interface EthereumListener {
 
     void onSendMessage(Channel channel, Message message);
 
-    void onBlock(Block block, List<TransactionReceipt> receipts);
+    void onBlock(BlockSummary blockSummary);
 
     void onPeerDisconnect(String host, long port);
 

--- a/ethereumj-core/src/main/java/org/ethereum/listener/EthereumListenerAdapter.java
+++ b/ethereumj-core/src/main/java/org/ethereum/listener/EthereumListenerAdapter.java
@@ -24,7 +24,7 @@ public class EthereumListenerAdapter implements EthereumListener {
 
     @Override
     public void onBlock(BlockSummary blockSummary) {
-        onBlock(blockSummary.getBlock(), blockSummary.getTxReceipts());
+        onBlock(blockSummary.getBlock(), blockSummary.getReceipts());
     }
 
     @Override

--- a/ethereumj-core/src/main/java/org/ethereum/listener/EthereumListenerAdapter.java
+++ b/ethereumj-core/src/main/java/org/ethereum/listener/EthereumListenerAdapter.java
@@ -19,8 +19,12 @@ public class EthereumListenerAdapter implements EthereumListener {
     public void trace(String output) {
     }
 
-    @Override
     public void onBlock(Block block, List<TransactionReceipt> receipts) {
+    }
+
+    @Override
+    public void onBlock(BlockSummary blockSummary) {
+        onBlock(blockSummary.getBlock(), blockSummary.getTxReceipts());
     }
 
     @Override

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -161,7 +161,7 @@ public class WorldManager {
             blockchain.setBestBlock(Genesis.getInstance(config));
             blockchain.setTotalDifficulty(Genesis.getInstance(config).getCumulativeDifficulty());
 
-            listener.onBlock(Genesis.getInstance(config), new ArrayList<TransactionReceipt>() );
+            listener.onBlock(new BlockSummary(Genesis.getInstance(config), new ArrayList<TransactionReceipt>(), new ArrayList<TransactionExecutionSummary>()));
             repository.dumpState(Genesis.getInstance(config), 0, 0, null);
 
             logger.info("Genesis block loaded");

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -23,6 +23,7 @@ import javax.annotation.PreDestroy;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
@@ -161,7 +162,7 @@ public class WorldManager {
             blockchain.setBestBlock(Genesis.getInstance(config));
             blockchain.setTotalDifficulty(Genesis.getInstance(config).getCumulativeDifficulty());
 
-            listener.onBlock(new BlockSummary(Genesis.getInstance(config), new ArrayList<TransactionReceipt>(), new ArrayList<TransactionExecutionSummary>()));
+            listener.onBlock(new BlockSummary(Genesis.getInstance(config), new HashMap<byte[], BigInteger>(), new ArrayList<TransactionReceipt>(), new ArrayList<TransactionExecutionSummary>()));
             repository.dumpState(Genesis.getInstance(config), 0, 0, null);
 
             logger.info("Genesis block loaded");


### PR DESCRIPTION
This adds two pieces of information into the `onBlock` callback:

* The `TransactionExecutionSummary` for each tx in the block.
* A `Map<byte[], BigInteger>` of all mining rewards (including uncles & tx fees) paid out in the block. (requested by @Melvillian).

This includes a breaking change to `EthereumListener` - but `EthereumListenerAdapter` (which I assume most people are using instead of the bare Listener) is still backwards compatible.