### PR TITLE
Not closing peer discovery db if not initialized

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -429,11 +429,14 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
         } catch (Exception e) {
             logger.warn("Problems canceling logStatsTimer", e);
         }
-        try {
-            logger.info("Closing discovery DB...");
-            db.close();
-        } catch (Throwable e) {
-            logger.warn("Problems closing db", e);
+        // if persistence is disabled, then don't try to close the db
+        if (db != null) {
+            try {
+                logger.info("Closing discovery DB...");
+                db.close();
+            } catch (Throwable e) {
+                logger.warn("Problems closing db", e);
+            }
         }
     }
 


### PR DESCRIPTION
Is PERSIST is not configured for peer discovery, then the db is never created, so this close is guaranteed to throw an NPE on shutdown