### PR TITLE
Eip 150 block target fix

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/net/MainNetConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/net/MainNetConfig.java
@@ -15,6 +15,6 @@ public class MainNetConfig extends AbstractNetConfig {
         add(0, new FrontierConfig());
         add(1_150_000, new HomesteadConfig());
         add(1_920_000, new DaoHFConfig());
-        add(2_457_000, new Eip150HFConfig(new DaoHFConfig()));
+        add(2_463_000, new Eip150HFConfig(new DaoHFConfig()));
     }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
@@ -36,7 +36,7 @@ public class GitHubStateTest {
         SystemProperties.getDefault().setBlockchainConfig(new AbstractNetConfig() {{
             add(0, new FrontierConfig());
             add(1_150_000, new HomesteadConfig());
-            add(2_457_000, new Eip150HFConfig(new DaoHFConfig()));
+            add(2_463_000, new Eip150HFConfig(new DaoHFConfig()));
 
         }});
     }


### PR DESCRIPTION
Take into account the additional 6000 block delay introduced to allow for extra testing before hard-fork.