### PR TITLE
Fixed skip behavior of Eth62 getHeaders

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -342,6 +342,7 @@ public class BlockHeader {
 
     private String toStringWithSuffix(final String suffix) {
         StringBuilder toStringBuff = new StringBuilder();
+        toStringBuff.append("  hash=").append(toHexString(getHash())).append(suffix);
         toStringBuff.append("  parentHash=").append(toHexString(parentHash)).append(suffix);
         toStringBuff.append("  unclesHash=").append(toHexString(unclesHash)).append(suffix);
         toStringBuff.append("  coinbase=").append(toHexString(coinbase)).append(suffix);

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -11,7 +11,6 @@ import org.ethereum.db.TransactionStore;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.manager.AdminInfo;
-import org.ethereum.manager.WorldManager;
 import org.ethereum.sync.SyncManager;
 import org.ethereum.trie.Trie;
 import org.ethereum.trie.TrieImpl;
@@ -27,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import java.io.BufferedWriter;
@@ -104,7 +102,7 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
     private Repository track;
 
     @Autowired
-    private BlockStore blockStore;
+    protected BlockStore blockStore;
 
     @Autowired
     private TransactionStore transactionStore;
@@ -1090,29 +1088,57 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         return pendingState;
     }
 
+    /**
+     * Returns up to limit headers found with following search parameters
+     * @param identifier        Identifier of start block, by number of by hash
+     * @param skip              Number of blocks to skip between consecutive headers
+     * @param limit             Maximum number of headers in return
+     * @param reverse           Is search reverse or not
+     * @return  {@link BlockHeader}'s list or empty list if none found
+     */
     @Override
     public synchronized List<BlockHeader> getListOfHeadersStartFrom(BlockIdentifier identifier, int skip, int limit, boolean reverse) {
-        long blockNumber = identifier.getNumber();
 
+        // Identifying block we'll move from
+        Block startBlock;
         if (identifier.getHash() != null) {
-            Block block = getBlockByHash(identifier.getHash());
-
-            if (block == null) {
-                return emptyList();
-            }
-
-            blockNumber = block.getNumber();
+            startBlock = getBlockByHash(identifier.getHash());
+        } else {
+            startBlock = getBlockByNumber(identifier.getNumber());
         }
 
-        long bestNumber = bestBlock.getNumber();
-
-        if (bestNumber < blockNumber) {
+        // If nothing found or provided hash is not on main chain, return empty array
+        if (startBlock == null) {
             return emptyList();
         }
+        if (identifier.getHash() != null) {
+            Block mainChainBlock = getBlockByNumber(startBlock.getNumber());
+            if (!startBlock.equals(mainChainBlock)) return emptyList();
+        }
 
+        List<BlockHeader> headers;
+        if (skip == 0) {
+            long bestNumber = bestBlock.getNumber();
+            headers = getContinuousHeaders(bestNumber, startBlock.getNumber(), limit, reverse);
+        } else {
+            headers = getGapedHeaders(startBlock, skip, limit, reverse);
+        }
+
+        return headers;
+    }
+
+    /**
+     * Finds up to limit blocks starting from blockNumber on main chain
+     * @param bestNumber        Number of best block
+     * @param blockNumber       Number of block to start search (included in return)
+     * @param limit             Maximum number of headers in response
+     * @param reverse           Order of search
+     * @return  headers found by query or empty list if none
+     */
+    private List<BlockHeader> getContinuousHeaders(long bestNumber, long blockNumber, int limit, boolean reverse) {
         int qty = getQty(blockNumber, bestNumber, limit, reverse);
 
-        byte[] startHash = getStartHash(blockNumber, skip, qty, reverse);
+        byte[] startHash = getStartHash(blockNumber, qty, reverse);
 
         if (startHash == null) {
             return emptyList();
@@ -1123,6 +1149,35 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         // blocks come with falling numbers
         if (!reverse) {
             Collections.reverse(headers);
+        }
+
+        return headers;
+    }
+
+    /**
+     * Gets blocks from main chain with gaps between
+     * @param startBlock        Block to start from (included in return)
+     * @param skip              Number of blocks skipped between every header in return
+     * @param limit             Maximum number of headers in return
+     * @param reverse           Order of search
+     * @return  headers found by query or empty list if none
+     */
+    private List<BlockHeader> getGapedHeaders(Block startBlock, int skip, int limit, boolean reverse) {
+        List<BlockHeader> headers = new ArrayList<>();
+        headers.add(startBlock.getHeader());
+        int offset = skip + 1;
+        if (reverse) offset = -offset;
+        long currentNumber = startBlock.getNumber();
+        boolean finished = false;
+
+        while(!finished && headers.size() < limit) {
+            currentNumber += offset;
+            Block nextBlock = blockStore.getChainBlockByNumber(currentNumber);
+            if (nextBlock == null) {
+                finished = true;
+            } else {
+                headers.add(nextBlock.getHeader());
+            }
         }
 
         return headers;
@@ -1140,14 +1195,14 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         }
     }
 
-    private byte[] getStartHash(long blockNumber, int skip, int qty, boolean reverse) {
+    private byte[] getStartHash(long blockNumber, int qty, boolean reverse) {
 
         long startNumber;
 
         if (reverse) {
-            startNumber = blockNumber - skip;
+            startNumber = blockNumber;
         } else {
-            startNumber = blockNumber + skip + qty - 1;
+            startNumber = blockNumber + qty - 1;
         }
 
         Block block = getBlockByNumber(startNumber);

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/Eth62.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/Eth62.java
@@ -641,7 +641,7 @@ public class Eth62 extends EthHandler {
         return response.getBlockBodies().size() <= sentHeaders.size();
     }
 
-    private boolean isValid(BlockHeadersMessage response, GetBlockHeadersMessageWrapper requestWrapper) {
+    protected boolean isValid(BlockHeadersMessage response, GetBlockHeadersMessageWrapper requestWrapper) {
 
         GetBlockHeadersMessage request = requestWrapper.getMessage();
         List<BlockHeader> headers = response.getBlockHeaders();
@@ -685,22 +685,16 @@ public class Eth62 extends EthHandler {
         BlockHeader first = headers.get(0);
 
         if (request.getBlockHash() != null) {
+            if (!Arrays.equals(request.getBlockHash(), first.getHash())) {
 
-            if (request.getSkipBlocks() == 0) {
-                if (!Arrays.equals(request.getBlockHash(), first.getHash())) {
-
-                    if (logger.isInfoEnabled()) logger.info(
-                            "Peer {}: invalid response to {}, first header is invalid {}",
-                            channel.getPeerIdShort(), request, first
-                    );
-                    return false;
-                }
+                if (logger.isInfoEnabled()) logger.info(
+                        "Peer {}: invalid response to {}, first header is invalid {}",
+                        channel.getPeerIdShort(), request, first
+                );
+                return false;
             }
-
         } else {
-
-            long expectedNum = request.getBlockNumber() + request.getSkipBlocks();
-            if (expectedNum != first.getNumber()) {
+            if (request.getBlockNumber() != first.getNumber()) {
 
                 if (logger.isInfoEnabled()) logger.info(
                         "Peer {}: invalid response to {}, first header is invalid {}",
@@ -714,56 +708,40 @@ public class Eth62 extends EthHandler {
         if (requestWrapper.isNewHashesHandling()) return true;
 
         // numbers and ancestors
-        if (request.isReverse()) {
+        int offset = 1 + request.getSkipBlocks();
+        if (request.isReverse()) offset = -offset;
 
-            for (int i = 1; i < headers.size(); i++) {
+        for (int i = 1; i < headers.size(); i++) {
 
-                BlockHeader cur = headers.get(i);
-                BlockHeader prev = headers.get(i - 1);
+            BlockHeader cur = headers.get(i);
+            BlockHeader prev = headers.get(i - 1);
 
-                long num = cur.getNumber();
-                long expectedNum = prev.getNumber() - 1;
+            long num = cur.getNumber();
+            long expectedNum = prev.getNumber() + offset;
 
-                if (num != expectedNum) {
-                    if (logger.isInfoEnabled()) logger.info(
-                            "Peer {}: invalid response to {}, got #{}, expected #{}",
-                            channel.getPeerIdShort(), request, num, expectedNum
-                    );
-                    return false;
-                }
-
-                if (!Arrays.equals(prev.getParentHash(), cur.getHash())) {
-                    if (logger.isInfoEnabled()) logger.info(
-                            "Peer {}: invalid response to {}, got parent hash {} for #{}, expected {}",
-                            channel.getPeerIdShort(), request, toHexString(prev.getParentHash()),
-                            prev.getNumber(), toHexString(cur.getHash())
-                            );
-                    return false;
-                }
+            if (num != expectedNum) {
+                if (logger.isInfoEnabled()) logger.info(
+                        "Peer {}: invalid response to {}, got #{}, expected #{}",
+                        channel.getPeerIdShort(), request, num, expectedNum
+                );
+                return false;
             }
-        } else {
 
-            for (int i = 1; i < headers.size(); i++) {
-
-                BlockHeader cur = headers.get(i);
-                BlockHeader prev = headers.get(i - 1);
-
-                long num = cur.getNumber();
-                long expectedNum = prev.getNumber() + 1;
-
-                if (num != expectedNum) {
-                    if (logger.isInfoEnabled()) logger.info(
-                            "Peer {}: invalid response to {}, got #{}, expected #{}",
-                            channel.getPeerIdShort(), request, num, expectedNum
-                    );
-                    return false;
+            if (request.getSkipBlocks() == 0) {
+                BlockHeader parent;
+                BlockHeader child;
+                if (request.isReverse()) {
+                    parent = cur;
+                    child = prev;
+                } else {
+                    parent = prev;
+                    child = cur;
                 }
-
-                if (!Arrays.equals(cur.getParentHash(), prev.getHash())) {
+                if (!Arrays.equals(child.getParentHash(), parent.getHash())) {
                     if (logger.isInfoEnabled()) logger.info(
                             "Peer {}: invalid response to {}, got parent hash {} for #{}, expected {}",
-                            channel.getPeerIdShort(), request, toHexString(cur.getParentHash()),
-                            cur.getNumber(), toHexString(prev.getHash())
+                            channel.getPeerIdShort(), request, toHexString(child.getParentHash()),
+                            prev.getNumber(), toHexString(parent.getHash())
                     );
                     return false;
                 }

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/message/GetBlockHeadersMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/message/GetBlockHeadersMessage.java
@@ -39,7 +39,7 @@ public class GetBlockHeadersMessage extends EthMessage {
     private int maxHeaders;
 
     /**
-     * The number of skipped blocks starting from initial block. <br>
+     * Blocks to skip between consecutive headers. <br>
      * Direction depends on {@code reverse} param.
      */
     private int skipBlocks;

--- a/ethereumj-core/src/test/java/org/ethereum/core/BlockchainGetHeadersTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/BlockchainGetHeadersTest.java
@@ -1,0 +1,160 @@
+package org.ethereum.core;
+
+import org.ethereum.db.BlockStoreDummy;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Testing {@link BlockchainImpl#getListOfHeadersStartFrom(BlockIdentifier, int, int, boolean)}
+ */
+public class BlockchainGetHeadersTest {
+
+    private class BlockStoreMock extends BlockStoreDummy {
+
+        private List<Block> dummyBlocks = new ArrayList<>();
+
+        public BlockStoreMock() {
+            byte [] emptyArray = new byte[0];
+            byte [] recentHash = emptyArray;
+
+            for (long i = 0; i < 10; ++i) {
+                BlockHeader blockHeader = new BlockHeader(recentHash, emptyArray, emptyArray, emptyArray, emptyArray,
+                        i, emptyArray, 0L, 0L, emptyArray, emptyArray, emptyArray);
+                recentHash = blockHeader.getHash();
+                Block block = new Block(blockHeader, new ArrayList<Transaction>(), new ArrayList<BlockHeader>());
+                dummyBlocks.add(block);
+            }
+        }
+
+        @Override
+        public Block getBlockByHash(byte[] hash) {
+            for (Block block: dummyBlocks) {
+                if (Arrays.equals(block.getHash(), hash)) {
+                    return block;
+                }
+            }
+
+            return null;
+        }
+
+        @Override
+        public Block getChainBlockByNumber(long blockNumber) {
+            return blockNumber < dummyBlocks.size() ? dummyBlocks.get((int) blockNumber) : null;
+        }
+
+        @Override
+        public List<BlockHeader> getListHeadersEndWith(byte[] hash, long qty) {
+            List<BlockHeader> headers = new ArrayList<>();
+            Block start = getBlockByHash(hash);
+            if (start != null) {
+                long i = start.getNumber();
+                while (i >= 0 && headers.size() < qty) {
+                    headers.add(getChainBlockByNumber(i).getHeader());
+                    --i;
+                }
+            }
+
+            return headers;
+        }
+    }
+
+
+    private class BlockchainImplTester extends BlockchainImpl {
+
+        public BlockchainImplTester() {
+            blockStore = new BlockStoreMock();
+            setBestBlock(blockStore.getChainBlockByNumber(9));
+        }
+    }
+
+
+    private BlockchainImpl blockchain;
+
+    public BlockchainGetHeadersTest() {
+        blockchain = new BlockchainImplTester();
+    }
+
+    @Test
+    public void singleHeader() {
+        // Get by number
+        long blockNumber = 2L;
+        BlockIdentifier identifier = new BlockIdentifier(null, blockNumber);
+        List<BlockHeader> headers = blockchain.getListOfHeadersStartFrom(identifier, 0, 1, false);
+
+        assert headers.size() == 1;
+        assert headers.get(0).getNumber() == blockNumber;
+
+        // Get by hash
+        byte[] hash = headers.get(0).getHash();
+        BlockIdentifier hashIdentifier = new BlockIdentifier(hash, 0L);
+        List<BlockHeader> headersByHash = blockchain.getListOfHeadersStartFrom(hashIdentifier, 0, 1, false);
+
+        assert headersByHash.size() == 1;
+        assert headersByHash.get(0).getNumber() == blockNumber;
+
+        // Reverse doesn't matter for single block
+        List<BlockHeader> headersReverse = blockchain.getListOfHeadersStartFrom(hashIdentifier, 0, 1, true);
+        assert headersReverse.size() == 1;
+        assert headersReverse.get(0).getNumber() == blockNumber;
+
+        // Skip doesn't matter for single block
+        List<BlockHeader> headersSkip = blockchain.getListOfHeadersStartFrom(hashIdentifier, 15, 1, false);
+        assert headersReverse.size() == 1;
+        assert headersReverse.get(0).getNumber() == blockNumber;
+    }
+
+    @Test
+    public void continuousHeaders() {
+        // Get by number
+        long blockNumber = 2L;
+        BlockIdentifier identifier = new BlockIdentifier(null, blockNumber);
+        List<BlockHeader> headers = blockchain.getListOfHeadersStartFrom(identifier, 0, 3, false);
+
+        assert headers.size() == 3;
+        assert headers.get(0).getNumber() == blockNumber;
+        assert headers.get(1).getNumber() == blockNumber + 1;
+        assert headers.get(2).getNumber() == blockNumber + 2;
+
+        List<BlockHeader> headersReverse = blockchain.getListOfHeadersStartFrom(identifier, 0, 3, true);
+        assert headersReverse.size() == 3;
+        assert headersReverse.get(0).getNumber() == blockNumber;
+        assert headersReverse.get(1).getNumber() == blockNumber - 1;
+        assert headersReverse.get(2).getNumber() == blockNumber - 2;
+
+        // Requesting more than we have
+        BlockIdentifier identifierMore = new BlockIdentifier(null, 8L);
+        List<BlockHeader> headersMore = blockchain.getListOfHeadersStartFrom(identifierMore, 0, 3, false);
+        assert headersMore.size() == 2;
+        assert headersMore.get(0).getNumber() == 8L;
+        assert headersMore.get(1).getNumber() == 9L;
+    }
+
+    @Test
+    public void gapedHeaders() {
+        int skip = 2;
+        BlockIdentifier identifier = new BlockIdentifier(null, 2L);
+        List<BlockHeader> headers = blockchain.getListOfHeadersStartFrom(identifier, skip, 3, false);
+
+        assert headers.size() == 3;
+        assert headers.get(0).getNumber() == 2L;
+        assert headers.get(1).getNumber() == 5L; // 2, [3, 4], 5 - skipping []
+        assert headers.get(2).getNumber() == 8L; // 5, [6, 7], 8 - skipping []
+
+        // Same for reverse
+        BlockIdentifier identifierReverse = new BlockIdentifier(null, 8L);
+        List<BlockHeader> headersReverse = blockchain.getListOfHeadersStartFrom(identifierReverse, skip, 3, true);
+        assert headersReverse.size() == 3;
+        assert headersReverse.get(0).getNumber() == 8L;
+        assert headersReverse.get(1).getNumber() == 5L;
+        assert headersReverse.get(2).getNumber() == 2L;
+
+        // Requesting more than we have
+        BlockIdentifier identifierMore = new BlockIdentifier(null, 8L);
+        List<BlockHeader> headersMore = blockchain.getListOfHeadersStartFrom(identifierMore, skip, 3, false);
+        assert headersMore.size() == 1;
+        assert headersMore.get(0).getNumber() == 8L;
+    }
+}

--- a/ethereumj-core/src/test/java/org/ethereum/net/handler/HeaderMessageValidationTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/handler/HeaderMessageValidationTest.java
@@ -1,0 +1,137 @@
+package org.ethereum.net.handler;
+
+import org.ethereum.core.BlockHeader;
+import org.ethereum.net.eth.handler.Eth62;
+import org.ethereum.net.eth.handler.GetBlockHeadersMessageWrapper;
+import org.ethereum.net.eth.message.BlockHeadersMessage;
+import org.ethereum.net.eth.message.GetBlockHeadersMessage;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Testing {@link org.ethereum.net.eth.handler.Eth62#isValid(BlockHeadersMessage, GetBlockHeadersMessageWrapper)}
+ */
+public class HeaderMessageValidationTest {
+
+    private byte[] EMPTY_ARRAY = new byte[0];
+
+    private class Eth62Tester extends Eth62 {
+
+        boolean blockHeaderMessageValid(BlockHeadersMessage msg, GetBlockHeadersMessageWrapper request) {
+            return super.isValid(msg, request);
+        }
+    }
+
+    private Eth62Tester ethHandler;
+
+    public HeaderMessageValidationTest() {
+        ethHandler = new Eth62Tester();
+    }
+
+
+    @Test
+    public void testSingleBlockResponse() {
+        long blockNumber = 0L;
+        BlockHeader blockHeader = new BlockHeader(new byte[] {11, 12}, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY,
+                EMPTY_ARRAY, blockNumber, EMPTY_ARRAY, 1L, 2L, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY);
+        List<BlockHeader> blockHeaders = new ArrayList<>();
+        blockHeaders.add(blockHeader);
+        BlockHeadersMessage msg = new BlockHeadersMessage(blockHeaders);
+
+        byte[] hash = blockHeader.getHash();
+        // Block number doesn't matter when hash is provided in request
+        GetBlockHeadersMessage requestHash = new GetBlockHeadersMessage(123L, hash, 1, 0, false);
+        GetBlockHeadersMessageWrapper wrapperHash = new GetBlockHeadersMessageWrapper(requestHash);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperHash);
+
+        // Getting same with block number request
+        GetBlockHeadersMessage requestNumber = new GetBlockHeadersMessage(blockNumber, null, 1, 0, false);
+        GetBlockHeadersMessageWrapper wrapperNumber = new GetBlockHeadersMessageWrapper(requestNumber);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperNumber);
+
+        // Getting same with reverse request
+        GetBlockHeadersMessage requestReverse = new GetBlockHeadersMessage(blockNumber, null, 1, 0, true);
+        GetBlockHeadersMessageWrapper wrapperReverse = new GetBlockHeadersMessageWrapper(requestReverse);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperReverse);
+
+        // Getting same with skip request
+        GetBlockHeadersMessage requestSkip = new GetBlockHeadersMessage(blockNumber, null, 1, 10, false);
+        GetBlockHeadersMessageWrapper wrapperSkip = new GetBlockHeadersMessageWrapper(requestSkip);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperSkip);
+    }
+
+    @Test
+    public void testFewBlocksNoSkip() {
+        List<BlockHeader> blockHeaders = new ArrayList<>();
+
+        long blockNumber1 = 0L;
+        BlockHeader blockHeader1 = new BlockHeader(new byte[] {11, 12}, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY,
+                EMPTY_ARRAY, blockNumber1, EMPTY_ARRAY, 1L, 2L, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY);
+        byte[] hash1 = blockHeader1.getHash();
+        blockHeaders.add(blockHeader1);
+
+        long blockNumber2 = 1L;
+        BlockHeader blockHeader2 = new BlockHeader(hash1, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY,
+                EMPTY_ARRAY, blockNumber2, EMPTY_ARRAY, 1L, 2L, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY);
+        byte[] hash2 = blockHeader2.getHash();
+        blockHeaders.add(blockHeader2);
+
+        BlockHeadersMessage msg = new BlockHeadersMessage(blockHeaders);
+
+        // Block number doesn't matter when hash is provided in request
+        GetBlockHeadersMessage requestHash = new GetBlockHeadersMessage(123L, hash1, 2, 0, false);
+        GetBlockHeadersMessageWrapper wrapperHash = new GetBlockHeadersMessageWrapper(requestHash);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperHash);
+
+        // Getting same with block number request
+        GetBlockHeadersMessage requestNumber = new GetBlockHeadersMessage(blockNumber1, null, 2, 0, false);
+        GetBlockHeadersMessageWrapper wrapperNumber = new GetBlockHeadersMessageWrapper(requestNumber);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperNumber);
+
+        // Reverse list
+        Collections.reverse(blockHeaders);
+        GetBlockHeadersMessage requestReverse = new GetBlockHeadersMessage(blockNumber2, null, 2, 0, true);
+        GetBlockHeadersMessageWrapper wrapperReverse = new GetBlockHeadersMessageWrapper(requestReverse);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperReverse);
+    }
+
+    @Test
+    public void testFewBlocksWithSkip() {
+        List<BlockHeader> blockHeaders = new ArrayList<>();
+
+        long blockNumber1 = 0L;
+        BlockHeader blockHeader1 = new BlockHeader(new byte[] {11, 12}, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY,
+                EMPTY_ARRAY, blockNumber1, EMPTY_ARRAY, 1L, 2L, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY);
+        blockHeaders.add(blockHeader1);
+
+        long blockNumber2 = 16L;
+        BlockHeader blockHeader2 = new BlockHeader(new byte[] {12, 13}, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY,
+                EMPTY_ARRAY, blockNumber2, EMPTY_ARRAY, 1L, 2L, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY);
+        blockHeaders.add(blockHeader2);
+
+        long blockNumber3 = 32L;
+        BlockHeader blockHeader3 = new BlockHeader(new byte[] {14, 15}, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY,
+                EMPTY_ARRAY, blockNumber3, EMPTY_ARRAY, 1L, 2L, EMPTY_ARRAY, EMPTY_ARRAY, EMPTY_ARRAY);
+        blockHeaders.add(blockHeader3);
+
+        BlockHeadersMessage msg = new BlockHeadersMessage(blockHeaders);
+
+        GetBlockHeadersMessage requestNumber = new GetBlockHeadersMessage(blockNumber1, null, 3, 15, false);
+        GetBlockHeadersMessageWrapper wrapperNumber = new GetBlockHeadersMessageWrapper(requestNumber);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperNumber);
+
+        // Requesting more than we have
+        GetBlockHeadersMessage requestMore = new GetBlockHeadersMessage(blockNumber1, null, 4, 15, false);
+        GetBlockHeadersMessageWrapper wrapperMore = new GetBlockHeadersMessageWrapper(requestMore);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperMore);
+
+        // Reverse list
+        Collections.reverse(blockHeaders);
+        GetBlockHeadersMessage requestReverse = new GetBlockHeadersMessage(blockNumber3, null, 3, 15, true);
+        GetBlockHeadersMessageWrapper wrapperReverse = new GetBlockHeadersMessageWrapper(requestReverse);
+        assert ethHandler.blockHeaderMessageValid(msg, wrapperReverse);
+    }
+}


### PR DESCRIPTION
Actually Geth tries to return something for hash not from the main chain but:
- From [Wire Protocol descirption](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol):
`beginning at block block (denoted by either number or hash) in the canonical chain`
- Every header from not main chain will violate protocol description
- Moving towards leafs could be a random challenge
- Currently we throw out hash and return part of canonical chain, so first block of response and request hash doesn't match
- It's allowed to return blocks less than requested