### PR TITLE
Adding support for the payable keyword to the solidity Abi class

### DIFF
--- a/ethereumj-core/src/test/java/org/ethereum/solidity/AbiTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/solidity/AbiTest.java
@@ -1,0 +1,38 @@
+package org.ethereum.solidity;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.ethereum.solidity.Abi.Entry;
+import org.ethereum.solidity.Abi.Entry.Type;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AbiTest {
+
+    @Test
+    public void simpleTest() throws IOException {
+        String contractAbi = "[{"
+                + "\"name\":\"simpleFunction\","
+                + "\"constant\":true,"
+                + "\"payable\":true,"
+                + "\"type\":\"function\","
+                + "\"inputs\": [{\"name\":\"_in\", \"type\":\"bytes32\"}],"
+                + "\"outputs\":[{\"name\":\"_out\",\"type\":\"bytes32\"}]}]";
+
+        Abi abi = Abi.fromJson(contractAbi);
+        assertEquals(abi.size(), 1);
+
+        Entry onlyFunc = abi.get(0);
+        assertEquals(onlyFunc.type, Type.function);
+        assertEquals(onlyFunc.inputs.size(), 1);
+        assertEquals(onlyFunc.outputs.size(), 1);
+        assertTrue(onlyFunc.payable);
+        assertTrue(onlyFunc.constant);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new AbiTest().simpleTest();
+    }
+}


### PR DESCRIPTION
This PR follows the strategy in https://github.com/ethereum/ethereumj/pull/579 for adding the payable keyword to the ABI parsing mechanism (also a currently-unused `fallback` enum type).

Should be pretty straightforward, except maybe one thing: I'm not sure the custom ObjectMapper settings are a good idea – on one hand it may cause the parser to accept invalid ABIs, hiding errors that would otherwise be noticed quickly, but on the other it prevents this class from breaking entirely if new properties are added to Solidity.
