### PR TITLE
Switch to solc 0.4.7

### DIFF
--- a/ethereumj-core/build.gradle
+++ b/ethereumj-core/build.gradle
@@ -121,7 +121,7 @@ dependencies {
 
     compile "org.ethereum:leveldbjni-all:1.18.3"             // native leveldb components
 
-    compile "org.ethereum:solcJ-all:0.4.6"                   // Solidity Compiler win/mac/linux binaries
+    compile "org.ethereum:solcJ-all:0.4.7"                   // Solidity Compiler win/mac/linux binaries
 
     compile "com.cedarsoftware:java-util:1.8.0" // for deep equals
     compile "org.javassist:javassist:3.15.0-GA"

--- a/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/CompilationResult.java
+++ b/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/CompilationResult.java
@@ -1,7 +1,7 @@
 package org.ethereum.solidity.compiler;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -30,6 +30,7 @@ public class CompilationResult {
         public String abi;
         public String bin;
         public String solInterface;
+        public String metadata;
 
         public String getInterface() {
             return solInterface;

--- a/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java
@@ -28,7 +28,8 @@ public class SolidityCompiler {
         AST("ast"),
         BIN("bin"),
         INTERFACE("interface"),
-        ABI("abi");
+        ABI("abi"),
+        METADATA("metadata");
 
         private String name;
 

--- a/ethereumj-core/src/test/java/org/ethereum/solidity/CompilerTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/solidity/CompilerTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.ethereum.solidity.compiler.SolidityCompiler.Options.*;
+
 /**
  * Created by Anton Nashatyrev on 03.03.2016.
  */
@@ -15,7 +17,7 @@ public class CompilerTest {
     @Test
     public void simpleTest() throws IOException {
         String contract =
-            "pragma solidity ^0.4.3;\n" +
+            "pragma solidity ^0.4.7;\n" +
                     "\n" +
                     "contract a {\n" +
                     "\n" +
@@ -27,7 +29,7 @@ public class CompilerTest {
                     "}";
 
         SolidityCompiler.Result res = SolidityCompiler.compile(
-                contract.getBytes(), true, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN, SolidityCompiler.Options.INTERFACE);
+                contract.getBytes(), true, ABI, BIN, INTERFACE, METADATA);
         System.out.println("Out: '" + res.output + "'");
         System.out.println("Err: '" + res.errors + "'");
         CompilationResult result = CompilationResult.parse(res.output);


### PR DESCRIPTION
To fix #638 
 - use solc 0.4.7;
 - fix json parsing unknown properties.

I see some related tests are failed before my changes. I hope merging solc update will not break it fuse.
```
ImportLightTest.operateNotExistingContractTest
TransactionTest.multiSuicideTest
LockBlockchainTest.testStatus (looks unrelated to solidity)
```