### PR TITLE
Ignore Solidity warnings on compile

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java
@@ -49,14 +49,16 @@ public class SolidityCompiler {
     public static class Result {
         public String errors;
         public String output;
+        private boolean success = false;
 
-        public Result(String errors, String output) {
+        public Result(String errors, String output, boolean success) {
             this.errors = errors;
             this.output = output;
+            this.success = success;
         }
 
         public boolean isFailed() {
-            return isNotBlank(errors);
+            return !success;
         }
     }
 
@@ -143,8 +145,9 @@ public class SolidityCompiler {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+        boolean success = process.exitValue() == 0;
 
-        return new Result(error.getContent(), output.getContent());
+        return new Result(error.getContent(), output.getContent(), success);
     }
 
     public static SolidityCompiler getInstance() {


### PR DESCRIPTION
For Multisig contract https://github.com/ethereum/dapp-bin/blob/master/wallet/wallet.sol
getting no output for embedded EthereumJ solc:
```
~ /private/var/folders/26/zt29ynld52x75drdyz6yz8vc0000gp/T/solc/solc --version
solc, the solidity compiler commandline interface
Version: 0.3.1-c492d9be/RelWithDebInfo-Darwin/appleclang/JIT linked to libethereum-1.2.3-bb12c30a/RelWithDebInfo-Darwin/appleclang/JIT
```
and warnings:
```
<stdin>:349:13: Warning: Return value of low-level calls not used.
           _to.call.value(_value)(_data);
           ^---------------------------^
<stdin>:366:13: Warning: Return value of low-level calls not used.
           m_txs[_h].to.call.value(m_txs[_h].value)(m_txs[_h].data);
           ^------------------------------------------------------^
```
for local solc:
```
~ solc --version
solc, the solidity compiler commandline interface
Version: 0.3.6-0/Release-Darwin/appleclang
```
So if use standard `Result.isFailed()` on this contract, it's failed for second solc executable: 
https://github.com/ethereum/ethereumj/blob/develop/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java#L49-L61

I think we could check exitValue() for the same, but not sure, if it will work on all OSes