### PR TITLE
Fixed fail with active.peers defined in config

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -93,10 +93,10 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
             }
         }, 1 * 1000, 60 * 1000);
 
+        this.pongTimer = Executors.newSingleThreadScheduledExecutor();
         for (Node node : config.peerActive()) {
             getNodeHandler(node).getNodeStatistics().setPredefined(true);
         }
-        this.pongTimer = Executors.newSingleThreadScheduledExecutor();
     }
 
     public ScheduledExecutorService getPongTimer() {


### PR DESCRIPTION
My bad, did it wrong in #491 
pongTimer is not yet initialised in certain situations, but used with NullPointer :(
For me, failed when run from sample