### PR TITLE
Bean init sequence refactored

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
@@ -55,7 +55,7 @@ public class CommonConfig {
 
     @Bean
     @Primary
-    Repository repository() {
+    RepositoryImpl repository() {
         return new RepositoryImpl(systemProperties(), keyValueDataSource(), keyValueDataSource(), this);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
@@ -1,6 +1,7 @@
 package org.ethereum.config;
 
 import org.ethereum.core.*;
+import org.ethereum.datasource.DataSourcePool;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.LevelDbDataSource;
 import org.ethereum.datasource.mapdb.MapDBFactory;
@@ -55,7 +56,7 @@ public class CommonConfig {
     @Bean
     @Primary
     Repository repository() {
-        return new RepositoryImpl();
+        return new RepositoryImpl(systemProperties(), keyValueDataSource(), keyValueDataSource(), this);
     }
 
     @Bean
@@ -99,7 +100,12 @@ public class CommonConfig {
     @Bean
     @Scope("prototype")
     public ContractDetailsImpl contractDetailsImpl() {
-        return new ContractDetailsImpl();
+        return new ContractDetailsImpl(this, systemProperties(), dataSourcePool());
+    }
+
+    @Bean
+    public DataSourcePool dataSourcePool() {
+        return DataSourcePool.getDefault();
     }
 
     @Bean

--- a/ethereumj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -1,15 +1,10 @@
 package org.ethereum.config;
 
 import org.ethereum.datasource.CachingDataSource;
-import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
-import org.ethereum.datasource.LevelDbDataSource;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.IndexedBlockStore;
 import org.ethereum.db.TransactionStore;
-import org.mapdb.DB;
-import org.mapdb.DBMaker;
-import org.mapdb.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,15 +12,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Scope;
-
-import javax.annotation.PostConstruct;
-import java.io.File;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.ethereum.db.IndexedBlockStore.BLOCK_INFO_SERIALIZER;
 
 /**
  *
@@ -46,8 +32,7 @@ public class DefaultConfig {
     @Autowired
     SystemProperties config;
 
-    @PostConstruct
-    public void init() {
+    public DefaultConfig() {
         Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(Thread t, Throwable e) {

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -11,6 +11,7 @@ import org.ethereum.db.TransactionStore;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.manager.AdminInfo;
+import org.ethereum.manager.WorldManager;
 import org.ethereum.sync.SyncManager;
 import org.ethereum.trie.Trie;
 import org.ethereum.trie.TrieImpl;
@@ -26,9 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -131,13 +132,12 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
     EventDispatchThread eventDispatchThread;
 
     @Autowired
-    SystemProperties config = SystemProperties.getDefault();
-
-    @Autowired
     CommonConfig commonConfig = CommonConfig.getDefault();
 
     @Autowired
     SyncManager syncManager;
+
+    SystemProperties config = SystemProperties.getDefault();
 
     private List<Chain> altChains = new ArrayList<>();
     private List<Block> garbage = new ArrayList<>();
@@ -157,11 +157,18 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
 
     private Stack<State> stateStack = new Stack<>();
 
+    /** Tests only **/
     public BlockchainImpl() {
     }
 
+    @Autowired
+    public BlockchainImpl(final SystemProperties config) {
+        this.config = config;
+        initConst(config);
+    }
+
     //todo: autowire over constructor
-    public BlockchainImpl(BlockStore blockStore, Repository repository) {
+    public BlockchainImpl(final BlockStore blockStore, final Repository repository) {
         this.blockStore = blockStore;
         this.repository = repository;
         this.adminInfo = new AdminInfo();
@@ -196,11 +203,6 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
     public BlockchainImpl withParentBlockHeaderValidator(ParentBlockHeaderValidator parentHeaderValidator) {
         this.parentHeaderValidator = parentHeaderValidator;
         return this;
-    }
-
-    @PostConstruct
-    private void init() {
-        initConst(config);
     }
 
     private void initConst(SystemProperties config) {
@@ -500,6 +502,9 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         return block;
     }
 
+    @Autowired
+    ApplicationContext ctx;
+
     @Override
     public synchronized BlockSummary add(Block block) {
 
@@ -541,6 +546,9 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
             //return null;
         }
 
+//        if (block.getNumber() == 1641748L) {
+//            ctx.getBean(WorldManager.class).close();
+//        }
         String logBloomHash = Hex.toHexString(block.getLogBloom());
         String logBloomListHash = Hex.toHexString(calcLogBloom(receipts));
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -502,9 +502,6 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         return block;
     }
 
-    @Autowired
-    ApplicationContext ctx;
-
     @Override
     public synchronized BlockSummary add(Block block) {
 
@@ -546,9 +543,6 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
             //return null;
         }
 
-//        if (block.getNumber() == 1641748L) {
-//            ctx.getBean(WorldManager.class).close();
-//        }
         String logBloomHash = Hex.toHexString(block.getLogBloom());
         String logBloomListHash = Hex.toHexString(calcLogBloom(receipts));
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/PendingState.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/PendingState.java
@@ -9,12 +9,6 @@ import java.util.List;
 public interface PendingState extends org.ethereum.facade.PendingState {
 
     /**
-     * Initialized pending state <br>
-     * Must be called when {@link Repository} has been initialized
-     */
-    void init();
-
-    /**
      * Adds transactions received from the net to the list of wire transactions <br>
      * Don't have an impact on pending state
      *

--- a/ethereumj-core/src/main/java/org/ethereum/core/PendingStateImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/PendingStateImpl.java
@@ -18,7 +18,6 @@ import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.util.*;
 
 import static org.ethereum.listener.EthereumListener.PendingTransactionState.*;
@@ -61,9 +60,6 @@ public class PendingStateImpl implements PendingState {
     private EthereumListener listener;
 
     @Autowired
-    private Repository repository;
-
-    @Autowired
     private Blockchain blockchain;
 
     @Autowired
@@ -74,6 +70,8 @@ public class PendingStateImpl implements PendingState {
 
     @Autowired
     private ProgramInvokeFactory programInvokeFactory;
+
+    private Repository repository;
 
     private final List<PendingTransaction> pendingTransactions = new ArrayList<>();
 
@@ -86,10 +84,13 @@ public class PendingStateImpl implements PendingState {
 
     private Block best = null;
 
-    public PendingStateImpl() {
+    @Autowired
+    public PendingStateImpl(Repository repository) {
+        this.repository = repository;
+        init();
     }
 
-    public PendingStateImpl(EthereumListener listener, BlockchainImpl blockchain) {
+    public PendingStateImpl(final EthereumListener listener, final BlockchainImpl blockchain) {
         this.listener = listener;
         this.blockchain = blockchain;
         this.repository = blockchain.getRepository();
@@ -98,7 +99,6 @@ public class PendingStateImpl implements PendingState {
         this.transactionStore = blockchain.getTransactionStore();
     }
 
-    @PostConstruct
     public void init() {
         this.pendingState = repository.startTracking();
     }

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/DataSourcePool.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/DataSourcePool.java
@@ -2,7 +2,6 @@ package org.ethereum.datasource;
 
 import org.ethereum.config.CommonConfig;
 import org.slf4j.Logger;
-import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
 import javax.annotation.PreDestroy;
@@ -11,7 +10,6 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-@Component
 public class DataSourcePool {
     private static final Logger logger = getLogger("db");
     private static DataSourcePool inst;

--- a/ethereumj-core/src/main/java/org/ethereum/db/ContractDetailsImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/ContractDetailsImpl.java
@@ -25,17 +25,15 @@ import static org.ethereum.util.ByteUtil.*;
  * @author Roman Mandeleil
  * @since 24.06.2014
  */
-@Component @Scope("prototype")
+@Component
+@Scope("prototype")
 public class ContractDetailsImpl extends AbstractContractDetails {
     private static final Logger logger = LoggerFactory.getLogger("general");
 
-    @Autowired
     CommonConfig commonConfig = CommonConfig.getDefault();
 
-    @Autowired
     SystemProperties config = SystemProperties.getDefault();
 
-    @Autowired
     DataSourcePool dataSourcePool = DataSourcePool.getDefault();
 
     private byte[] rlpEncoded;
@@ -48,9 +46,18 @@ public class ContractDetailsImpl extends AbstractContractDetails {
     boolean externalStorage;
     private KeyValueDataSource externalStorageDataSource;
 
+    /** Tests only **/
     public ContractDetailsImpl() {
     }
 
+    public ContractDetailsImpl(final CommonConfig commonConfig, final SystemProperties config,
+                               final DataSourcePool dataSourcePool) {
+        this.commonConfig = commonConfig;
+        this.config = config;
+        this.dataSourcePool = dataSourcePool;
+    }
+
+    /** Tests only **/
     public ContractDetailsImpl(byte[] rlpCode) {
         decode(rlpCode);
     }

--- a/ethereumj-core/src/main/java/org/ethereum/db/DetailsDataStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/DetailsDataStore.java
@@ -22,7 +22,6 @@ import static org.ethereum.util.ByteUtil.wrap;
 @Component
 public class DetailsDataStore {
 
-    @Autowired
     CommonConfig commonConfig = CommonConfig.getDefault();
 
     private static final Logger gLogger = LoggerFactory.getLogger("general");
@@ -32,6 +31,11 @@ public class DetailsDataStore {
     private Set<ByteArrayWrapper> removes = new HashSet<>();
 
     public DetailsDataStore() {
+    }
+
+    @Autowired
+    public DetailsDataStore(final CommonConfig commonConfig) {
+        this.commonConfig = commonConfig;
     }
 
     public void setDB(DatabaseImpl db) {

--- a/ethereumj-core/src/main/java/org/ethereum/db/RepositoryImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/RepositoryImpl.java
@@ -15,8 +15,6 @@ import org.ethereum.json.JSONHelper;
 import org.ethereum.trie.JournalPruneDataSource;
 import org.ethereum.trie.SecureTrie;
 import org.ethereum.trie.Trie;
-import org.ethereum.trie.TrieImpl;
-import org.ethereum.util.Value;
 import org.ethereum.vm.DataWord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.FileSystemUtils;
 
 import javax.annotation.Nonnull;
-import javax.annotation.PostConstruct;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -53,24 +50,19 @@ public class RepositoryImpl implements Repository , org.ethereum.facade.Reposito
     private static final Logger gLogger = LoggerFactory.getLogger("general");
 
     @Autowired
+    private BlockStore blockStore;
+
     CommonConfig commonConfig = new CommonConfig();
 
-    @Autowired
-    SystemProperties config = SystemProperties.getDefault();
+    private SystemProperties config = SystemProperties.getDefault();
 
-    @Autowired
     private DetailsDataStore dds = new DetailsDataStore();
-
-    @Autowired
-    private BlockStore blockStore;
 
     private Trie worldState;
 
     private DatabaseImpl detailsDB = null;
 
-    @Autowired
     private KeyValueDataSource detailsDS;
-    @Autowired
     private KeyValueDataSource stateDS;
     private CachingDataSource stateDSCache;
     private JournalPruneDataSource stateDSPrune;
@@ -85,6 +77,16 @@ public class RepositoryImpl implements Repository , org.ethereum.facade.Reposito
     public RepositoryImpl() {
     }
 
+    public RepositoryImpl(final SystemProperties config, final KeyValueDataSource detailsDS,
+                          final KeyValueDataSource stateDS, final CommonConfig commonConfig) {
+        this.config = config;
+        this.detailsDS = detailsDS;
+        this.stateDS = stateDS;
+        this.commonConfig = commonConfig;
+        init();
+    }
+
+    /** Tests only  **/
     public RepositoryImpl(KeyValueDataSource detailsDS, KeyValueDataSource stateDS) {
         this(detailsDS, stateDS, false);
     }
@@ -94,6 +96,7 @@ public class RepositoryImpl implements Repository , org.ethereum.facade.Reposito
         this.stateDS = stateDS;
         this.pruneEnabled = pruneEnabled;
         init();
+        dds.setDB(detailsDB);
     }
 
     public RepositoryImpl withBlockStore(BlockStore blockStore) {
@@ -101,8 +104,7 @@ public class RepositoryImpl implements Repository , org.ethereum.facade.Reposito
         return this;
     }
 
-    @PostConstruct
-    void init() {
+    private void init() {
         detailsDS.setName(DETAILS_DB);
         detailsDS.init();
 
@@ -112,11 +114,16 @@ public class RepositoryImpl implements Repository , org.ethereum.facade.Reposito
         stateDSPrune = new JournalPruneDataSource(stateDSCache);
 
         detailsDB = new DatabaseImpl(detailsDS);
-        dds.setDB(detailsDB);
 
         pruneBlockCount = pruneEnabled ? config.databasePruneDepth() : -1;
 
         worldState = createStateTrie();
+    }
+
+    @Autowired
+    public void setDds(DetailsDataStore dds) {
+        this.dds = dds;
+        dds.setDB(detailsDB);
     }
 
     private Trie createStateTrie() {

--- a/ethereumj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -125,8 +125,6 @@ public interface Ethereum {
      */
     Repository getPendingState();
 
-
-    void init();
 //  2.   // is blockchain still loading - if buffer is not empty
 
     Repository getSnapshotTo(byte[] root);

--- a/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -34,7 +34,6 @@ import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.concurrent.FutureAdapter;
 
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.util.*;
@@ -76,25 +75,21 @@ public class EthereumImpl implements Ethereum, SmartLifecycle {
     PendingState pendingState;
 
     @Autowired
-    SystemProperties config;
-
-    @Autowired
-    CompositeEthereumListener compositeEthereumListener;
-
-    @Autowired
     CommonConfig commonConfig = CommonConfig.getDefault();
+
+    private SystemProperties config;
+
+    private CompositeEthereumListener compositeEthereumListener;
 
 
     private GasPriceTracker gasPriceTracker = new GasPriceTracker();
 
-    public EthereumImpl() {
+    @Autowired
+    public EthereumImpl(final SystemProperties config, final CompositeEthereumListener compositeEthereumListener) {
+        this.compositeEthereumListener = compositeEthereumListener;
+        this.config = config;
         System.out.println();
-    }
-
-    @PostConstruct
-    public void init() {
-        compositeEthereumListener.addListener(gasPriceTracker);
-
+        this.compositeEthereumListener.addListener(gasPriceTracker);
         gLogger.info("EthereumJ node started: enode://" + Hex.toHexString(config.nodeId()) + "@" + config.externalIp() + ":" + config.listenPort());
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpcImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/jsonrpc/JsonRpcImpl.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -99,9 +98,6 @@ public class JsonRpcImpl implements JsonRpc {
     public Repository repository;
 
     @Autowired
-    BlockchainImpl blockchain;
-
-    @Autowired
     Ethereum eth;
 
     @Autowired
@@ -117,9 +113,6 @@ public class JsonRpcImpl implements JsonRpc {
     ChannelManager channelManager;
 
     @Autowired
-    CompositeEthereumListener compositeEthereumListener;
-
-    @Autowired
     BlockMiner blockMiner;
 
     @Autowired
@@ -131,6 +124,11 @@ public class JsonRpcImpl implements JsonRpc {
     @Autowired
     SolidityCompiler solidityCompiler;
 
+    BlockchainImpl blockchain;
+
+    CompositeEthereumListener compositeEthereumListener;
+
+
     long initialBlockNumber;
 
     Map<ByteArrayWrapper, Account> accounts = new HashMap<>();
@@ -138,8 +136,10 @@ public class JsonRpcImpl implements JsonRpc {
     Map<Integer, Filter> installedFilters = new Hashtable<>();
     Map<ByteArrayWrapper, TransactionReceipt> pendingReceipts = Collections.synchronizedMap(new LRUMap<ByteArrayWrapper, TransactionReceipt>(0, 1024));
 
-    @PostConstruct
-    private void init() {
+    @Autowired
+    public JsonRpcImpl(final BlockchainImpl blockchain, final CompositeEthereumListener compositeEthereumListener) {
+        this.blockchain = blockchain;
+        this.compositeEthereumListener = compositeEthereumListener;
         initialBlockNumber = blockchain.getBestBlock().getNumber();
 
         compositeEthereumListener.addListener(new EthereumListenerAdapter() {

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -111,6 +111,8 @@ public class WorldManager {
     }
 
     public void initSyncing() {
+        syncManager.init(channelManager, pool);
+        pool.init(channelManager);
     }
 
     public ChannelManager getChannelManager() {

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -41,19 +41,7 @@ public class WorldManager {
     private static final Logger logger = LoggerFactory.getLogger("general");
 
     @Autowired
-    private EthereumListener listener;
-
-    @Autowired
-    private Blockchain blockchain;
-
-    @Autowired
-    private RepositoryImpl repository;
-
-    @Autowired
     private PeerClient activePeer;
-
-    @Autowired
-    private BlockStore blockStore;
 
     @Autowired
     private ChannelManager channelManager;
@@ -80,25 +68,33 @@ public class WorldManager {
     private EventDispatchThread eventDispatchThread;
 
     @Autowired
-    SystemProperties config;
+    private ApplicationContext ctx;
+
+    private SystemProperties config;
+
+    private EthereumListener listener;
+
+    private Blockchain blockchain;
+
+    private RepositoryImpl repository;
+
+    private BlockStore blockStore;
 
     @Autowired
-    ApplicationContext ctx;
-
-    private CountDownLatch initSemaphore = new CountDownLatch(1);
-
-    @PostConstruct
-    public void init() {
+    public WorldManager(final SystemProperties config, final RepositoryImpl repository,
+                        final EthereumListener listener, final Blockchain blockchain,
+                        final BlockStore blockStore) {
+        this.listener = listener;
+        this.blockchain = blockchain;
+        this.repository = repository;
+        this.blockStore = blockStore;
+        this.config = config;
         loadBlockchain();
-        initSemaphore.countDown();
     }
 
-    public void waitForInit() {
-        try {
-            initSemaphore.await();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+    @PostConstruct
+    private void init() {
+        syncManager.init(channelManager, pool);
     }
 
     public void addListener(EthereumListener listener) {
@@ -115,8 +111,6 @@ public class WorldManager {
     }
 
     public void initSyncing() {
-        syncManager.init();
-        pool.init();
     }
 
     public ChannelManager getChannelManager() {

--- a/ethereumj-core/src/main/java/org/ethereum/mine/BlockMiner.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/BlockMiner.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.*;
@@ -43,13 +42,11 @@ public class BlockMiner {
     private Ethereum ethereum;
 
     @Autowired
+    protected PendingState pendingState;
+
     private CompositeEthereumListener listener;
 
-    @Autowired
     private SystemProperties config;
-
-    @Autowired
-    protected PendingState pendingState;
 
     private List<MinerListener> listeners = new CopyOnWriteArrayList<>();
 
@@ -66,9 +63,10 @@ public class BlockMiner {
     private int UNCLE_LIST_LIMIT;
     private int UNCLE_GENERATION_LIMIT;
 
-
-    @PostConstruct
-    private void init() {
+    @Autowired
+    public BlockMiner(final SystemProperties config, final CompositeEthereumListener listener) {
+        this.listener = listener;
+        this.config = config;
         UNCLE_LIST_LIMIT = config.getBlockchainConfig().getCommonConstants().getUNCLE_LIST_LIMIT();
         UNCLE_GENERATION_LIMIT = config.getBlockchainConfig().getCommonConstants().getUNCLE_GENERATION_LIMIT();
         minGasPrice = config.getMineMinGasPrice();

--- a/ethereumj-core/src/main/java/org/ethereum/net/client/ConfigCapabilities.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/client/ConfigCapabilities.java
@@ -7,7 +7,6 @@ import org.ethereum.net.swarm.bzz.BzzHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
@@ -21,13 +20,14 @@ import static org.ethereum.net.client.Capability.*;
  */
 @Component
 public class ConfigCapabilities {
-    @Autowired
+
     SystemProperties config;
 
     private SortedSet<Capability> AllCaps = new TreeSet<>();
 
-    @PostConstruct
-    private void init() {
+    @Autowired
+    public ConfigCapabilities(final SystemProperties config) {
+        this.config = config;
         if (config.syncVersion() != null) {
             EthVersion eth = fromCode(config.syncVersion());
             if (eth != null) AllCaps.add(new Capability(ETH, eth.getCode()));

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/Eth62.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/Eth62.java
@@ -2,8 +2,10 @@ package org.ethereum.net.eth.handler;
 
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.commons.lang3.tuple.Pair;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.db.BlockStore;
+import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.net.eth.EthVersion;
 import org.ethereum.net.eth.message.*;
 import org.ethereum.net.message.ReasonCode;
@@ -21,13 +23,10 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static java.lang.Math.exp;
-import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Collections.singletonList;
 import static org.ethereum.net.eth.EthVersion.V62;
@@ -92,8 +91,10 @@ public class Eth62 extends EthHandler {
         super(V62);
     }
 
-    @PostConstruct
-    private void init() {
+    @Autowired
+    public Eth62(final SystemProperties config, final Blockchain blockchain,
+                 final CompositeEthereumListener ethereumListener) {
+        super(V62, config, blockchain, ethereumListener);
         maxHashesAsk = config.maxHashesAsk();
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/EthHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/EthHandler.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.annotation.PostConstruct;
 import java.util.List;
 
 /**
@@ -29,13 +28,10 @@ public abstract class EthHandler extends SimpleChannelInboundHandler<EthMessage>
 
     private final static Logger logger = LoggerFactory.getLogger("net");
 
-    @Autowired
     protected Blockchain blockchain;
 
-    @Autowired
     protected SystemProperties config;
 
-    @Autowired
     protected CompositeEthereumListener ethereumListener;
 
     protected Channel channel;
@@ -62,11 +58,15 @@ public abstract class EthHandler extends SimpleChannelInboundHandler<EthMessage>
         this.version = version;
     }
 
-    @PostConstruct
-    private void init() {
+    protected EthHandler(final EthVersion version, final SystemProperties config,
+                         final Blockchain blockchain, final CompositeEthereumListener ethereumListener) {
+        this.version = version;
+        this.config = config;
+        this.ethereumListener = ethereumListener;
+        this.blockchain = blockchain;
         maxHashesAsk = config.maxHashesAsk();
         bestBlock = blockchain.getBestBlock();
-        ethereumListener.addListener(listener);
+        this.ethereumListener.addListener(listener);
         // when sync enabled we delay transactions processing until sync is complete
         processTransactions = !config.isSyncEnabled();
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -13,7 +13,6 @@ import org.ethereum.net.p2p.HelloMessage;
 import org.ethereum.net.p2p.P2pMessageCodes;
 import org.ethereum.net.p2p.P2pMessageFactory;
 import org.ethereum.net.server.Channel;
-import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.crypto.InvalidCipherTextException;
@@ -23,14 +22,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 
 import static org.ethereum.net.rlpx.FrameCodec.Frame;
 import static org.ethereum.util.ByteUtil.bigEndianToShort;
-import static org.ethereum.util.ByteUtil.merge;
 
 /**
  * The Netty handler which manages initial negotiation with peer
@@ -48,9 +45,6 @@ import static org.ethereum.util.ByteUtil.merge;
 @Scope("prototype")
 public class HandshakeHandler extends ByteToMessageDecoder {
 
-    @Autowired
-    SystemProperties config;
-
     private static final Logger loggerWire = LoggerFactory.getLogger("wire");
     private static final Logger loggerNet = LoggerFactory.getLogger("net");
 
@@ -63,11 +57,11 @@ public class HandshakeHandler extends ByteToMessageDecoder {
     private Channel channel;
     private boolean isHandshakeDone;
 
-    public HandshakeHandler() {
-    }
+    private SystemProperties config;
 
-    @PostConstruct
-    private void init() {
+    @Autowired
+    public HandshakeHandler(final SystemProperties config) {
+        this.config = config;
         myKey = config.getMyKey();
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodec.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodec.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -57,8 +56,7 @@ public class MessageCodec extends MessageToMessageCodec<Frame, Message> {
     @Autowired
     EthereumListener ethereumListener;
 
-    @Autowired
-    SystemProperties config;
+    private SystemProperties config;
 
     private boolean supportChunkedFrames = true;
 
@@ -66,8 +64,12 @@ public class MessageCodec extends MessageToMessageCodec<Frame, Message> {
     // LRU avoids OOM on invalid peers
     AtomicInteger contextIdCounter = new AtomicInteger(1);
 
-    @PostConstruct
-    private void init() {
+    public MessageCodec() {
+    }
+
+    @Autowired
+    private MessageCodec(final SystemProperties config) {
+        this.config = config;
         setMaxFramePayloadSize(config.rlpxMaxFrameSize());
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/PeerConnectionTester.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/PeerConnectionTester.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.*;
@@ -30,8 +29,7 @@ public class PeerConnectionTester {
     @Autowired
     private PeerClient peerClient;
 
-    @Autowired
-    SystemProperties config = SystemProperties.getDefault();
+    private SystemProperties config = SystemProperties.getDefault();
 
     // NodeHandler instance should be unique per Node instance
     private Map<NodeHandler, ?> connectedCandidates = Collections.synchronizedMap(new IdentityHashMap());
@@ -82,11 +80,9 @@ public class PeerConnectionTester {
         }
     }
 
-    public PeerConnectionTester() {
-    }
-
-    @PostConstruct
-    void init() {
+    @Autowired
+    public PeerConnectionTester(final SystemProperties config) {
+        this.config = config;
         ConnectThreads = config.peerDiscoveryWorkers();
         ReconnectPeriod = config.peerDiscoveryTouchPeriod() * 1000;
         ReconnectMaxPeers = config.peerDiscoveryTouchMaxNodes();

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/UDPListener.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/UDPListener.java
@@ -12,7 +12,6 @@ import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,7 +39,7 @@ public class UDPListener {
     private DiscoveryExecutor discoveryExecutor;
 
     @Autowired
-    public UDPListener(SystemProperties config, NodeManager nodeManager) {
+    public UDPListener(final SystemProperties config, final NodeManager nodeManager) {
         this.config = config;
         this.nodeManager = nodeManager;
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
@@ -22,8 +22,6 @@ import java.net.InetAddress;
 import java.util.*;
 import java.util.concurrent.*;
 
-import javax.annotation.PostConstruct;
-
 import static org.ethereum.net.message.ReasonCode.DUPLICATE_PEER;
 import static org.ethereum.net.message.ReasonCode.TOO_MANY_PEERS;
 
@@ -50,22 +48,23 @@ public class ChannelManager {
     private NodeFilter trustedPeers;
 
     @Autowired
-    SystemProperties config;
-
-    @Autowired
-    SyncManager syncManager;
-
-    @Autowired
     SyncPool syncPool;
 
     @Autowired
     private Ethereum ethereum;
 
-    @Autowired
-    PeerServer peerServer;
+    private SystemProperties config;
 
-    @PostConstruct
-    public void init() {
+    private SyncManager syncManager;
+
+    private PeerServer peerServer;
+
+    @Autowired
+    private ChannelManager(final SystemProperties config, final SyncManager syncManager,
+                           final PeerServer peerServer) {
+        this.config = config;
+        this.syncManager = syncManager;
+        this.peerServer = peerServer;
         maxActivePeers = config.maxActivePeers();
         trustedPeers = config.peerTrusted();
         mainWorker.scheduleWithFixedDelay(new Runnable() {

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/PeerServer.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/PeerServer.java
@@ -32,16 +32,13 @@ public class PeerServer {
 
     private static final Logger logger = LoggerFactory.getLogger("net");
 
-    @Autowired
-    SystemProperties config;
+    private SystemProperties config;
 
-    @Autowired
     private ApplicationContext ctx;
 
-    public EthereumChannelInitializer ethereumChannelInitializer;
+    private EthereumListener ethereumListener;
 
-    @Autowired
-    EthereumListener ethereumListener;
+    public EthereumChannelInitializer ethereumChannelInitializer;
 
     private boolean listening;
 
@@ -49,9 +46,13 @@ public class PeerServer {
     EventLoopGroup workerGroup;
     ChannelFuture channelFuture;
 
-    public PeerServer() {
+    @Autowired
+    public PeerServer(final SystemProperties config, final ApplicationContext ctx,
+                      final EthereumListener ethereumListener) {
+        this.ctx = ctx;
+        this.config = config;
+        this.ethereumListener = ethereumListener;
     }
-
 
     public void start(int port) {
 

--- a/ethereumj-core/src/main/java/org/ethereum/sync/SyncManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/SyncManager.java
@@ -4,8 +4,6 @@ import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.listener.EthereumListener;
-import org.ethereum.manager.WorldManager;
-import org.ethereum.net.eth.handler.Eth62;
 import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.util.ExecutorPipeline;
@@ -17,7 +15,6 @@ import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -81,19 +78,13 @@ public class SyncManager {
     private CompositeEthereumListener compositeEthereumListener;
 
     @Autowired
-    SyncPool pool;
-
-    @Autowired
-    WorldManager worldManager;
-
-    @Autowired
-    SystemProperties config;
-
-    @Autowired
     EthereumListener ethereumListener;
 
-    @Autowired
     ChannelManager channelManager;
+
+    private SystemProperties config;
+
+    private SyncPool pool;
 
     private SyncQueueIfc syncQueue;
 
@@ -105,59 +96,58 @@ public class SyncManager {
     private Thread getBodiesThread;
     private ScheduledExecutorService logExecutor = Executors.newSingleThreadScheduledExecutor();
 
-    @PostConstruct
-    public void init() {
+    public SyncManager() {
+    }
 
-        // make it asynchronously
-        new Thread(new Runnable() {
+    @Autowired
+    public SyncManager(final SystemProperties config) {
+        this.config = config;
+    }
+
+    public void init(final ChannelManager channelManager, final SyncPool pool) {
+        this.pool = pool;
+        this.channelManager = channelManager;
+        if (!config.isSyncEnabled()) {
+            logger.info("Sync Manager: OFF");
+            return;
+        }
+        logger.info("Sync Manager: ON");
+
+        logger.info("Initializing SyncManager.");
+        pool.init(channelManager);
+
+        Runnable queueProducer = new Runnable(){
+
             @Override
             public void run() {
-
-                if (!config.isSyncEnabled()) {
-                    logger.info("Sync Manager: OFF");
-                    return;
-                }
-
-                logger.info("Sync Manager: ON");
-
-                worldManager.waitForInit();
-                logger.info("Initializing SyncManager.");
-
-                Runnable queueProducer = new Runnable(){
-
-                    @Override
-                    public void run() {
-                        produceQueue();
-                    }
-                };
-
-                syncQueueThread =new Thread (queueProducer, "SyncQueueThread");
-                syncQueueThread.start();
-
-                syncQueue = new SyncQueueImpl(blockchain);
-
-                getHeadersThread = new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        headerRetrieveLoop();
-                    }
-                }, "NewSyncThreadHeaders");
-                getHeadersThread.start();
-
-                getBodiesThread = new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        blockRetrieveLoop();
-                    }
-                }, "NewSyncThreadBlocks");
-                getBodiesThread.start();
-
-                if (logger.isInfoEnabled()) {
-                    startLogWorker();
-                }
-
+                produceQueue();
             }
-        }).start();
+        };
+
+        syncQueueThread = new Thread (queueProducer, "SyncQueueThread");
+        syncQueueThread.start();
+
+        syncQueue = new SyncQueueImpl(blockchain);
+
+        getHeadersThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                headerRetrieveLoop();
+            }
+        }, "NewSyncThreadHeaders");
+        getHeadersThread.start();
+
+        getBodiesThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                blockRetrieveLoop();
+            }
+        }, "NewSyncThreadBlocks");
+        getBodiesThread.start();
+
+        if (logger.isInfoEnabled()) {
+            startLogWorker();
+        }
     }
 
     private void headerRetrieveLoop() {

--- a/ethereumj-core/src/main/java/org/ethereum/sync/SyncPool.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/SyncPool.java
@@ -15,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.Executors;
@@ -51,23 +50,24 @@ public class SyncPool {
     private EthereumListener ethereumListener;
 
     @Autowired
-    private Blockchain blockchain;
-
-    @Autowired
-    private SystemProperties config;
-
-    @Autowired
     private NodeManager nodeManager;
 
-    @Autowired
     private ChannelManager channelManager;
+
+    private Blockchain blockchain;
+
+    private SystemProperties config;
+
     private ScheduledExecutorService poolLoopExecutor = Executors.newSingleThreadScheduledExecutor();
 
-    @PostConstruct
-    public void init() {
+    @Autowired
+    public SyncPool(final SystemProperties config, final Blockchain blockchain) {
+        this.config = config;
+        this.blockchain = blockchain;
+    }
 
-        if (!config.isSyncEnabled()) return;
-
+    public void init(final ChannelManager channelManager) {
+        this.channelManager = channelManager;
         updateLowerUsefulDifficulty();
 
         poolLoopExecutor.scheduleWithFixedDelay(

--- a/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
@@ -380,8 +380,6 @@ public class StandaloneBlockchain implements LocalBlockchain {
 
         pendingState = new PendingStateImpl(listener, blockchain);
 
-        pendingState.init();
-
         pendingState.setBlockchain(blockchain);
         blockchain.setPendingState(pendingState);
 

--- a/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -463,8 +463,6 @@ public class ImportLightTest {
 
         PendingStateImpl pendingState = new PendingStateImpl(listener, blockchain);
 
-        pendingState.init();
-
         pendingState.setBlockchain(blockchain);
         blockchain.setPendingState(pendingState);
 

--- a/ethereumj-core/src/test/java/org/ethereum/core/PendingStateLongRunTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/PendingStateLongRunTest.java
@@ -119,8 +119,6 @@ public class PendingStateLongRunTest {
 
         PendingStateImpl pendingState = new PendingStateImpl(new EthereumListenerAdapter(), blockchain);
 
-        pendingState.init();
-
         pendingState.setBlockchain(blockchain);
         blockchain.setPendingState(pendingState);
 

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/suite/TestRunner.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/suite/TestRunner.java
@@ -92,7 +92,6 @@ public class TestRunner {
         blockchain.byTest = true;
 
         PendingStateImpl pendingState = new PendingStateImpl(new EthereumListenerAdapter(), blockchain);
-        pendingState.init();
 
         blockchain.setBestBlock(genesis);
         blockchain.setTotalDifficulty(genesis.getCumulativeDifficulty());


### PR DESCRIPTION
- Almost all `@PostConstruct`'s removed. One left in `AdminInfo` as it's part of logic and one in `WorldManager` as it's an entry point for all managers init.
- Managers ball has only unidirectional autowiring now.
- It should be a bit safer because constructors require things to be passed in. I've not put everything in, because it's usually a huge list, but at least we could guarantee some dependencies.