### PR TITLE
Fixed incorrect recognition of testnet config in samples

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/samples/TestNetSample.java
+++ b/ethereumj-core/src/main/java/org/ethereum/samples/TestNetSample.java
@@ -39,6 +39,7 @@ public class TestNetSample extends BasicSample {
                 "sync.enabled = true \n" +
                 // special genesis for this test network
                 "genesis = frontier-test.json \n" +
+                "blockchain.config.name = 'testnet' \n" +
                 "database.dir = testnetSampleDb \n" +
                 "cache.flush.memory = 0";
 


### PR DESCRIPTION
config.getBlockchainConfig() was returning MainNetConfig for samples. Fixed it.