### PR TITLE
Switch to solc 0.4.6 in order to fix solc on mac issue

### DIFF
--- a/ethereumj-core/build.gradle
+++ b/ethereumj-core/build.gradle
@@ -121,7 +121,7 @@ dependencies {
 
     compile "org.ethereum:leveldbjni-all:1.18.3"             // native leveldb components
 
-    compile "org.ethereum:solcJ-all:0.4.3"                   // Solidity Compiler win/mac/linux binaries
+    compile "org.ethereum:solcJ-all:0.4.6"                   // Solidity Compiler win/mac/linux binaries
 
     compile "com.cedarsoftware:java-util:1.8.0" // for deep equals
     compile "org.javassist:javassist:3.15.0-GA"


### PR DESCRIPTION
@Nashatyrev Need to update to latestest 0.4.6, because my solcJ-all 0.4.3 doesn't work properly on Mac. I've checked CreateContractSample.