### PR TITLE
Fixed: some touched accounts were not verified for eip161 deletion

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -320,7 +320,7 @@ public class TransactionExecutor {
                     throw result.getException();
                 }
 
-                touchedAccounts.addAll(program.getTouchedAccounts());
+                touchedAccounts.addAll(result.getTouchedAccounts());
             }
 
             cacheTrack.commit();

--- a/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1161,7 +1161,7 @@ public class VM {
                             PrecompiledContracts.getContractForAddress(codeAddress);
 
                     if (op.equals(CALL)) {
-                        program.touchAccount(codeAddress.getLast20Bytes());
+                        program.getResult().addTouchAccount(codeAddress.getLast20Bytes());
                     }
 
                     if (contract != null) {
@@ -1192,7 +1192,7 @@ public class VM {
                 case SUICIDE: {
                     DataWord address = program.stackPop();
                     program.suicide(address);
-                    program.touchAccount(address.getLast20Bytes());
+                    program.getResult().addTouchAccount(address.getLast20Bytes());
 
                     if (logger.isInfoEnabled())
                         hint = "address: " + Hex.toHexString(program.getOwnerAddress().getLast20Bytes());

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -464,8 +464,6 @@ public class Program {
 
         if (!byTestingSuite())
             track.commit();
-        getResult().addDeleteAccounts(result.getDeleteAccounts());
-        getResult().addTouchAccounts(result.getTouchedAccounts());
 
         // IN SUCCESS PUSH THE ADDRESS INTO THE STACK
         stackPush(new DataWord(newAddress));
@@ -571,7 +569,6 @@ public class Program {
             } else if (Arrays.equals(transaction.getReceiveAddress(), internalTx.getReceiveAddress())) {
                 storageDiffListener.merge(program.getStorageDiff());
             }
-            getResult().addTouchAccounts(result.getTouchedAccounts());
         }
 
         // 3. APPLY RESULTS: result.getHReturn() into out_memory allocated

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -425,6 +425,7 @@ public class Program {
             Program program = commonConfig.program(programCode, programInvoke, internalTx);
             vm.play(program);
             result = program.getResult();
+            touchedAccounts.addAll(program.getTouchedAccounts());
 
             getResult().merge(result);
         }

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -425,7 +425,6 @@ public class Program {
             Program program = commonConfig.program(programCode, programInvoke, internalTx);
             vm.play(program);
             result = program.getResult();
-            touchedAccounts.addAll(program.getTouchedAccounts());
 
             getResult().merge(result);
         }
@@ -466,6 +465,7 @@ public class Program {
         if (!byTestingSuite())
             track.commit();
         getResult().addDeleteAccounts(result.getDeleteAccounts());
+        getResult().addTouchAccounts(result.getTouchedAccounts());
 
         // IN SUCCESS PUSH THE ADDRESS INTO THE STACK
         stackPush(new DataWord(newAddress));
@@ -554,7 +554,6 @@ public class Program {
 
             getTrace().merge(program.getTrace());
             getResult().merge(result);
-            touchedAccounts.addAll(program.getTouchedAccounts());
 
             if (result.getException() != null) {
                 logger.debug("contract run halted by Exception: contract: [{}], exception: [{}]",
@@ -572,6 +571,7 @@ public class Program {
             } else if (Arrays.equals(transaction.getReceiveAddress(), internalTx.getReceiveAddress())) {
                 storageDiffListener.merge(program.getStorageDiff());
             }
+            getResult().addTouchAccounts(result.getTouchedAccounts());
         }
 
         // 3. APPLY RESULTS: result.getHReturn() into out_memory allocated
@@ -868,14 +868,6 @@ public class Program {
                 i += op.asInt() - OpCode.PUSH1.asInt() + 1;
             }
         }
-    }
-
-    public void touchAccount(byte[] addr) {
-        touchedAccounts.add(addr);
-    }
-
-    public Set<byte[]> getTouchedAccounts() {
-        return touchedAccounts;
     }
 
     static String formatBinData(byte[] binData, int startPC) {

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/ProgramResult.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/ProgramResult.java
@@ -1,5 +1,6 @@
 package org.ethereum.vm.program;
 
+import org.ethereum.util.ByteArraySet;
 import org.ethereum.vm.CallCreate;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
@@ -24,6 +25,7 @@ public class ProgramResult {
     private RuntimeException exception;
 
     private Set<DataWord> deleteAccounts;
+    private ByteArraySet touchedAccounts = new ByteArraySet();
     private List<InternalTransaction> internalTransactions;
     private List<LogInfo> logInfoList;
     private long futureRefund = 0;
@@ -78,6 +80,20 @@ public class ProgramResult {
     public void addDeleteAccounts(Set<DataWord> accounts) {
         if (!isEmpty(accounts)) {
             getDeleteAccounts().addAll(accounts);
+        }
+    }
+
+    public void addTouchAccount(byte[] addr) {
+        touchedAccounts.add(addr);
+    }
+
+    public Set<byte[]> getTouchedAccounts() {
+        return touchedAccounts;
+    }
+
+    public void addTouchAccounts(Set<byte[]> accounts) {
+        if (!isEmpty(accounts)) {
+            getTouchedAccounts().addAll(accounts);
         }
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/ProgramResult.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/ProgramResult.java
@@ -167,6 +167,7 @@ public class ProgramResult {
             addDeleteAccounts(another.getDeleteAccounts());
             addLogInfos(another.getLogInfoList());
             addFutureRefund(another.getFutureRefund());
+            addTouchAccounts(another.getTouchedAccounts());
         }
     }
     


### PR DESCRIPTION
Let's clarify
https://github.com/ethereum/EIPs/issues/161

An account changes state when:
1. it is the target or refund of a SUICIDE operation for zero or more value; 
1. it is the source or destination of a CALL operation or message-call transaction transferring zero or more value; 
1. it is the source or newly-creation of a CREATE operation or contract-creation transaction endowing zero or more value; 
1. as the block author ("miner") it is recipient of block-rewards or transaction-fees of zero or more. 

Looks like we could answer *YES* on all of this, but you'd better check too. So:
- Do we now check and merge results of all cases?
- Should we move touched accounts to ProgramResult?