### PR TITLE
Fix NullpointerException when using zero gas configuration for transactions

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/PendingStateImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/PendingStateImpl.java
@@ -1,5 +1,17 @@
 package org.ethereum.core;
 
+import static org.ethereum.listener.EthereumListener.PendingTransactionState.DROPPED;
+import static org.ethereum.listener.EthereumListener.PendingTransactionState.INCLUDED;
+import static org.ethereum.listener.EthereumListener.PendingTransactionState.NEW_PENDING;
+import static org.ethereum.listener.EthereumListener.PendingTransactionState.PENDING;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
 import org.apache.commons.collections4.map.LRUMap;
 import org.ethereum.config.CommonConfig;
 import org.ethereum.config.SystemProperties;
@@ -17,10 +29,6 @@ import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.*;
-
-import static org.ethereum.listener.EthereumListener.PendingTransactionState.*;
 
 /**
  * Keeps logic providing pending state management

--- a/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -1,5 +1,13 @@
 package org.ethereum.core;
 
+import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
+import static org.ethereum.util.ByteUtil.ZERO_BYTE_ARRAY;
+
+import java.math.BigInteger;
+import java.security.SignatureException;
+import java.util.Arrays;
+
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.ECKey.ECDSASignature;
@@ -10,19 +18,10 @@ import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.BigIntegers;
 import org.spongycastle.util.encoders.Hex;
-
-import java.math.BigInteger;
-import java.security.SignatureException;
-import java.util.Arrays;
-
-import static org.apache.commons.lang3.ArrayUtils.isEmpty;
-import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
-import static org.ethereum.util.ByteUtil.ZERO_BYTE_ARRAY;
 
 /**
  * A transaction (formally, T) is a single cryptographically
@@ -45,29 +44,29 @@ public class Transaction {
     private byte[] hash;
 
     /* a counter used to make sure each transaction can only be processed once */
-    protected byte[] nonce;
+    private byte[] nonce;
 
     /* the amount of ether to transfer (calculated as wei) */
-    protected byte[] value;
+    private byte[] value;
 
     /* the address of the destination account
      * In creation transaction the receive address is - 0 */
-    protected byte[] receiveAddress;
+    private byte[] receiveAddress;
 
     /* the amount of ether to pay as a transaction fee
      * to the miner for each unit of gas */
-    protected byte[] gasPrice;
+    private byte[] gasPrice;
 
     /* the amount of "gas" to allow for the computation.
      * Gas is the fuel of the computational engine;
      * every computational step taken and every byte added
      * to the state or transaction list consumes some gas. */
-    protected byte[] gasLimit;
+    private byte[] gasLimit;
 
     /* An unlimited size byte array specifying
      * input [data] of the message call or
      * Initialization code for a new contract */
-    protected byte[] data;
+    private byte[] data;
 
     /**
      * Since EIP-155, we could encode chainId in V
@@ -245,6 +244,11 @@ public class Transaction {
         return nonce == null ? ZERO_BYTE_ARRAY : nonce;
     }
 
+    protected void setNonce(byte[] nonce) {
+        this.nonce = nonce;
+        parsed = true;
+    }
+
     public boolean isValueTx() {
         if (!parsed) rlpParse();
         return value != null;
@@ -255,9 +259,19 @@ public class Transaction {
         return value == null ? ZERO_BYTE_ARRAY : value;
     }
 
+    protected void setValue(byte[] value) {
+        this.value = value;
+        parsed = true;
+    }
+
     public byte[] getReceiveAddress() {
         if (!parsed) rlpParse();
         return receiveAddress;
+    }
+
+    protected void setReceiveAddress(byte[] receiveAddress) {
+        this.receiveAddress = receiveAddress;
+        parsed = true;
     }
 
     public byte[] getGasPrice() {
@@ -265,9 +279,19 @@ public class Transaction {
         return gasPrice == null ? ZERO_BYTE_ARRAY : gasPrice;
     }
 
+    protected void setGasPrice(byte[] gasPrice) {
+        this.gasPrice = gasPrice;
+        parsed = true;
+    }
+
     public byte[] getGasLimit() {
         if (!parsed) rlpParse();
-        return gasLimit;
+        return gasLimit == null ? ZERO_BYTE_ARRAY : gasLimit;
+    }
+
+    protected void setGasLimit(byte[] gasLimit) {
+        this.gasLimit = gasLimit;
+        parsed = true;
     }
 
     public long nonZeroDataBytes() {
@@ -292,6 +316,11 @@ public class Transaction {
     public byte[] getData() {
         if (!parsed) rlpParse();
         return data;
+    }
+
+    protected void setData(byte[] data) {
+        this.data = data;
+        parsed = true;
     }
 
     public ECDSASignature getSignature() {

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/InternalTransaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/InternalTransaction.java
@@ -1,17 +1,19 @@
 package org.ethereum.vm.program;
 
+import static org.apache.commons.lang3.ArrayUtils.getLength;
+import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+import static org.apache.commons.lang3.ArrayUtils.nullToEmpty;
+import static org.ethereum.util.ByteUtil.toHexString;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.ethereum.vm.DataWord;
-
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-
-import static org.apache.commons.lang3.ArrayUtils.*;
-import static org.ethereum.util.ByteUtil.toHexString;
 
 public class InternalTransaction extends Transaction {
 
@@ -114,14 +116,14 @@ public class InternalTransaction extends Transaction {
         RLPList decodedTxList = RLP.decode2(rlpEncoded);
         RLPList transaction = (RLPList) decodedTxList.get(0);
 
-        this.nonce = transaction.get(0).getRLPData();
+        setNonce(transaction.get(0).getRLPData());
         this.parentHash = transaction.get(1).getRLPData();
         this.sendAddress = transaction.get(2).getRLPData();
-        this.receiveAddress = transaction.get(3).getRLPData();
-        this.value = transaction.get(4).getRLPData();
-        this.gasPrice = transaction.get(5).getRLPData();
-        this.gasLimit = transaction.get(6).getRLPData();
-        this.data = transaction.get(7).getRLPData();
+        setReceiveAddress(transaction.get(3).getRLPData());
+        setValue(transaction.get(4).getRLPData());
+        setGasPrice(transaction.get(5).getRLPData());
+        setGasLimit(transaction.get(6).getRLPData());
+        setData(transaction.get(7).getRLPData());
         this.note = new String(transaction.get(8).getRLPData());
         this.deep = decodeInt(transaction.get(9).getRLPData());
         this.index = decodeInt(transaction.get(10).getRLPData());


### PR DESCRIPTION
When creating private chain where gas is switched off, there is some NullpointerExceptions that pop up all over the place, these changes make sure that those don't occur.

I've also cleaned up some of the access logic for `transaction` properties, because these have complex accessor logic it really should be private and have setters. One `NullpointerException` was caused by gasPrice property being accessed directly rather than using getter