### PR TITLE
Fix Java Security global state in test suite

### DIFF
--- a/ethereumj-core/src/test/java/org/ethereum/crypto/ECIESTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/crypto/ECIESTest.java
@@ -41,8 +41,6 @@ public class ECIESTest {
 
     @BeforeClass
     public static void beforeAll() {
-        if (Security.getProvider("SC") == null)
-            Security.insertProviderAt(new org.spongycastle.jce.provider.BouncyCastleProvider(), 1);
         curve = new ECDomainParameters(IES_CURVE_PARAM.getCurve(), IES_CURVE_PARAM.getG(), IES_CURVE_PARAM.getN(), IES_CURVE_PARAM.getH());
     }
 


### PR DESCRIPTION
Under some orderings of running the test suite, the test
`org.ethereum.crypto.ECKeyTest.testSunECRoundTrip`
can fail.

Git Bisect reveals this was introduced in commit d4491a5

The `beforeAll` method in ECIESTest inserts the Bouncy Castle Security Provider
into the provider list with the highest priority.
This high priority can cause problems for other Java security code. Specifically,
in `ECKeyTest.testSunECRoundTrip`, when `sun.security.ec.ECKeyPairGenerator`
is looking for algorithm parameters, it ends up in
`org.spongycastle.jcajce.provider.asymmetric.ec.AlgorithmParametersSpi`.

The code that was removed in commit d4491a5
_appended_ the Bouncy Castle provider, so the conditional in `ECIESTest.beforeAll`
would be false. But after d4491a5, the conditional is true.

The fix is simple: just remove the provider insertion in `ECIESTest.beforeAll` as this
is not required.