### PR TITLE
Support for custom classloaders

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -790,7 +790,7 @@ public class SystemProperties {
 
     public Genesis getGenesis() {
         if (genesis == null) {
-            genesis = GenesisLoader.loadGenesis(this);
+            genesis = GenesisLoader.loadGenesis(this, classLoader);
         }
         return genesis;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -125,6 +125,8 @@ public class SystemProperties {
     private BlockchainNetConfig blockchainConfig;
     private Genesis genesis;
 
+    private final ClassLoader classLoader;
+
     public SystemProperties() {
         this(ConfigFactory.empty());
     }
@@ -138,7 +140,13 @@ public class SystemProperties {
     }
 
     public SystemProperties(Config apiConfig) {
+        this(apiConfig, SystemProperties.class.getClassLoader());
+    }
+
+    public SystemProperties(Config apiConfig, ClassLoader classLoader) {
         try {
+            this.classLoader = classLoader;
+
             Config javaSystemProperties = ConfigFactory.load("no-such-resource-only-system-props");
             Config referenceConfig = ConfigFactory.parseResources("ethereumj.conf");
             logger.info("Config (" + (referenceConfig.entrySet().size() > 0 ? " yes " : " no  ") + "): default properties from resource 'ethereumj.conf'");
@@ -277,7 +285,7 @@ public class SystemProperties {
             } else {
                 String className = config.getString("blockchain.config.class");
                 try {
-                    Class<? extends BlockchainNetConfig> aClass = (Class<? extends BlockchainNetConfig>) Class.forName(className);
+                    Class<? extends BlockchainNetConfig> aClass = (Class<? extends BlockchainNetConfig>) classLoader.loadClass(className);
                     blockchainConfig = aClass.newInstance();
                 } catch (ClassNotFoundException e) {
                     throw new RuntimeException("The class specified via blockchain.config.class '" + className + "' not found" , e);

--- a/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
@@ -25,10 +25,10 @@ import static org.ethereum.util.ByteUtil.wrap;
 
 public class GenesisLoader {
 
-    public static Genesis loadGenesis(SystemProperties config)  {
+    public static Genesis loadGenesis(SystemProperties config, ClassLoader classLoader)  {
         String genesisFile = config.genesisInfo();
 
-        InputStream is = GenesisLoader.class.getResourceAsStream("/genesis/" + genesisFile);
+        InputStream is = classLoader.getResourceAsStream("/genesis/" + genesisFile);
         return loadGenesis(config, is);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
@@ -28,7 +28,7 @@ public class GenesisLoader {
     public static Genesis loadGenesis(SystemProperties config, ClassLoader classLoader)  {
         String genesisFile = config.genesisInfo();
 
-        InputStream is = classLoader.getResourceAsStream("/genesis/" + genesisFile);
+        InputStream is = classLoader.getResourceAsStream("genesis/" + genesisFile);
         return loadGenesis(config, is);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/crypto/jce/SpongyCastleProvider.java
+++ b/ethereumj-core/src/main/java/org/ethereum/crypto/jce/SpongyCastleProvider.java
@@ -7,10 +7,10 @@ import java.security.Security;
 
 public final class SpongyCastleProvider {
 
-  public static final String PROVIDER_NAME = BouncyCastleProvider.PROVIDER_NAME;
+  private static final String PROVIDER_NAME = BouncyCastleProvider.PROVIDER_NAME;
 
   private static class Holder {
-    private static final BouncyCastleProvider INSTANCE;
+    private static final Provider INSTANCE;
 
     static {
       Provider provider = Security.getProvider(PROVIDER_NAME);
@@ -19,8 +19,7 @@ public final class SpongyCastleProvider {
         INSTANCE = new BouncyCastleProvider();
         Security.addProvider(INSTANCE);
       } else {
-        assert provider instanceof BouncyCastleProvider;
-        INSTANCE = (BouncyCastleProvider) provider;
+        INSTANCE = provider;
       }
     }
   }

--- a/ethereumj-core/src/main/java/org/ethereum/crypto/jce/SpongyCastleProvider.java
+++ b/ethereumj-core/src/main/java/org/ethereum/crypto/jce/SpongyCastleProvider.java
@@ -3,25 +3,11 @@ package org.ethereum.crypto.jce;
 import org.spongycastle.jce.provider.BouncyCastleProvider;
 
 import java.security.Provider;
-import java.security.Security;
 
 public final class SpongyCastleProvider {
 
-  private static final String PROVIDER_NAME = BouncyCastleProvider.PROVIDER_NAME;
-
   private static class Holder {
-    private static final Provider INSTANCE;
-
-    static {
-      Provider provider = Security.getProvider(PROVIDER_NAME);
-
-      if (provider == null) {
-        INSTANCE = new BouncyCastleProvider();
-        Security.addProvider(INSTANCE);
-      } else {
-        INSTANCE = provider;
-      }
-    }
+    private static final Provider INSTANCE = new BouncyCastleProvider();
   }
 
   public static Provider getInstance() {

--- a/ethereumj-core/src/test/java/org/ethereum/core/BlockTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/BlockTest.java
@@ -120,7 +120,7 @@ public class BlockTest {
         String prev = SystemProperties.getDefault().genesisInfo();
         SystemProperties.getDefault().setGenesisInfo("frontier.json");
 
-        Block genesis = GenesisLoader.loadGenesis(SystemProperties.getDefault());
+        Block genesis = GenesisLoader.loadGenesis(SystemProperties.getDefault(), getClass().getClassLoader());
 
         String hash = Hex.toHexString(genesis.getHash());
         String root = Hex.toHexString(genesis.getStateRoot());


### PR DESCRIPTION
`Class.forName()` can be dangerous inside a library, because various containers, like J2EE, OSGI, Apache Spark, and the Play Framework (which I'm using) use different classloaders for app code and for library code.  So when I tried to use a custom `BlockchainNetConfig` and a custom genesis JSON file, EthereumJ wasn't able to load them.  This change allows the user to pass in a custom classloader, and defaults to the one used to load the `SystemProperties` class.