### PR TITLE
Fixing development restart behavior

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -116,8 +116,7 @@ public class EthereumImpl implements Ethereum, SmartLifecycle {
     @Override
     public void connect(final String ip, final int port, final String remoteId) {
         logger.info("Connecting to: {}:{}", ip, port);
-        final PeerClient peerClient = ctx.getBean(PeerClient.class);
-        peerClient.connectAsync(ip, port, remoteId, false);
+        worldManager.getActivePeer().connectAsync(ip, port, remoteId, false);
     }
 
     @Override
@@ -157,14 +156,7 @@ public class EthereumImpl implements Ethereum, SmartLifecycle {
 
     @Override
     public PeerClient getDefaultPeer() {
-
-        PeerClient peer = worldManager.getActivePeer();
-        if (peer == null) {
-
-            peer = new PeerClient();
-            worldManager.setActivePeer(peer);
-        }
-        return peer;
+        return worldManager.getActivePeer();
     }
 
     @Override

--- a/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.concurrent.FutureAdapter;
@@ -45,7 +46,7 @@ import java.util.concurrent.Future;
  * @since 27.07.2014
  */
 @Component
-public class EthereumImpl implements Ethereum {
+public class EthereumImpl implements Ethereum, SmartLifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger("facade");
     private static final Logger gLogger = LoggerFactory.getLogger("general");
@@ -352,5 +353,39 @@ public class EthereumImpl implements Ethereum {
      */
     public ApplicationContext getApplicationContext() {
         return ctx;
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return false;
+    }
+
+    /**
+     * Shutting down all app beans
+     */
+    @Override
+    public void stop(Runnable callback) {
+        logger.info("### Shutdown initiated ### ");
+        close();
+        callback.run();
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
+
+    @Override
+    public boolean isRunning() {
+        return true;
+    }
+
+    /**
+     * Called first on shutdown lifecycle
+     */
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE;
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -76,6 +77,9 @@ public class WorldManager {
 
     @Autowired
     SystemProperties config;
+
+    @Autowired
+    ApplicationContext ctx;
 
     private CountDownLatch initSemaphore = new CountDownLatch(1);
 
@@ -209,6 +213,8 @@ public class WorldManager {
         channelManager.close();
         logger.info("close: stopping SyncManager ...");
         syncManager.close();
+        logger.info("close: stopping PeerClient ...");
+        ctx.getBean(PeerClient.class).close();
         logger.info("close: shutting down event dispatch thread used by EventBus ...");
         eventDispatchThread.shutdown();
         logger.info("close: closing Blockchain instance ...");

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -126,10 +126,6 @@ public class WorldManager {
         return blockchain;
     }
 
-    public void setActivePeer(PeerClient peer) {
-        this.activePeer = peer;
-    }
-
     public PeerClient getActivePeer() {
         return activePeer;
     }
@@ -214,7 +210,7 @@ public class WorldManager {
         logger.info("close: stopping SyncManager ...");
         syncManager.close();
         logger.info("close: stopping PeerClient ...");
-        ctx.getBean(PeerClient.class).close();
+        activePeer.close();
         logger.info("close: shutting down event dispatch thread used by EventBus ...");
         eventDispatchThread.shutdown();
         logger.info("close: closing Blockchain instance ...");

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
@@ -6,11 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayDeque;
 import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -22,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 public class NodeHandler {
     static final org.slf4j.Logger logger = LoggerFactory.getLogger("discover");
 
-    private static ScheduledExecutorService pongTimer = Executors.newSingleThreadScheduledExecutor();
     static long PingTimeout = 15000; //KademliaOptions.REQ_TIMEOUT;
     private static volatile int msgInCount = 0, msgOutCount = 0;
     private static boolean initialLogging = true;
@@ -260,7 +255,7 @@ public class NodeHandler {
         sendMessage(ping);
         getNodeStatistics().discoverOutPing.add();
 
-        pongTimer.schedule(new Runnable() {
+        nodeManager.getPongTimer().schedule(new Runnable() {
             public void run() {
                 try {
                     if (waitForPong) {

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -14,11 +14,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static java.lang.Math.min;
 
@@ -69,6 +70,7 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
     private boolean inited = false;
     private Timer logStatsTimer = new Timer();
     private Timer nodeManagerTasksTimer = new Timer("NodeManagerTasks");;
+    private ScheduledExecutorService pongTimer;
 
     @Autowired
     public NodeManager(SystemProperties config, EthereumListener ethereumListener, MapDBFactory mapDBFactory, PeerConnectionTester peerConnectionManager) {
@@ -94,6 +96,11 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
         for (Node node : config.peerActive()) {
             getNodeHandler(node).getNodeStatistics().setPredefined(true);
         }
+        this.pongTimer = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    public ScheduledExecutorService getPongTimer() {
+        return pongTimer;
     }
 
     void setBootNodes(List<Node> bootNodes) {
@@ -410,6 +417,12 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
             nodeManagerTasksTimer.cancel();
         } catch (Exception e) {
             logger.warn("Problems canceling nodeManagerTasksTimer", e);
+        }
+        try {
+            logger.info("Cancelling pongTimer");
+            pongTimer.shutdownNow();
+        } catch (Exception e) {
+            logger.warn("Problems cancelling pongTimer", e);
         }
         try {
             logStatsTimer.cancel();

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/PeerConnectionTester.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/PeerConnectionTester.java
@@ -7,7 +7,6 @@ import org.ethereum.net.client.PeerClient;
 import org.ethereum.net.rlpx.Node;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -29,7 +28,7 @@ public class PeerConnectionTester {
     private long ReconnectMaxPeers;
 
     @Autowired
-    private ApplicationContext ctx;
+    private PeerClient peerClient;
 
     @Autowired
     SystemProperties config = SystemProperties.getDefault();
@@ -57,7 +56,6 @@ public class PeerConnectionTester {
                     nodeHandler.getNodeStatistics().rlpxConnectionAttempts.add();
                     logger.debug("Trying node connection: " + nodeHandler);
                     Node node = nodeHandler.getNode();
-                    PeerClient peerClient = ctx.getBean(PeerClient.class);
                     peerClient.connect(node.getHost(), node.getPort(),
                             Hex.encodeHexString(node.getId()), true);
                     logger.debug("Terminated node connection: " + nodeHandler);

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
@@ -8,7 +8,6 @@ import org.ethereum.core.Transaction;
 import org.ethereum.db.ByteArrayWrapper;
 
 import org.ethereum.facade.Ethereum;
-import org.ethereum.net.client.PeerClient;
 import org.ethereum.net.message.ReasonCode;
 import org.ethereum.net.rlpx.Node;
 import org.ethereum.sync.SyncManager;


### PR DESCRIPTION
Let me explain the idea:
Main entry is in EthereumImpl, it catches Spring Context shutdown signal and processes all closes.
The problem is that classes not managed by Spring stays alive and continue their common flow. So we need to integrate their lifecycle into Spring's, so we could manage them on shutdown. And these ThreadGroups should be somehow reinitialised after restart.
Do we really need "prototype" scope for PeerClient?