### PR TITLE
use correct time in EDT warning

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/EventDispatchThread.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/EventDispatchThread.java
@@ -57,8 +57,8 @@ public class EventDispatchThread {
                     r.run();
                     long t = (System.nanoTime() - s) / 1_000_000;
                     if (t > 1000) {
-                        logger.warn("EDT task executed in more than 1 sec: " + r + " ms, " + this +
-                        ". Executor queue size: " + executorQueue.size());
+                        logger.warn("EDT task executed in more than 1 sec: " + t + "ms, " +
+                        "Executor queue size: " + executorQueue.size());
 
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
Here's one example of the log line before this commit's changes:

`[EDT] WARN  blockchain - EDT task executed in more than 1 sec: org.ethereum.listener.CompositeEthereumListener$2@78ef929a ms, org.ethereum.core.EventDispatchThread$3@11c0bd3e. Executor queue size: 141`

Now we print out more useful information about how long it took to complete the task.