### PR TITLE
Fixed ArrayIndexOutOfBounds error when performing parseEvent

### DIFF
--- a/ethereumj-core/src/test/java/org/ethereum/log/DecodeLogTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/log/DecodeLogTest.java
@@ -1,0 +1,25 @@
+package org.ethereum.log;
+
+import java.math.BigInteger;
+
+import org.ethereum.core.CallTransaction;
+import org.ethereum.vm.LogInfo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+public class DecodeLogTest {
+
+	@Test
+	public void decodeEventWithIndexedParamsTest() {
+		byte[] encodedLog = Hex.decode("f89b9494d9cf9ed550a358d4576e2efd168a80075c648bf863a027772adc63db07aae765b71eb2b533064fa781bd57457e1b138592d8198d0959a0000000000000000000000000bb8492b71d933c1da7ac154b4d01bf54d6f09e99a0000000000000000000000000f84e5656d026ba9c321394a59cca7cd8e705f448a00000000000000000000000000000000000000000000000000000000000000064");
+		String abi = "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint128\"}],\"name\":\"Transfer\",\"type\":\"event\"}]\n";
+		LogInfo logInfo = new LogInfo(encodedLog);
+		CallTransaction.Contract contract = new CallTransaction.Contract(abi);
+		CallTransaction.Invocation invocation = contract.parseEvent(logInfo);
+		Assert.assertEquals(3, invocation.args.length);
+		Assert.assertArrayEquals(Hex.decode("bb8492b71d933c1da7ac154b4d01bf54d6f09e99"), (byte[]) invocation.args[0]);
+		Assert.assertArrayEquals(Hex.decode("f84e5656d026ba9c321394a59cca7cd8e705f448"), (byte[]) invocation.args[1]);
+		Assert.assertEquals(new BigInteger("100"), invocation.args[2]);
+	}
+}


### PR DESCRIPTION
Currently if you parse an event log that contains indexed parameters, it fails with an ArrayIndexOutOfBounds error. This is because indexed parameters are included as topic and not into the event log data field

As per https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#events, i've implemented a fix for this. I've tested it and it seems to work without any issues