### PR TITLE
Remove locking possibility of eth handler by blockchainImpl

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -1093,6 +1093,7 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
 
     /**
      * Returns up to limit headers found with following search parameters
+     * [Synchronized only in blockstore, not using any synchronized BlockchainImpl methods]
      * @param identifier        Identifier of start block, by number of by hash
      * @param skip              Number of blocks to skip between consecutive headers
      * @param limit             Maximum number of headers in return
@@ -1100,14 +1101,14 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
      * @return  {@link BlockHeader}'s list or empty list if none found
      */
     @Override
-    public synchronized List<BlockHeader> getListOfHeadersStartFrom(BlockIdentifier identifier, int skip, int limit, boolean reverse) {
+    public List<BlockHeader> getListOfHeadersStartFrom(BlockIdentifier identifier, int skip, int limit, boolean reverse) {
 
         // Identifying block we'll move from
         Block startBlock;
         if (identifier.getHash() != null) {
-            startBlock = getBlockByHash(identifier.getHash());
+            startBlock = blockStore.getBlockByHash(identifier.getHash());
         } else {
-            startBlock = getBlockByNumber(identifier.getNumber());
+            startBlock = blockStore.getChainBlockByNumber(identifier.getNumber());
         }
 
         // If nothing found or provided hash is not on main chain, return empty array
@@ -1115,13 +1116,13 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
             return emptyList();
         }
         if (identifier.getHash() != null) {
-            Block mainChainBlock = getBlockByNumber(startBlock.getNumber());
+            Block mainChainBlock = blockStore.getChainBlockByNumber(startBlock.getNumber());
             if (!startBlock.equals(mainChainBlock)) return emptyList();
         }
 
         List<BlockHeader> headers;
         if (skip == 0) {
-            long bestNumber = bestBlock.getNumber();
+            long bestNumber = blockStore.getBestBlock().getNumber();
             headers = getContinuousHeaders(bestNumber, startBlock.getNumber(), limit, reverse);
         } else {
             headers = getGapedHeaders(startBlock, skip, limit, reverse);
@@ -1208,7 +1209,7 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
             startNumber = blockNumber + qty - 1;
         }
 
-        Block block = getBlockByNumber(startNumber);
+        Block block = blockStore.getChainBlockByNumber(startNumber);
 
         if (block == null) {
             return null;
@@ -1217,8 +1218,14 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         return block.getHash();
     }
 
+    /**
+     * Returns list of block bodies by block hashes, stopping on first not found block
+     * [Synchronized only in blockstore, not using any synchronized BlockchainImpl methods]
+     * @param hashes List of hashes
+     * @return List of RLP encoded block bodies
+     */
     @Override
-    public synchronized List<byte[]> getListOfBodiesByHashes(List<byte[]> hashes) {
+    public List<byte[]> getListOfBodiesByHashes(List<byte[]> hashes) {
         List<byte[]> bodies = new ArrayList<>(hashes.size());
 
         for (byte[] hash : hashes) {

--- a/ethereumj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -51,7 +51,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
         }).withCacheSize(256);
     }
 
-    public Block getBestBlock(){
+    public synchronized Block getBestBlock(){
 
         Long maxLevel = getMaxNumber();
         if (maxLevel < 0) return null;
@@ -71,7 +71,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
         return bestBlock;
     }
 
-    public byte[] getBlockHashByNumber(long blockNumber){
+    public synchronized byte[] getBlockHashByNumber(long blockNumber){
         Block chainBlock = getChainBlockByNumber(blockNumber);
         return chainBlock == null ? null : chainBlock.getHash(); // FIXME: can be improved by accessing the hash directly in the index
     }
@@ -91,7 +91,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
 
 
     @Override
-    public void saveBlock(Block block, BigInteger cummDifficulty, boolean mainChain){
+    public synchronized void saveBlock(Block block, BigInteger cummDifficulty, boolean mainChain){
         addInternalBlock(block, cummDifficulty, mainChain);
     }
 
@@ -133,7 +133,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
     @Override
-    public Block getChainBlockByNumber(long number){
+    public synchronized Block getChainBlockByNumber(long number){
         if (number >= index.size()){
             return null;
         }
@@ -179,8 +179,8 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
 
-        @Override
-    public BigInteger getTotalDifficulty(){
+    @Override
+    public synchronized BigInteger getTotalDifficulty(){
         long maxNumber = getMaxNumber();
 
         List<BlockInfo> blockInfos = index.get((int) maxNumber);
@@ -203,7 +203,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
     @Override
-    public long getMaxNumber(){
+    public synchronized long getMaxNumber(){
 
         Long bestIndex = 0L;
 
@@ -263,7 +263,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
     @Override
-    public void reBranch(Block forkBlock){
+    public synchronized void reBranch(Block forkBlock){
 
         Block bestBlock = getBestBlock();
 

--- a/ethereumj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -78,7 +78,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
 
 
     @Override
-    public void flush(){
+    public synchronized void flush(){
         blocks.flush();
         index.flush();
         if (blocksDS instanceof Flushable) {
@@ -112,7 +112,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
 
-    public List<Block> getBlocksByNumber(long number){
+    public synchronized List<Block> getBlocksByNumber(long number){
 
         List<Block> result = new ArrayList<>();
 
@@ -153,18 +153,18 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
     @Override
-    public Block getBlockByHash(byte[] hash) {
+    public synchronized Block getBlockByHash(byte[] hash) {
         return blocks.get(hash);
     }
 
     @Override
-    public boolean isBlockExist(byte[] hash) {
+    public synchronized boolean isBlockExist(byte[] hash) {
         return blocks.get(hash) != null;
     }
 
 
     @Override
-    public BigInteger getTotalDifficultyForHash(byte[] hash){
+    public synchronized BigInteger getTotalDifficultyForHash(byte[] hash){
         Block block = this.getBlockByHash(hash);
         if (block == null) return ZERO;
 
@@ -215,7 +215,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
     @Override
-    public List<byte[]> getListHashesEndWith(byte[] hash, long number){
+    public synchronized List<byte[]> getListHashesEndWith(byte[] hash, long number){
 
         List<Block> blocks = getListBlocksEndWith(hash, number);
         List<byte[]> hashes = new ArrayList<>(blocks.size());
@@ -228,7 +228,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
     @Override
-    public List<BlockHeader> getListHeadersEndWith(byte[] hash, long qty) {
+    public synchronized List<BlockHeader> getListHeadersEndWith(byte[] hash, long qty) {
 
         List<Block> blocks = getListBlocksEndWith(hash, qty);
         List<BlockHeader> headers = new ArrayList<>(blocks.size());
@@ -241,7 +241,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
     @Override
-    public List<Block> getListBlocksEndWith(byte[] hash, long qty) {
+    public synchronized List<Block> getListBlocksEndWith(byte[] hash, long qty) {
         return getListBlocksEndWithInner(hash, qty);
     }
 
@@ -330,7 +330,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
 
-    public List<byte[]> getListHashesStartWith(long number, long maxBlocks){
+    public synchronized List<byte[]> getListHashesStartWith(long number, long maxBlocks){
 
         List<byte[]> result = new ArrayList<>();
 
@@ -412,7 +412,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
     };
 
 
-    public void printChain(){
+    public synchronized void printChain(){
 
         Long number = getMaxNumber();
 
@@ -434,11 +434,11 @@ public class IndexedBlockStore extends AbstractBlockstore{
 
     }
 
-    private List<BlockInfo> getBlockInfoForLevel(long level){
+    private synchronized List<BlockInfo> getBlockInfoForLevel(long level){
         return index.get((int) level);
     }
 
-    private void setBlockInfoForLevel(long level, List<BlockInfo> infos){
+    private synchronized void setBlockInfoForLevel(long level, List<BlockInfo> infos){
         index.set((int) level, infos);
     }
 
@@ -451,11 +451,11 @@ public class IndexedBlockStore extends AbstractBlockstore{
     }
 
     @Override
-    public void load() {
+    public synchronized void load() {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         logger.info("Closing IndexedBlockStore...");
         try {
             indexDS.close();

--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/Eth62.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/Eth62.java
@@ -145,7 +145,8 @@ public class Eth62 extends EthHandler {
         int networkId = config.networkId();
 
         BigInteger totalDifficulty = blockchain.getTotalDifficulty();
-        byte[] bestHash = blockchain.getBestBlockHash();
+        // Getting it from blockstore, not blocked by blockchain sync
+        byte[] bestHash = blockstore.getBestBlock().getHash();
         StatusMessage msg = new StatusMessage(protocolVersion, networkId,
                 ByteUtil.bigIntegerToBytes(totalDifficulty), bestHash, config.getGenesis().getHash());
         sendMessage(msg);

--- a/ethereumj-core/src/test/java/org/ethereum/core/BlockchainGetHeadersTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/BlockchainGetHeadersTest.java
@@ -59,6 +59,11 @@ public class BlockchainGetHeadersTest {
 
             return headers;
         }
+
+        @Override
+        public Block getBestBlock() {
+            return dummyBlocks.get(dummyBlocks.size() - 1);
+        }
     }
 
 

--- a/ethereumj-core/src/test/java/org/ethereum/net/eth/handler/LockBlockchainTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/eth/handler/LockBlockchainTest.java
@@ -1,0 +1,216 @@
+package org.ethereum.net.eth.handler;
+
+import org.ethereum.config.NoAutoscan;
+import org.ethereum.config.SystemProperties;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Blockchain;
+import org.ethereum.core.BlockchainImpl;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.BlockStoreDummy;
+import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.net.eth.message.EthMessage;
+import org.ethereum.net.eth.message.GetBlockBodiesMessage;
+import org.ethereum.net.eth.message.GetBlockHeadersMessage;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Testing whether Eth handler {@link Eth62} is blocking {@link BlockchainImpl}
+ */
+@Ignore
+public class LockBlockchainTest {
+
+    private final AtomicBoolean result = new AtomicBoolean();
+    private Blockchain blockchain;
+
+    private final static long DELAY = 1000;  //Default delay in ms
+    private final static String BLOCK_RLP = "f901f8f901f3a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a09178d0f23c965d81f0834a4c72c6253ce6830f4022b1359aaebfc1ecba442d4ea056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008302000080832fefd8808080a0000000000000000000000000000000000000000000000000000000000000000088000000000000002ac0c0";
+
+    public LockBlockchainTest() {
+
+        SysPropConfig1.props.overrideParams(
+                "peer.listen.port", "30334",
+                "peer.privateKey", "3ec771c31cac8c0dba77a69e503765701d3c2bb62435888d4ffa38fed60c445c",
+                "genesis", "genesis-light.json",
+                "database.dir", "testDB-1");
+
+        final BlockStore blockStoreDummy = new BlockStoreDummy() {
+            @Override
+            public synchronized Block getChainBlockByNumber(long blockNumber) {
+                return super.getChainBlockByNumber(blockNumber);
+            }
+
+            @Override
+            public synchronized List<BlockHeader> getListHeadersEndWith(byte[] hash, long qty) {
+                return super.getListHeadersEndWith(hash, qty);
+            }
+
+            @Override
+            public synchronized Block getBestBlock() {
+                return new Block(Hex.decode(BLOCK_RLP));
+            }
+        };
+
+        this.blockchain = new BlockchainImpl(SysPropConfig1.props) {
+            @Override
+            public synchronized boolean isBlockExist(byte[] hash) {
+                try {
+                    this.blockStore = blockStoreDummy;
+                    Thread.sleep(100000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                return true;
+            }
+        };
+
+        SysPropConfig1.testHandler = new Eth62(SysPropConfig1.props, blockchain, new CompositeEthereumListener()) {
+            @Override
+            public synchronized void sendStatus() {
+                this.blockstore = blockStoreDummy;
+                super.sendStatus();
+            }
+
+            @Override
+            protected void sendMessage(EthMessage message) {
+                result.set(true);
+                System.out.println("Mocking message sending...");
+            }
+        };
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        result.set(false);
+    }
+
+    @Configuration
+    @NoAutoscan
+    public static class SysPropConfig1 {
+        static Eth62 testHandler = null;
+
+        @Bean
+        @Scope("prototype")
+        public Eth62 eth62() {
+            return testHandler;
+        }
+
+        static SystemProperties props = new SystemProperties();
+
+        @Bean
+        public SystemProperties systemProperties() {
+            return props;
+        }
+    }
+
+    @Test
+    public synchronized void testHeadersWithoutSkip() throws FileNotFoundException, InterruptedException {
+        ExecutorService executor1 = Executors.newSingleThreadExecutor();
+        executor1.submit(new Runnable() {
+                             @Override
+                             public void run() {
+                                 blockchain.isBlockExist(null);
+                             }
+                         }
+        );
+        this.wait(DELAY);
+        ExecutorService executor2 = Executors.newSingleThreadExecutor();
+        executor2.submit(new Runnable() {
+                             @Override
+                             public void run() {
+                                 GetBlockHeadersMessage msg = new GetBlockHeadersMessage(1L, new byte[0], 10, 0, false);
+                                 SysPropConfig1.testHandler.processGetBlockHeaders(msg);
+                             }
+                         }
+        );
+        this.wait(DELAY);
+        assert result.get();
+    }
+
+    @Test
+    public synchronized void testHeadersWithSkip() throws FileNotFoundException, InterruptedException {
+        ExecutorService executor1 = Executors.newSingleThreadExecutor();
+        executor1.submit(new Runnable() {
+                             @Override
+                             public void run() {
+                                 blockchain.isBlockExist(null);
+                             }
+                         }
+        );
+        this.wait(DELAY);
+        ExecutorService executor2 = Executors.newSingleThreadExecutor();
+        executor2.submit(new Runnable() {
+                             @Override
+                             public void run() {
+                                 GetBlockHeadersMessage msg = new GetBlockHeadersMessage(1L, new byte[0], 10, 5, false);
+                                 SysPropConfig1.testHandler.processGetBlockHeaders(msg);
+                             }
+                         }
+        );
+        this.wait(DELAY);
+        assert result.get();
+    }
+
+    @Test
+    public synchronized void testBodies() throws FileNotFoundException, InterruptedException {
+        ExecutorService executor1 = Executors.newSingleThreadExecutor();
+        executor1.submit(new Runnable() {
+                             @Override
+                             public void run() {
+                                 blockchain.isBlockExist(null);
+                             }
+                         }
+        );
+        this.wait(DELAY);
+        ExecutorService executor2 = Executors.newSingleThreadExecutor();
+        executor2.submit(new Runnable() {
+                             @Override
+                             public void run() {
+                                 List<byte[]> hashes = new ArrayList<>();
+                                 hashes.add(new byte[] {1, 2, 3});
+                                 hashes.add(new byte[] {4, 5, 6});
+                                 GetBlockBodiesMessage msg = new GetBlockBodiesMessage(hashes);
+                                 SysPropConfig1.testHandler.processGetBlockBodies(msg);
+                             }
+                         }
+        );
+        this.wait(DELAY);
+        assert result.get();
+    }
+
+    @Test
+    public synchronized void testStatus() throws FileNotFoundException, InterruptedException {
+        ExecutorService executor1 = Executors.newSingleThreadExecutor();
+        executor1.submit(new Runnable() {
+                             @Override
+                             public void run() {
+                                 blockchain.isBlockExist(null);
+                             }
+                         }
+        );
+        this.wait(DELAY);
+        ExecutorService executor2 = Executors.newSingleThreadExecutor();
+        executor2.submit(new Runnable() {
+                             @Override
+                             public void run() {
+                                 SysPropConfig1.testHandler.sendStatus();
+                             }
+                         }
+        );
+        this.wait(DELAY);
+        assert result.get();
+    }
+}


### PR DESCRIPTION
It's fix for #406 
I had not moved synchronized methods, Eth handler was using to Blockstore, because there are a lot of not "storing" logic in them, I think this approach is better.
Also I'm not sure I did correct with synchronized in BlockStore. Marked all methods that are reading and writing changing objects.
