### PR TITLE
Switch 'Retrying again...' to be a warning

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -136,7 +136,7 @@ public class LevelDbDataSource implements KeyValueDataSource {
                 if (logger.isTraceEnabled()) logger.trace("<~ LevelDbDataSource.get(): " + name + ", key: " + Hex.toHexString(key) + ", " + (ret == null ? "null" : ret.length));
                 return ret;
             } catch (DBException e) {
-                logger.error("Exception. Retrying again...", e);
+                logger.warn("Exception. Retrying again...", e);
                 byte[] ret = db.get(key);
                 if (logger.isTraceEnabled()) logger.trace("<~ LevelDbDataSource.get(): " + name + ", key: " + Hex.toHexString(key) + ", " + (ret == null ? "null" : ret.length));
                 return ret;


### PR DESCRIPTION
As I mentioned at https://gitter.im/ethereum/ethereumj?at=576afd0b80f1c6a5257e0485, we've been hitting this LevelDB error handler a good bit lately.  Since it's a recoverable situation, though, I'd like to make it log as a warning instead of an error if possible.