### PR TITLE
Feature/337 remove fake info in discovery

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -49,7 +49,7 @@ public class HandshakeHandler extends ByteToMessageDecoder {
     private static final Logger loggerNet = LoggerFactory.getLogger("net");
 
     private FrameCodec frameCodec;
-    private ECKey myKey;
+    private final ECKey myKey;
     private byte[] nodeId;
     private byte[] remoteId;
     private EncryptionHandshake handshake;
@@ -227,7 +227,6 @@ public class HandshakeHandler extends ByteToMessageDecoder {
 
                 this.remoteId = new byte[compressed.length - 1];
                 System.arraycopy(compressed, 1, this.remoteId, 0, this.remoteId.length);
-                channel.setNode(remoteId);
 
                 final ByteBuf byteBufMsg = ctx.alloc().buffer(responsePacket.length);
                 byteBufMsg.writeBytes(responsePacket);
@@ -251,15 +250,16 @@ public class HandshakeHandler extends ByteToMessageDecoder {
                     throw new RuntimeException("The message type is not HELLO or DISCONNECT: " + message);
                 }
 
-                HelloMessage inboundHelloMessage = (HelloMessage) message;
+                final HelloMessage inboundHelloMessage = (HelloMessage) message;
+                channel.setNode(remoteId, inboundHelloMessage.getListenPort());
 
                 // Secret authentication finish here
                 channel.sendHelloMessage(ctx, frameCodec, Hex.toHexString(nodeId), inboundHelloMessage);
                 isHandshakeDone = true;
                 this.channel.publicRLPxHandshakeFinished(ctx, frameCodec, inboundHelloMessage);
+                channel.getNodeStatistics().rlpxInHello.add();
             }
         }
