### PR TITLE
Handle correctly discovery endpoint with fake nodeId

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -73,7 +73,7 @@ public class HandshakeHandler extends ByteToMessageDecoder {
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         channel.setInetSocketAddress((InetSocketAddress) ctx.channel().remoteAddress());
         if (remoteId.length == 64) {
-            channel.setNode(remoteId);
+            channel.initWithNode(remoteId);
             initiate(ctx);
         } else {
             handshake = new EncryptionHandshake();
@@ -255,9 +255,10 @@ public class HandshakeHandler extends ByteToMessageDecoder {
                 }
 
                 final HelloMessage inboundHelloMessage = (HelloMessage) message;
-                channel.setNode(remoteId, inboundHelloMessage.getListenPort());
-                // use node into discovery
-                nodeManager.getNodeHandler(channel.getNode());
+
+                // now we know both remote nodeId and port
+                // let's set node, that will cause registering node in NodeManager
+                channel.initWithNode(remoteId, inboundHelloMessage.getListenPort());
 
                 // Secret authentication finish here
                 channel.sendHelloMessage(ctx, frameCodec, Hex.toHexString(nodeId), inboundHelloMessage);

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -12,6 +12,7 @@ import org.ethereum.net.p2p.DisconnectMessage;
 import org.ethereum.net.p2p.HelloMessage;
 import org.ethereum.net.p2p.P2pMessageCodes;
 import org.ethereum.net.p2p.P2pMessageFactory;
+import org.ethereum.net.rlpx.discover.NodeManager;
 import org.ethereum.net.server.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,11 +58,14 @@ public class HandshakeHandler extends ByteToMessageDecoder {
     private Channel channel;
     private boolean isHandshakeDone;
 
-    private SystemProperties config;
+    private final SystemProperties config;
+    private final NodeManager nodeManager;
 
     @Autowired
-    public HandshakeHandler(final SystemProperties config) {
+    public HandshakeHandler(final SystemProperties config, final NodeManager nodeManager) {
         this.config = config;
+        this.nodeManager = nodeManager;
+
         myKey = config.getMyKey();
     }
 
@@ -252,6 +256,8 @@ public class HandshakeHandler extends ByteToMessageDecoder {
 
                 final HelloMessage inboundHelloMessage = (HelloMessage) message;
                 channel.setNode(remoteId, inboundHelloMessage.getListenPort());
+                // use node into discovery
+                nodeManager.getNodeHandler(channel.getNode());
 
                 // Secret authentication finish here
                 channel.sendHelloMessage(ctx, frameCodec, Hex.toHexString(nodeId), inboundHelloMessage);

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/Node.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/Node.java
@@ -1,5 +1,6 @@
 package org.ethereum.net.rlpx;
 
+import com.google.common.base.Strings;
 import org.ethereum.datasource.mapdb.Serializers;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.RLP;
@@ -13,13 +14,14 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.ethereum.util.ByteUtil.byteArrayToInt;
 
 public class Node implements Serializable {
     private static final long serialVersionUID = -4267600517925770636L;
+
+    public static final String DISCOVERY_NODE_PREFIX = Strings.repeat("0", 128);
 
     public static final Serializer<Node> MapDBSerializer = new Serializer<Node>() {
         @Override
@@ -101,6 +103,14 @@ public class Node implements Serializable {
         this.host = host;
         this.port = port;
         this.id = idB;
+    }
+
+    /**
+     * @return true if this node is endpoint for discovery loaded from config
+     */
+    public boolean isDiscoveryNode() {
+        // discovery node has nodeId with doubled size
+        return id.length > 64;
     }
 
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
@@ -140,38 +140,41 @@ public class NodeHandler {
             // will wait for Pong to assume this alive
             sendPing();
         }
-        if (newState == State.Alive) {
-            Node evictCandidate = nodeManager.table.addNode(this.node);
-            if (evictCandidate == null) {
-                newState = State.Active;
-            } else {
-                NodeHandler evictHandler = nodeManager.getNodeHandler(evictCandidate);
-                if (evictHandler.state != State.EvictCandidate) {
-                    evictHandler.challengeWith(this);
+        if (!node.isDiscoveryNode()) {
+            if (newState == State.Alive) {
+                Node evictCandidate = nodeManager.table.addNode(this.node);
+                if (evictCandidate == null) {
+                    newState = State.Active;
+                } else {
+                    NodeHandler evictHandler = nodeManager.getNodeHandler(evictCandidate);
+                    if (evictHandler.state != State.EvictCandidate) {
+                        evictHandler.challengeWith(this);
+                    }
                 }
             }
-        }
-        if (newState == State.Active) {
-            if (oldState == State.Alive) {
-                // new node won the challenge
-                nodeManager.table.addNode(node);
-            } else if (oldState == State.EvictCandidate) {
-                // nothing to do here the node is already in the table
-            } else {
-                // wrong state transition
+            if (newState == State.Active) {
+                if (oldState == State.Alive) {
+                    // new node won the challenge
+                    nodeManager.table.addNode(node);
+                } else if (oldState == State.EvictCandidate) {
+                    // nothing to do here the node is already in the table
+                } else {
+                    // wrong state transition
+                }
             }
-        }
-        if (newState == State.NonActive) {
-            if (oldState == State.EvictCandidate) {
-                // lost the challenge
-                // Removing ourselves from the table
-                nodeManager.table.dropNode(node);
-                // Congratulate the winner
-                replaceCandidate.changeState(State.Active);
-            } else if (oldState == State.Alive) {
-                // ok the old node was better, nothing to do here
-            } else {
-                // wrong state transition
+
+            if (newState == State.NonActive) {
+                if (oldState == State.EvictCandidate) {
+                    // lost the challenge
+                    // Removing ourselves from the table
+                    nodeManager.table.dropNode(node);
+                    // Congratulate the winner
+                    replaceCandidate.changeState(State.Active);
+                } else if (oldState == State.Alive) {
+                    // ok the old node was better, nothing to do here
+                } else {
+                    // wrong state transition
+                }
             }
         }
 
@@ -223,6 +226,8 @@ public class NodeHandler {
 //        logMessage(" ===> [FIND_NODE] " + this);
         getNodeStatistics().discoverInFind.add();
         List<Node> closest = nodeManager.table.getClosestNodes(msg.getTarget());
+        closest.add(nodeManager.homeNode);
+
         sendNeighbours(closest);
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -207,13 +207,13 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
                 ethereumListener.onNodeDiscovered(ret.getNode());
             }
         } else if (ret.getNode().isDiscoveryNode() && !n.isDiscoveryNode()) {
-            // if we found discovery node with same host:port,
-            // then replace node with correct nodeId
+            // we found discovery node with same host:port,
+            // replace node with correct nodeId
             ret.node = n;
             if (!n.getHexId().equals(homeNode.getHexId())) {
                 ethereumListener.onNodeDiscovered(ret.getNode());
             }
-            logger.debug("Found real nodeId for discovery endpoint {}", n);
+            logger.debug(" +++ Found real nodeId for discovery endpoint {}", n);
         }
 
         return ret;

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -54,8 +54,8 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
 
     NodeTable table;
     private Map<String, NodeHandler> nodeHandlerMap = new HashMap<>();
-    ECKey key;
-    Node homeNode;
+    final ECKey key;
+    final Node homeNode;
     private List<Node> bootNodes;
 
     // option to handle inbounds only from known peers (i.e. which were discovered by ourselves)
@@ -195,16 +195,27 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
         return (addr == null ? address.getHostString() : addr.getHostAddress()) + ":" + address.getPort();
     }
 
-    synchronized  NodeHandler getNodeHandler(Node n) {
+    public synchronized NodeHandler getNodeHandler(Node n) {
         String key = getKey(n);
         NodeHandler ret = nodeHandlerMap.get(key);
         if (ret == null) {
             trimTable();
             ret = new NodeHandler(n ,this);
             nodeHandlerMap.put(key, ret);
-            logger.debug(" +++ New node: " + ret);
-            ethereumListener.onNodeDiscovered(ret.getNode());
+            logger.debug(" +++ New node: " + ret + " " + n);
+            if (!n.isDiscoveryNode() && !n.getHexId().equals(homeNode.getHexId())) {
+                ethereumListener.onNodeDiscovered(ret.getNode());
+            }
+        } else if (ret.getNode().isDiscoveryNode() && !n.isDiscoveryNode()) {
+            // if we found discovery node with same host:port,
+            // then replace node with correct nodeId
+            ret.node = n;
+            if (!n.getHexId().equals(homeNode.getHexId())) {
+                ethereumListener.onNodeDiscovered(ret.getNode());
+            }
+            logger.debug("Found real nodeId for discovery endpoint {}", n);
         }
+
         return ret;
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/PeerConnectionTester.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/PeerConnectionTester.java
@@ -112,7 +112,9 @@ public class PeerConnectionTester {
     }
 
     public void nodeStatusChanged(final NodeHandler nodeHandler) {
-        if (connectedCandidates.size() < NodeManager.MAX_NODES && !connectedCandidates.containsKey(nodeHandler)) {
+        if (connectedCandidates.size() < NodeManager.MAX_NODES
+                && !connectedCandidates.containsKey(nodeHandler)
+                && !nodeHandler.getNode().isDiscoveryNode()) {
             logger.debug("Submitting node for RLPx connection : " + nodeHandler);
             connectedCandidates.put(nodeHandler, null);
             peerConnectionPool.execute(new ConnectTask(nodeHandler));

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/UDPListener.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/UDPListener.java
@@ -90,8 +90,9 @@ public class UDPListener {
 
         for (String boot: args) {
             // since discover IP list has no NodeIds we will generate random but persistent
-            byte[] nodeId = ECKey.fromPrivate(sha3(boot.getBytes())).getNodeId();
-            bootNodes.add(new Node("enode://" + Hex.toHexString(nodeId) + "@" + boot));
+            final ECKey generatedNodeKey = ECKey.fromPrivate(sha3(boot.getBytes()));
+            final String generatedNodeId = Node.DISCOVERY_NODE_PREFIX + Hex.toHexString(generatedNodeKey.getNodeId());
+            bootNodes.add(new Node("enode://" + generatedNodeId + "@" + boot));
         }
 
         nodeManager.setBootNodes(bootNodes);

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/UDPListener.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/UDPListener.java
@@ -90,9 +90,7 @@ public class UDPListener {
 
         for (String boot: args) {
             // since discover IP list has no NodeIds we will generate random but persistent
-            final ECKey generatedNodeKey = ECKey.fromPrivate(sha3(boot.getBytes()));
-            final String generatedNodeId = Node.DISCOVERY_NODE_PREFIX + Hex.toHexString(generatedNodeKey.getNodeId());
-            bootNodes.add(new Node("enode://" + generatedNodeId + "@" + boot));
+            bootNodes.add(Node.createWithoutId(boot));
         }
 
         nodeManager.setBootNodes(bootNodes);

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/table/NodeTable.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/table/NodeTable.java
@@ -130,7 +130,9 @@ public class NodeTable {
         }
 
         for (NodeEntry e : closestEntries) {
-            closestNodes.add(e.getNode());
+            if (!e.getNode().isDiscoveryNode()) {
+                closestNodes.add(e.getNode());
+            }
         }
         return closestNodes;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/Channel.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/Channel.java
@@ -216,13 +216,16 @@ public class Channel {
         return nodeStatistics;
     }
 
-    public void setNode(byte[] nodeId, int remotePort) {
+    /**
+     * Set node and register it in NodeManager if it is not registered yet.
+     */
+    public void initWithNode(byte[] nodeId, int remotePort) {
         node = new Node(nodeId, inetSocketAddress.getHostString(), remotePort);
         nodeStatistics = nodeManager.getNodeStatistics(node);
     }
 
-    public void setNode(byte[] nodeId) {
-        setNode(nodeId, inetSocketAddress.getPort());
+    public void initWithNode(byte[] nodeId) {
+        initWithNode(nodeId, inetSocketAddress.getPort());
     }
 
     public Node getNode() {

--- a/ethereumj-core/src/main/java/org/ethereum/samples/BasicSample.java
+++ b/ethereumj-core/src/main/java/org/ethereum/samples/BasicSample.java
@@ -167,7 +167,7 @@ public class BasicSample implements Runnable {
     protected void waitForDiscovery() throws Exception {
         logger.info("Waiting for nodes discovery...");
 
-        int bootNodes = config.peerDiscoveryIPList().size() + 1; // +1: home node
+        int bootNodes = config.peerDiscoveryIPList().size();
         int cnt = 0;
         while(true) {
             Thread.sleep(cnt < 30 ? 300 : 5000);

--- a/ethereumj-core/src/main/java/org/ethereum/samples/PrivateNetworkDiscoverySample.java
+++ b/ethereumj-core/src/main/java/org/ethereum/samples/PrivateNetworkDiscoverySample.java
@@ -84,7 +84,7 @@ public class PrivateNetworkDiscoverySample {
                                 Thread.sleep(5000);
                                 while (true) {
                                     if (logger != null) {
-                                        Thread.sleep(5000);
+                                        Thread.sleep(15000);
                                         if (channelManager != null) {
                                             final Collection<Channel> activePeers = channelManager.getActivePeers();
                                             final ArrayList<String> ports = new ArrayList<>();


### PR DESCRIPTION
To resolve #567 with changes:
 - we have special handling for discovery endpoints nodes.  They are not stored in all nodes table and are not used for TCP connections;
 - discovery endpoint node could become normal node once we receive it's real nodeId via discovery;
 - home node is always included to NEIGHBORS response in discovery;
 - we don't dispatch home node via `ethereumListener.onNodeDiscovered()`