### PR TITLE
Don't force a GC when the Blockchain is flushed to disk

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -548,8 +548,6 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         repository.flush();
         blockStore.flush();
         transactionStore.flush();
-
-        System.gc();
     }
 
     private boolean needFlush(Block block) {


### PR DESCRIPTION
We're managing GC timing pretty tightly in our app and would rather not have this `System.gc()` call every 1000 blocks.  Is it alright to remove?  Or could we make it configurable?