### PR TITLE
Other disconnect reasons penalized more than TOO_MANY_PEERS

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeStatistics.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeStatistics.java
@@ -133,9 +133,9 @@ public class NodeStatistics {
                 if (rlpxLastRemoteDisconnectReason == ReasonCode.TOO_MANY_PEERS) {
                     // The peer is popular, but we were unlucky
                     rlpxReput *= 0.3;
-                } else {
+                } else if (rlpxLastRemoteDisconnectReason != ReasonCode.REQUESTED) {
                     // other disconnect reasons
-                    rlpxReput *= 0.5;
+                    rlpxReput *= 0.2;
                 }
             }
         }


### PR DESCRIPTION
According to yesterdays feedback:
- penalize more for other reasons. I've excluded REQUESTED because it looks not harmful, matching even EthereumJ with itself (same for Parity and Geth)
- I've added randomness in getBestEthNodes and tests for it, but from several runs it looks worse than current setup - 9 minutes for first 100k blocks comparing with 6 min. currently, checked it on several runs, so reverted it