-        channel.getNodeStatistics().rlpxInHello.add();
     }
 
     private byte[] readEIP8Packet(ByteBuf buffer, byte[] plainPacket) {
@@ -286,14 +286,6 @@ public class HandshakeHandler extends ByteToMessageDecoder {
     public void setRemoteId(String remoteId, Channel channel){
         this.remoteId = Hex.decode(remoteId);
         this.channel = channel;
-    }
-
-    /**
-     * Generate random Key (and thus NodeID) per channel for 'anonymous'
-     * connection (e.g. for peer discovery)
-     */
-    public void generateTempKey() {
-        myKey = new ECKey();
     }
 
     public byte[] getRemoteId() {

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/Node.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/Node.java
@@ -9,8 +9,10 @@ import org.mapdb.Serializer;
 import org.spongycastle.util.encoders.Hex;
 
 import java.io.*;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -135,13 +137,14 @@ public class Node implements Serializable {
     }
 
     public byte[] getRLP() {
-        String[] ipArray = host.split("\\.");
-        byte[] host = new byte[4];
-        for (int i = 0; i < ipArray.length; i++) {
-            host[i] = (byte) (Integer.parseInt(ipArray[i]) | 0x00);
+        byte[] ip;
+        try {
+            ip = InetAddress.getByName(host).getAddress();
+        } catch (UnknownHostException e) {
+            ip = new byte[4];  // fall back to invalid 0.0.0.0 address
         }
 
-        byte[] rlphost = RLP.encodeElement(host);
+        byte[] rlphost = RLP.encodeElement(ip);
         byte[] rlpTCPPort = RLP.encodeInt(port);
         byte[] rlpUDPPort = RLP.encodeInt(port);
         byte[] rlpId = RLP.encodeElement(id);

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/Node.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/Node.java
@@ -135,8 +135,13 @@ public class Node implements Serializable {
     }
 
     public byte[] getRLP() {
+        String[] ipArray = host.split("\\.");
+        byte[] host = new byte[4];
+        for (int i = 0; i < ipArray.length; i++) {
+            host[i] = (byte) (Integer.parseInt(ipArray[i]) | 0x00);
+        }
 
-        byte[] rlphost = RLP.encodeElement(host.getBytes(StandardCharsets.UTF_8));
+        byte[] rlphost = RLP.encodeElement(host);
         byte[] rlpTCPPort = RLP.encodeInt(port);
         byte[] rlpUDPPort = RLP.encodeInt(port);
         byte[] rlpId = RLP.encodeElement(id);

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/Channel.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/Channel.java
@@ -216,9 +216,13 @@ public class Channel {
         return nodeStatistics;
     }
 
-    public void setNode(byte[] nodeId) {
-        node = new Node(nodeId, inetSocketAddress.getHostString(), inetSocketAddress.getPort());
+    public void setNode(byte[] nodeId, int remotePort) {
+        node = new Node(nodeId, inetSocketAddress.getHostString(), remotePort);
         nodeStatistics = nodeManager.getNodeStatistics(node);
+    }
+
+    public void setNode(byte[] nodeId) {
+        setNode(nodeId, inetSocketAddress.getPort());
     }
 
     public Node getNode() {

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/Channel.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/Channel.java
@@ -112,7 +112,7 @@ public class Channel {
         if (discoveryMode) {
             // temporary key/nodeId to not accidentally smear our reputation with
             // unexpected disconnect
-            handshakeHandler.generateTempKey();
+//            handshakeHandler.generateTempKey();
         }
 
         handshakeHandler.setRemoteId(remoteId, this);
@@ -156,20 +156,15 @@ public class Channel {
     public void sendHelloMessage(ChannelHandlerContext ctx, FrameCodec frameCodec, String nodeId,
                                  HelloMessage inboundHelloMessage) throws IOException, InterruptedException {
 
-        // in discovery mode we are supplying fake port along with fake nodeID to not receive
-        // incoming connections with fake public key
-        HelloMessage helloMessage = discoveryMode ? staticMessages.createHelloMessage(nodeId, 9) :
-                staticMessages.createHelloMessage(nodeId);
+        final HelloMessage helloMessage = staticMessages.createHelloMessage(nodeId);
 
         if (inboundHelloMessage != null && P2pHandler.isProtocolVersionSupported(inboundHelloMessage.getP2PVersion())) {
             // the p2p version can be downgraded if requested by peer and supported by us
             helloMessage.setP2pVersion(inboundHelloMessage.getP2PVersion());
         }
 
-        byte[] payload = helloMessage.getEncoded();
-
         ByteBuf byteBufMsg = ctx.alloc().buffer();
-        frameCodec.writeFrame(new FrameCodec.Frame(helloMessage.getCode(), payload), byteBufMsg);
+        frameCodec.writeFrame(new FrameCodec.Frame(helloMessage.getCode(), helloMessage.getEncoded()), byteBufMsg);
         ctx.writeAndFlush(byteBufMsg).sync();
 
         if (logger.isDebugEnabled())

--- a/ethereumj-core/src/main/java/org/ethereum/samples/PrivateNetworkDiscoverySample.java
+++ b/ethereumj-core/src/main/java/org/ethereum/samples/PrivateNetworkDiscoverySample.java
@@ -1,0 +1,209 @@
+package org.ethereum.samples;
+
+import com.google.common.base.Joiner;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueFactory;
+import org.ethereum.config.SystemProperties;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.facade.EthereumFactory;
+import org.ethereum.net.rlpx.discover.NodeManager;
+import org.ethereum.net.rlpx.discover.table.NodeEntry;
+import org.ethereum.net.server.Channel;
+import org.ethereum.net.server.ChannelManager;
+import org.spongycastle.util.encoders.Hex;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Testing peers discovery.
+ *
+ * The sample creates a small private net with three peers:
+ *  - first is point for discovery;
+ *  - two other ones will connect to first.
+ *
+ * Peers run on same IP 127.0.0.1 and are different by ports.
+ *
+ * After some time all peers should find each other. We use `peer.discovery.ip.list` config
+ * option to point to discovery peer.
+ *
+ * Created by Stan Reshetnyk on 06.10.2016.
+ */
+public class PrivateNetworkDiscoverySample {
+
+    /**
+     *  Creating 3 instances with different config classes
+     */
+    public static void main(String[] args) throws Exception {
+        BasicSample.sLogger.info("Starting main node to which others will connect to");
+        EthereumFactory.createEthereum(Node0Config.class);
+
+        BasicSample.sLogger.info("Starting regular instance 1!");
+        EthereumFactory.createEthereum(Node1Config.class);
+
+        BasicSample.sLogger.info("Starting regular instance 2!");
+        EthereumFactory.createEthereum(Node2Config.class);
+    }
+
+
+    /**
+     * Spring configuration class for the Regular peer
+     */
+    private static class RegularConfig {
+
+        private final String discoveryNode;
+
+        private final int nodeIndex;
+
+        public RegularConfig(int nodeIndex, String discoveryNode) {
+            this.nodeIndex = nodeIndex;
+            this.discoveryNode = discoveryNode;
+        }
+
+        @Bean
+        public BasicSample node() {
+            return new BasicSample("sampleNode-" + nodeIndex) {
+
+                @Autowired
+                ChannelManager channelManager;
+
+                @Autowired
+                NodeManager nodeManager;
+
+                {
+                    new Thread(new Runnable() {
+
+                        @Override
+                        public void run() {
+                            try {
+                                Thread.sleep(5000);
+                                while (true) {
+                                    if (logger != null) {
+                                        Thread.sleep(5000);
+                                        if (channelManager != null) {
+                                            final Collection<Channel> activePeers = channelManager.getActivePeers();
+                                            final ArrayList<String> ports = new ArrayList<>();
+                                            for (Channel channel: activePeers) {
+                                                ports.add(channel.getInetSocketAddress().getHostName() + ":" + channel.getInetSocketAddress().getPort());
+                                            }
+
+                                            final Collection<NodeEntry> nodes = nodeManager.getTable().getAllNodes();
+                                            final ArrayList<String> nodesString = new ArrayList<>();
+                                            for (NodeEntry node: nodes) {
+                                                nodesString.add(node.getNode().getHost() + ":" + node.getNode().getPort() + "@" + node.getNode().getHexId().substring(0, 6) );
+                                            }
+
+                                            logger.info("channelManager.getActivePeers() " + activePeers.size() + " " + Joiner.on(", ").join(ports));
+                                            logger.info("nodeManager.getTable().getAllNodes() " + nodesString.size() + " " + Joiner.on(", ").join(nodesString));
+                                        } else {
+                                            logger.info("Channel manager is null");
+                                        }
+                                    } else {
+                                        System.err.println("Logger is null for " + nodeIndex);
+                                    }
+                                }
+                            } catch (Exception e) {
+                                logger.error("Error checking peers count: ", e);
+                            }
+                        }
+                    }).start();
+                }
+
+
+                @Override
+                public void onSyncDone() {
+                    logger.info("onSyncDone");
+
+
+                }
+            };
+        }
+
+        /**
+         * Instead of supplying properties via config file for the peer
+         * we are substituting the corresponding bean which returns required
+         * config for this instance.
+         */
+        @Bean
+        public SystemProperties systemProperties() {
+            return new SystemProperties(getConfig(nodeIndex, discoveryNode));
+        }
+    }
+
+    public static class Node0Config extends RegularConfig {
+
+        public Node0Config() {
+            super(0, null);
+        }
+
+        @Bean
+        public SystemProperties systemProperties() {
+            return super.systemProperties();
+        }
+
+        @Bean
+        public BasicSample node() {
+            return super.node();
+        }
+    }
+
+    private static class Node1Config extends RegularConfig {
+
+        public Node1Config() {
+            super(1, "127.0.0.1:20000");
+        }
+
+        @Bean
+        public SystemProperties systemProperties() {
+            return super.systemProperties();
+        }
+
+        @Bean
+        public BasicSample node() {
+            return super.node();
+        }
+    }
+
+    private static class Node2Config extends RegularConfig{
+
+        public Node2Config() {
+            super(2, "127.0.0.1:20000");
+        }
+
+        @Bean
+        public SystemProperties systemProperties() {
+            return super.systemProperties();
+        }
+
+        @Bean
+        public BasicSample node() {
+            return super.node();
+        }
+    }
+
+    private static Config getConfig(int index, String discoveryNode) {
+        return ConfigFactory.empty()
+                .withValue("peer.discovery.enabled", value(true))
+                .withValue("peer.discovery.external.ip", value("127.0.0.1"))
+                .withValue("peer.discovery.bind.ip", value("127.0.0.1"))
+                .withValue("peer.discovery.persist", value("false"))
+
+                .withValue("peer.listen.port", value(20000 + index))
+                .withValue("peer.privateKey", value(Hex.toHexString(ECKey.fromPrivate(("" + index).getBytes()).getPrivKeyBytes())))
+                .withValue("peer.networkId", value(555))
+                .withValue("sync.enabled", value(true))
+                .withValue("database.incompatibleDatabaseBehavior", value("RESET"))
+                .withValue("genesis", value("sample-genesis.json"))
+                .withValue("database.dir", value("sampleDB-" + index))
+                .withValue("peer.discovery.ip.list", value(discoveryNode != null ? Arrays.asList(discoveryNode) : Arrays.asList()));
+    }
+
+    private static ConfigValue value(Object value) {
+        return ConfigValueFactory.fromAnyRef(value);
+    }
+}

--- a/ethereumj-core/src/main/java/org/ethereum/sync/SyncPool.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/SyncPool.java
@@ -163,6 +163,7 @@ public class SyncPool {
         if(lackSize <= 0) return;
 
         Set<String> nodesInUse = nodesInUse();
+        nodesInUse.add(Hex.toHexString(config.nodeId()));   // exclude home node
 
         List<NodeHandler> newNodes = nodeManager.getBestEthNodes(nodesInUse, lowerUsefulDifficulty, lackSize);
         if (lackSize > 0 && newNodes.isEmpty()) {

--- a/ethereumj-core/src/test/java/org/ethereum/net/rlpx/RLPXTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/rlpx/RLPXTest.java
@@ -132,7 +132,6 @@ public class RLPXTest {
     }
 
 
-    @Ignore
     @Test
     public void test6() {
 


### PR DESCRIPTION
To resolve #337 
 - fixed Node rlps encoding + test;
 - using proper remote port for incoming connections;
 - removed fake nodeId and wrong port during discovery;
 - added sample class with 3 peers in same JVM, interacting with each other.