### PR TITLE
Use Spring SystemProperties in DiscoveryChannel and PeerDiscovery

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/DiscoveryChannel.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/DiscoveryChannel.java
@@ -39,6 +39,9 @@ public class DiscoveryChannel {
     private boolean peerDiscoveryMode = false;
 
     @Autowired
+    SystemProperties config = SystemProperties.getDefault();
+
+    @Autowired
     EthereumListener ethereumListener;
 
     @Autowired
@@ -76,7 +79,7 @@ public class DiscoveryChannel {
 
             b.option(ChannelOption.SO_KEEPALIVE, true);
             b.option(ChannelOption.MESSAGE_SIZE_ESTIMATOR, DefaultMessageSizeEstimator.DEFAULT);
-            b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, SystemProperties.getDefault().peerConnectionTimeout());
+            b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, config.peerConnectionTimeout());
             b.remoteAddress(host, port);
 
 
@@ -101,7 +104,7 @@ public class DiscoveryChannel {
                             logger.info("Open connection, channel: {}", ch.toString());
 
                             ch.pipeline().addLast("readTimeoutHandler",
-                                    new ReadTimeoutHandler(SystemProperties.getDefault().peerChannelReadTimeout(), TimeUnit.SECONDS));
+                                    new ReadTimeoutHandler(config.peerChannelReadTimeout(), TimeUnit.SECONDS));
 //                            ch.pipeline().addLast("initiator", decoder.getInitiator());
                             ch.pipeline().addLast("messageCodec", decoder);
                             ch.pipeline().addLast(Capability.P2P, p2pHandler);

--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerDiscovery.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerDiscovery.java
@@ -46,6 +46,9 @@ public class PeerDiscovery {
     @Autowired
     private ApplicationContext ctx;
 
+    @Autowired
+    private SystemProperties config = SystemProperties.getDefault();
+
 
     private final AtomicBoolean started = new AtomicBoolean(false);
 
@@ -58,7 +61,7 @@ public class PeerDiscovery {
         threadFactory = Executors.defaultThreadFactory();
 
         // creating the ThreadPoolExecutor
-        executorPool = new ThreadPoolExecutor(SystemProperties.getDefault().peerDiscoveryWorkers(), SystemProperties.getDefault().peerDiscoveryWorkers(), 10,
+        executorPool = new ThreadPoolExecutor(config.peerDiscoveryWorkers(), config.peerDiscoveryWorkers(), 10,
                 TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1000), threadFactory, rejectionHandler);
 
         // start the monitoring thread
@@ -67,7 +70,7 @@ public class PeerDiscovery {
         monitorThread.start();
 
         // Initialize PeerData
-        List<PeerInfo> peerDataList = parsePeerDiscoveryIpList(SystemProperties.getDefault().peerDiscoveryIPList());
+        List<PeerInfo> peerDataList = parsePeerDiscoveryIpList(config.peerDiscoveryIPList());
         addPeers(peerDataList);
 
         for (PeerInfo peerData : this.peers) {

--- a/ethereumj-core/src/main/java/org/ethereum/validator/BestNumberRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/BestNumberRule.java
@@ -16,7 +16,7 @@ public class BestNumberRule extends DependentBlockHeaderRule {
     private final int BEST_NUMBER_DIFF_LIMIT;
 
     public BestNumberRule(SystemProperties config) {
-        BEST_NUMBER_DIFF_LIMIT = SystemProperties.getDefault().getBlockchainConfig().
+        BEST_NUMBER_DIFF_LIMIT = config.getBlockchainConfig().
                 getCommonConstants().getBEST_NUMBER_DIFF_LIMIT();
     }
 


### PR DESCRIPTION
I think I found a couple places left where the global Spring `SystemProperties` wasn't being used.