### PR TITLE
Feature/498 external miner support

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/CallTransaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/CallTransaction.java
@@ -68,7 +68,7 @@ public class CallTransaction {
         }
     }
 
-    enum FunctionType {
+    public enum FunctionType {
         constructor,
         function,
         event,

--- a/ethereumj-core/src/main/java/org/ethereum/mine/BlockMiner.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/BlockMiner.java
@@ -276,14 +276,6 @@ public class BlockMiner {
      * In success result miner will modify this block instance.
      */
     private Block cloneBlock(Block block) {
-        BlockHeader header = new BlockHeader(
-                block.getParentHash(), block.getUnclesHash(), block.getCoinbase(),
-                block.getLogBloom(), block.getDifficulty(), block.getNumber(),
-                block.getGasLimit(), block.getGasUsed(), block.getTimestamp(),
-                block.getExtraData(), block.getMixHash(), block.getNonce());
-        header.setTransactionsRoot(HashUtil.EMPTY_TRIE_HASH);
-        header.setLogsBloom(block.getLogBloom());
-
         return new Block(block.getEncoded());
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/mine/BlockMiner.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/BlockMiner.java
@@ -206,7 +206,7 @@ public class BlockMiner {
         return ret;
     }
 
-    protected void restartMining() {
+    public Block getNewBlockForMining() {
         Block bestBlockchain = blockchain.getBestBlock();
         Block bestPendingState = ((PendingStateImpl) pendingState).getBestBlock();
 
@@ -215,6 +215,11 @@ public class BlockMiner {
 
         Block newMiningBlock = blockchain.createNewBlock(bestPendingState, getAllPendingTransactions(),
                 getUncles(bestPendingState));
+        return newMiningBlock;
+    }
+
+    protected void restartMining() {
+        Block newMiningBlock = getNewBlockForMining();
 
         synchronized(this) {
             cancelCurrentBlock();
@@ -259,9 +264,19 @@ public class BlockMiner {
         miningBlock = null;
 
         // broadcast the block
-        logger.debug("Importing newly mined block " + newBlock.getShortHash() + " ...");
+        logger.debug("Importing newly mined block {} {} ...", newBlock.getShortHash(), newBlock.getNumber());
         ImportResult importResult = ((EthereumImpl) ethereum).addNewMinedBlock(newBlock);
-        logger.debug("Mined block import result is " + importResult + " : " + newBlock.getShortHash());
+        logger.debug("Mined block import result is " + importResult);
+    }
+
+    public void addMinedBlock(Block newBlock) {
+        logger.info("External miner found solution: {}", newBlock.toString());
+        fireBlockMined(newBlock);
+
+        // broadcast the block
+        logger.debug("Importing newly mined block {} {} ...", newBlock.getShortHash(), newBlock.getNumber());
+        ImportResult importResult = ((EthereumImpl) ethereum).addNewMinedBlock(newBlock);
+        logger.debug("External mined block import result is " + importResult);
     }
 
     public boolean isMining() {

--- a/ethereumj-core/src/main/java/org/ethereum/mine/Ethash.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/Ethash.java
@@ -189,7 +189,7 @@ public class Ethash {
                         sha3(block.getHeader().getEncodedWithoutNonce()),
                         ByteUtil.byteArrayToLong(block.getHeader().getDifficulty()));
                 final Pair<byte[], byte[]> pair = hashimotoLight(block.getHeader(), nonce);
-                return new MiningResult(nonce, pair.getLeft());
+                return updateBlock(nonce, pair.getLeft(), block);
             }
         }).submit();
     }
@@ -217,7 +217,7 @@ public class Ethash {
                         sha3(block.getHeader().getEncodedWithoutNonce()),
                         ByteUtil.byteArrayToLong(block.getHeader().getDifficulty()));
                 final Pair<byte[], byte[]> pair = hashimotoLight(block.getHeader(), nonce);
-                return new MiningResult(nonce, pair.getLeft());
+                return updateBlock(nonce, pair.getLeft(), block);
             }
         }).submit();
     }
@@ -230,6 +230,12 @@ public class Ethash {
         byte[] hash = hashimotoLight(header, header.getNonce()).getRight();
 
         return FastByteComparisons.compareTo(hash, 0, 32, boundary, 0, 32) < 0;
+    }
+
+    private MiningResult updateBlock(long nonce, byte[] digest, Block block) {
+        block.setNonce(longToBytes(nonce));
+        block.setMixHash(digest);
+        return new MiningResult(nonce, digest, block);
     }
 
 

--- a/ethereumj-core/src/main/java/org/ethereum/mine/Ethash.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/Ethash.java
@@ -17,6 +17,7 @@ import java.util.concurrent.*;
 
 import static org.ethereum.crypto.HashUtil.sha3;
 import static org.ethereum.util.ByteUtil.longToBytes;
+import static org.ethereum.mine.MinerIfc.MiningResult;
 
 /**
  * More high level validator/miner class which keeps a cache for the last requested block epoch
@@ -165,7 +166,7 @@ public class Ethash {
                 longToBytes(nonce));
     }
 
-    public ListenableFuture<Long> mine(final Block block) {
+    public ListenableFuture<MiningResult> mine(final Block block) {
         return mine(block, 1);
     }
 
@@ -180,18 +181,20 @@ public class Ethash {
      *  @param nThreads CPU threads to mine on
      *  @return the task which may be cancelled. On success returns nonce
      */
-    public ListenableFuture<Long> mine(final Block block, int nThreads) {
-        return new MineTask(block, nThreads,  new Callable<Long>() {
+    public ListenableFuture<MiningResult> mine(final Block block, int nThreads) {
+        return new MineTask(block, nThreads,  new Callable<MiningResult>() {
             @Override
-            public Long call() throws Exception {
-                return getEthashAlgo().mine(getFullSize(), getFullDataset(),
+            public MiningResult call() throws Exception {
+                long nonce = getEthashAlgo().mine(getFullSize(), getFullDataset(),
                         sha3(block.getHeader().getEncodedWithoutNonce()),
                         ByteUtil.byteArrayToLong(block.getHeader().getDifficulty()));
+                final Pair<byte[], byte[]> pair = hashimotoLight(block.getHeader(), nonce);
+                return new MiningResult(nonce, pair.getLeft());
             }
         }).submit();
     }
 
-    public ListenableFuture<Long> mineLight(final Block block) {
+    public ListenableFuture<MiningResult> mineLight(final Block block) {
         return mineLight(block, 1);
     }
 
@@ -206,13 +209,15 @@ public class Ethash {
      *  @param nThreads CPU threads to mine on
      *  @return the task which may be cancelled. On success returns nonce
      */
-    public ListenableFuture<Long> mineLight(final Block block, int nThreads) {
-        return new MineTask(block, nThreads,  new Callable<Long>() {
+    public ListenableFuture<MiningResult> mineLight(final Block block, int nThreads) {
+        return new MineTask(block, nThreads,  new Callable<MiningResult>() {
             @Override
-            public Long call() throws Exception {
-                return getEthashAlgo().mineLight(getFullSize(), getCacheLight(),
+            public MiningResult call() throws Exception {
+                final long nonce = getEthashAlgo().mineLight(getFullSize(), getCacheLight(),
                         sha3(block.getHeader().getEncodedWithoutNonce()),
                         ByteUtil.byteArrayToLong(block.getHeader().getDifficulty()));
+                final Pair<byte[], byte[]> pair = hashimotoLight(block.getHeader(), nonce);
+                return new MiningResult(nonce, pair.getLeft());
             }
         }).submit();
     }
@@ -227,12 +232,14 @@ public class Ethash {
         return FastByteComparisons.compareTo(hash, 0, 32, boundary, 0, 32) < 0;
     }
 
-    class MineTask extends AnyFuture<Long> {
+
+
+    class MineTask extends AnyFuture<MiningResult> {
         Block block;
         int nThreads;
-        Callable<Long> miner;
+        Callable<MiningResult> miner;
 
-        public MineTask(Block block, int nThreads, Callable<Long> miner) {
+        public MineTask(Block block, int nThreads, Callable<MiningResult> miner) {
             this.block = block;
             this.nThreads = nThreads;
             this.miner = miner;
@@ -240,17 +247,10 @@ public class Ethash {
 
         public MineTask submit() {
             for (int i = 0; i < nThreads; i++) {
-                ListenableFuture<Long> f = executor.submit(miner);
+                ListenableFuture<MiningResult> f = executor.submit(miner);
                 add(f);
             }
             return this;
-        }
-
-        @Override
-        protected void postProcess(Long nonce) {
-            Pair<byte[], byte[]> pair = hashimotoLight(block.getHeader(), nonce);
-            block.setNonce(longToBytes(nonce));
-            block.setMixHash(pair.getLeft());
         }
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/mine/EthashMiner.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/EthashMiner.java
@@ -24,7 +24,7 @@ public class EthashMiner implements MinerIfc {
     }
 
     @Override
-    public ListenableFuture<Long> mine(Block block) {
+    public ListenableFuture<MiningResult> mine(Block block) {
         return fullMining ?
                 Ethash.getForBlock(config, block.getNumber()).mine(block, cpuThreads) :
                 Ethash.getForBlock(config, block.getNumber()).mineLight(block, cpuThreads);

--- a/ethereumj-core/src/main/java/org/ethereum/mine/MinerIfc.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/MinerIfc.java
@@ -1,6 +1,7 @@
 package org.ethereum.mine;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 
@@ -13,13 +14,25 @@ public interface MinerIfc {
 
     /**
      * Starts mining the block. On successful mining the Block is update with necessary nonce and hash.
-     * @return Nonce Future object. The mining can be canceled via this Future. The Future is complete
+     * @return MiningResult Future object. The mining can be canceled via this Future. The Future is complete
      * when the block successfully mined.
      */
-    ListenableFuture<Long> mine(Block block);
+    ListenableFuture<MiningResult> mine(Block block);
 
     /**
      * Validates the Proof of Work for the block
      */
     boolean validate(BlockHeader blockHeader);
+
+    final class MiningResult {
+
+        public final Long nonce;
+
+        public final byte[] digest;
+
+        public MiningResult(Long nonce, byte[] digest) {
+            this.nonce = nonce;
+            this.digest = digest;
+        }
+    }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/mine/MinerIfc.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/MinerIfc.java
@@ -1,9 +1,10 @@
 package org.ethereum.mine;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
+
+import static org.ethereum.util.ByteUtil.longToBytes;
 
 /**
  * Mine algorithm interface
@@ -26,13 +27,19 @@ public interface MinerIfc {
 
     final class MiningResult {
 
-        public final Long nonce;
+        public final long nonce;
 
         public final byte[] digest;
 
-        public MiningResult(Long nonce, byte[] digest) {
+        /**
+         * Mined block
+         */
+        public final Block block;
+
+        public MiningResult(long nonce, byte[] digest, Block block) {
             this.nonce = nonce;
             this.digest = digest;
+            this.block = block;
         }
     }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/miner/EthashTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/miner/EthashTest.java
@@ -8,6 +8,7 @@ import org.ethereum.config.net.MainNetConfig;
 import org.ethereum.core.Block;
 import org.ethereum.mine.Ethash;
 import org.ethereum.mine.EthashAlgo;
+import org.ethereum.mine.MinerIfc;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.FastByteComparisons;
 import org.junit.*;
@@ -195,7 +196,7 @@ public class EthashTest {
 
         System.out.println(b);
 
-        long nonce = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(b).get();
+        long nonce = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(b).get().nonce;
         b.setNonce(longToBytes(nonce));
 
         Assert.assertTrue(Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).validate(b.getHeader()));
@@ -209,7 +210,7 @@ public class EthashTest {
         for (Block b : blocks) {
             b.getHeader().setDifficulty(ByteUtil.intToBytes(100));
             b.setNonce(new byte[0]);
-            long nonce = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(b).get();
+            long nonce = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(b).get().nonce;
             b.setNonce(longToBytes(nonce));
 
             Assert.assertTrue(Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).validate(b.getHeader()));
@@ -224,7 +225,7 @@ public class EthashTest {
         for (Block b : blocks) {
             b.getHeader().setDifficulty(ByteUtil.intToBytes(100));
             b.setNonce(new byte[0]);
-            long nonce = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mine(b).get();
+            long nonce = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mine(b).get().nonce;
             b.setNonce(longToBytes(nonce));
 
             Assert.assertTrue(Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).validate(b.getHeader()));
@@ -242,10 +243,10 @@ public class EthashTest {
 
         // first warming up for the cache to be created
         System.out.println("Warming...");
-        long res = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(b).get();
+        long res = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(b).get().nonce;
 
         System.out.println("Submitting...");
-        Future<Long> light = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(difficultBlock, 8);
+        Future<MinerIfc.MiningResult> light = Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(difficultBlock, 8);
 
         Thread.sleep(200);
 

--- a/ethereumj-core/src/test/java/org/ethereum/miner/ExternalMinerTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/miner/ExternalMinerTest.java
@@ -1,0 +1,81 @@
+package org.ethereum.miner;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.ethereum.config.SystemProperties;
+import org.ethereum.config.blockchain.FrontierConfig;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.ImportResult;
+import org.ethereum.facade.EthereumImpl;
+import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.mine.BlockMiner;
+import org.ethereum.mine.Ethash;
+import org.ethereum.mine.MinerIfc;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.util.blockchain.StandaloneBlockchain;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+import static java.util.Collections.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+/**
+ * Creates an instance
+ */
+public class ExternalMinerTest {
+
+    @Before
+    public void setup() {
+
+    }
+
+    @Test
+    public void externalMiner_shouldWork() throws Exception {
+        SystemProperties.getDefault().setBlockchainConfig(new FrontierConfig(new FrontierConfig.FrontierConstants() {
+            @Override
+            public BigInteger getMINIMUM_DIFFICULTY() {
+                return BigInteger.ONE;
+            }
+        }));
+
+        final StandaloneBlockchain bc = new StandaloneBlockchain().withAutoblock(false);
+
+        final CompositeEthereumListener listener = new CompositeEthereumListener();
+        final BlockMiner blockMiner = new BlockMiner(SystemProperties.getDefault(), listener);
+        blockMiner.blockchain = bc.getBlockchain();
+        blockMiner.blockStore = bc.getBlockchain().getBlockStore();
+        blockMiner.pendingState = bc.getPendingState();
+        blockMiner.ethereum = new EthereumImpl(SystemProperties.getDefault(), listener) {
+            public ImportResult addNewMinedBlock(Block block) {
+                return bc.getBlockchain().tryToConnect(block);
+            }
+        };
+
+        final Block startBestBlock = bc.getBlockchain().getBestBlock();
+
+        final SettableFuture<MinerIfc.MiningResult> futureBlock = SettableFuture.create();
+
+        blockMiner.setExternalMiner(new MinerIfc() {
+            @Override
+            public ListenableFuture<MiningResult> mine(Block block) {
+//                System.out.print("Mining requested");
+                return futureBlock;
+            }
+
+            @Override
+            public boolean validate(BlockHeader blockHeader) {
+                return true;
+            }
+        });
+        Block b = bc.getBlockchain().createNewBlock(startBestBlock, EMPTY_LIST, EMPTY_LIST);
+        Ethash.getForBlock(SystemProperties.getDefault(), b.getNumber()).mineLight(b).get();
+        futureBlock.set(new MinerIfc.MiningResult(ByteUtil.byteArrayToLong(b.getNonce()), b.getMixHash(), b));
+
+        assertThat(bc.getBlockchain().getBestBlock().getNumber(), is(startBestBlock.getNumber() + 1));
+    }
+}


### PR DESCRIPTION
Implemented:
 - as agreed added external miner by implementing `MinerIfc`;
 - changed return type of miner by adding digest to result. `MiningResult` was introduced if we decide to add more return values in future;
 - both external and local miner can work at the same time.

No test for external miner. Tested manually, by launching external miner
I didn't implement cumulated hash rate on harmony side.
