### PR TITLE
fix encodeInt for values > 2^255

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/solidity/SolidityType.java
+++ b/ethereumj-core/src/main/java/org/ethereum/solidity/SolidityType.java
@@ -376,6 +376,11 @@ public abstract class SolidityType {
         public static byte[] encodeInt(BigInteger bigInt) {
             byte[] ret = new byte[32];
             Arrays.fill(ret, bigInt.signum() < 0 ? (byte) 0xFF : 0);
+            if (bigInt.bitLength() > 255) {
+                // This will produce the number whose 2's complement (returned by toByteArray) is
+                // the unsigned representation of bigInt
+                bigInt = bigInt.subtract(BigInteger.ZERO.setBit(256));
+            }
             byte[] bytes = bigInt.toByteArray();
             System.arraycopy(bytes, 0, ret, 32 - bytes.length, bytes.length);
             return ret;


### PR DESCRIPTION
`encodeInt` causes an array out of bounds exception for any value > 2^255 since `toByteArray` returns the 2's complement representation (which requires 257 bits – 33 bytes for that case). To avoid this, we input the value whose 2's complement is the desired unsigned value when bigInt > 2^255.