### PR TITLE
add getter for blockstore on Blockchain interface

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -311,6 +311,7 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         return repository;
     }
 
+    @Override
     public BlockStore getBlockStore() {
         return blockStore;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/facade/Blockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/Blockchain.java
@@ -2,6 +2,7 @@ package org.ethereum.facade;
 
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
+import org.ethereum.db.BlockStore;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -30,6 +31,13 @@ public interface Blockchain {
      * @return - total difficulty
      */
     BigInteger getTotalDifficulty();
+
+    /**
+     * Get the underlying BlockStore
+     * @return
+     */
+    BlockStore getBlockStore();
+
 
     /**
      * @return - last added block from blockchain


### PR DESCRIPTION
We want access to the Ethereum object's underlying blockstore so we can query for information stored in levelDB (in particular, we want to get the totalDifficulty of a block given a blockhash). Adding this getter to the `Blockchain` interface allows us to make a call like

BigInteger blockTotalDifficulty = `ethereum.getBlockchain().getBlockStore().getTotalDifficultyForHash(ethJBlock.getHash());`

