### PR TITLE
Skip test when SunEC security provider doesn't exists. Happens on Ope…

### DIFF
--- a/ethereumj-core/src/test/java/org/ethereum/crypto/ECKeyTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/crypto/ECKeyTest.java
@@ -281,7 +281,12 @@ public class ECKeyTest {
 
     @Test
     public void testSunECRoundTrip() throws Exception {
-        testProviderRoundTrip(Security.getProvider("SunEC"));
+        Provider provider = Security.getProvider("SunEC");
+        if (provider != null) {
+            testProviderRoundTrip(provider);
+        } else {
+            System.out.println("Skip test as provider doesn't exist. Must be OpenJDK 1.7 which ships without 'SunEC'");
+        }
     }
 
     @Test


### PR DESCRIPTION
To resolve #552. Tested on Ubuntu 15 OpenJDK 1.7