### PR TITLE
Small speedup for the self-destruct attack

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/db/DetailsDataStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/DetailsDataStore.java
@@ -72,7 +72,10 @@ public class DetailsDataStore {
 
             if (removes.contains(wrappedKey)) return null;
             byte[] data = detailsDS.get(key);
-            if (data == null) return null;
+            if (data == null) {
+                removes.add(wrappedKey); // keeps it from being looked up again next time
+                return null;
+            }
 
             ContractDetailsImpl detailsImpl = commonConfig.contractDetailsImpl();
             detailsImpl.setDataSource(storageDSPrune);

--- a/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
@@ -1,7 +1,6 @@
 package org.ethereum.util.blockchain;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.ethereum.config.CommonConfig;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.core.genesis.GenesisLoader;
@@ -47,6 +46,7 @@ public class StandaloneBlockchain implements LocalBlockchain {
     long gasLimit;
     boolean autoBlock;
     long dbDelay = 0;
+    long totalDbHits = 0;
     List<Pair<byte[], BigInteger>> initialBallances = new ArrayList<>();
     int blockGasIncreasePercent = 0;
     private HashMapDB detailsDS;
@@ -373,6 +373,10 @@ public class StandaloneBlockchain implements LocalBlockchain {
         return storageDS;
     }
 
+    public long getTotalDbHits() {
+        return totalDbHits;
+    }
+
     private BlockchainImpl createBlockchain(Genesis genesis) {
         IndexedBlockStore blockStore = new IndexedBlockStore();
         blockStore.init(new SlowHashMapDB(), new SlowHashMapDB());
@@ -586,6 +590,7 @@ public class StandaloneBlockchain implements LocalBlockchain {
 
      class SlowHashMapDB extends HashMapDB {
         private void sleep(int cnt) {
+            totalDbHits += cnt;
             if (dbDelay == 0) return;
             try {
                 Thread.sleep(dbDelay * cnt);

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -499,7 +499,6 @@ public class ImportLightTest {
         String stateRoot = Hex.toHexString(bc.getBlockchain().getRepository().getRoot());
         Assert.assertEquals("82d5bdb6531e26011521da5601481c9dbef326aa18385f2945fd77bee288ca31", stateRoot);
         Object av = a.callConstFunction("a")[0];
-        System.out.println("bc.getTotalDbHits() = " + bc.getTotalDbHits());
         assert BigInteger.valueOf(2).equals(av);
         assert bc.getTotalDbHits() < 8300; // reduce this assertion if you make further optimizations
     }

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -470,7 +470,7 @@ public class ImportLightTest {
         assert BigInteger.valueOf(1).equals(bv);
     }
 
-    @Test(timeout = 120000)
+    @Test()
     public void selfdestructAttack() throws Exception {
         String contractSrc = "" +
                 "contract B {" +
@@ -491,7 +491,7 @@ public class ImportLightTest {
 
         StandaloneBlockchain bc = new StandaloneBlockchain()
                 .withGasLimit(1_000_000_000L)
-                .withDbDelay(5);
+                .withDbDelay(0);
         SolidityContract a = bc.submitNewContract(contractSrc, "A");
         bc.createBlock();
         a.callFunction("f");
@@ -499,7 +499,9 @@ public class ImportLightTest {
         String stateRoot = Hex.toHexString(bc.getBlockchain().getRepository().getRoot());
         Assert.assertEquals("82d5bdb6531e26011521da5601481c9dbef326aa18385f2945fd77bee288ca31", stateRoot);
         Object av = a.callConstFunction("a")[0];
+        System.out.println("bc.getTotalDbHits() = " + bc.getTotalDbHits());
         assert BigInteger.valueOf(2).equals(av);
+        assert bc.getTotalDbHits() < 8300; // reduce this assertion if you make further optimizations
     }
 
     @Test

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -470,6 +470,38 @@ public class ImportLightTest {
         assert BigInteger.valueOf(1).equals(bv);
     }
 
+    @Test(timeout = 120000)
+    public void selfdestructAttack() throws Exception {
+        String contractSrc = "" +
+                "contract B {" +
+                "  function suicide(address benefic) {" +
+                "    selfdestruct(benefic);" +
+                "  }" +
+                "}" +
+                "contract A {" +
+                "  uint public a;" +
+                "  function f() {" +
+                "    B b = new B();" +
+                "    for (uint i = 0; i < 3500; i++) {" +
+                "      b.suicide(address(i));" +
+                "    }" +
+                "    a = 2;" +
+                "  }" +
+                "}";
+
+        StandaloneBlockchain bc = new StandaloneBlockchain()
+                .withGasLimit(1_000_000_000L)
+                .withDbDelay(5);
+        SolidityContract a = bc.submitNewContract(contractSrc, "A");
+        bc.createBlock();
+        a.callFunction("f");
+        bc.createBlock();
+        String stateRoot = Hex.toHexString(bc.getBlockchain().getRepository().getRoot());
+        Assert.assertEquals("82d5bdb6531e26011521da5601481c9dbef326aa18385f2945fd77bee288ca31", stateRoot);
+        Object av = a.callConstFunction("a")[0];
+        assert BigInteger.valueOf(2).equals(av);
+    }
+
     @Test
     @Ignore
     public void threadRacePendingTest() throws Exception {


### PR DESCRIPTION
According to the test below, this change should result in about 25% fewer DB hits during the course of processing the ongoing self-destruct attack.