### PR TITLE
Specify ping timer scheduling parameter as long type

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/P2pHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/P2pHandler.java
@@ -315,7 +315,7 @@ public class P2pHandler extends SimpleChannelInboundHandler<P2pMessage> {
                     logger.error("Unhandled exception", t);
                 }
             }
-        }, 2, config.getProperty("peer.p2p.pingInterval", 5), TimeUnit.SECONDS);
+        }, 2, config.getProperty("peer.p2p.pingInterval", 5L), TimeUnit.SECONDS);
     }
 
     public void killTimers() {


### PR DESCRIPTION
I was getting a build error in Eclipse because it was assuming that config.getProperty() was returning an int in this case since it considered the second parameter (value 5) as an int rather than as a long.