### PR TITLE
add totalDifficulty property to Block

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/Block.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Block.java
@@ -46,6 +46,8 @@ public class Block {
 
     private Trie txsState;
 
+    private BigInteger totalDifficulty; // summed difficulty of this block and all its ancestors
+
 
     /* Constructors */
 
@@ -213,6 +215,22 @@ public class Block {
             calcDifficulty = calcDifficulty.add(new BigInteger(1, uncle.getDifficulty()));
         }
         return calcDifficulty;
+    }
+
+    /**
+     * Returns the summed difficulty of this block plus all the difficulty of all of its ancestors up to and
+     * including the genesis block
+     * @return BigInteger holding the block's totalDifficulty
+     */
+    public BigInteger getTotalDifficulty() {
+        return this.totalDifficulty;
+    }
+
+    /**
+     * Set the sum of the difficulty of this block and all of its ancestors up to and including the genesis block
+     */
+    public void setTotalDifficulty(BigInteger totalDifficulty) {
+        this.totalDifficulty = totalDifficulty;
     }
 
     public long getTimestamp() {

--- a/ethereumj-core/src/test/java/org/ethereum/core/BlockTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/BlockTest.java
@@ -175,4 +175,16 @@ public class BlockTest {
     }
 
 
+    @Test
+    public void testBlockTotalDifficulty() {
+        // create genesis block
+        SystemProperties.getDefault().setGenesisInfo("frontier.json");
+        Block genesis = GenesisLoader.loadGenesis(SystemProperties.getDefault(), getClass().getClassLoader());
+
+        genesis.setTotalDifficulty(BigInteger.ONE);
+        assertEquals(BigInteger.ONE, genesis.getTotalDifficulty());
+
+        genesis.setTotalDifficulty(BigInteger.valueOf(10)); // overwrite existing total difficulty
+        assertEquals(BigInteger.valueOf(10), genesis.getTotalDifficulty());
+    }
 }


### PR DESCRIPTION
`totalDifficulty` exists on the BlockSummary which is passed to the `onBlock()` callback, but not on the BlockSummary's Block object. In many cases it is easier to work with and pass via function calls the Block object rather than the more hefty BlockSummary, but Block doesn't have a totalDifficulty associated with it. This is useful for when you're trying to compare two blocks to see which one is the best block (i.e. which one has greater total difficulty).

This PR adds `totalDifficulty` as a gettable and settable property on the Block so totalDifficulty can easily be passed through various functions in apps that use the ethereumJ library.