### PR TITLE
Feature/457 leveldb on mac and repair

### DIFF
--- a/ethereumj-core/build.gradle
+++ b/ethereumj-core/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     }
 }
 
+
 plugins {
     id 'application'
     id 'jacoco'
@@ -111,10 +112,9 @@ dependencies {
     compile "com.madgag.spongycastle:core:${scastleVersion}" // for SHA3 and SECP256K1
     compile "com.madgag.spongycastle:prov:${scastleVersion}" // for SHA3 and SECP256K1
 
-    compile "org.iq80.leveldb:leveldb:${leveldbVersion}"
+    compile "org.iq80.leveldb:leveldb:${leveldbVersion}"     // Java API wrapper around native components
 
-    compile "org.fusesource.leveldbjni:leveldbjni:1.8"
-    compile "org.ethereum:leveldbjni-all:1.18.2"
+    compile "org.ethereum:leveldbjni-all:1.18.3"             // native leveldb components
 
     compile "com.cedarsoftware:java-util:1.8.0" // for deep equals
     compile "org.javassist:javassist:3.15.0-GA"

--- a/ethereumj-core/src/main/java/org/ethereum/util/BuildInfo.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/BuildInfo.java
@@ -20,11 +20,15 @@ public class BuildInfo {
             Properties props = new Properties();
             InputStream is = BuildInfo.class.getResourceAsStream("/build-info.properties");
 
+            if (is != null) {
                 props.load(is);
 
                 buildHash = props.getProperty("build.hash");
                 buildTime = props.getProperty("build.time");
                 buildBranch = props.getProperty("build.branch");
+            } else {
+                logger.warn("File not found `build-info.properties`. Run `gradle build` to generate it");
+            }
         } catch (IOException e) {
             logger.error("Error reading /build-info.properties", e);
         }


### PR DESCRIPTION
Resolve #457 with:
 - auto repair database once if any error occurs during database initialization;
 - switch to leveldb-1.18 on Mac;
 - adjust `BuildInfo.java` to not throw error when file missing. It is annoying to do `gradle build` after branch switch.

And yes, DB reset must be required for Mac. For me once it worked fine, but with second test DB detected corruption, repaired and then met "No parent" error.