### PR TITLE
Ip in PingMessage and PongMessage encoded according to specs (4 bytes…

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/PingMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/PingMessage.java
@@ -5,54 +5,46 @@ import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
-//import org.spongycastle.util.encoders.Hex;
 
-import java.nio.charset.Charset;
-
+import static org.ethereum.util.ByteUtil.bytesToIp;
 import static org.ethereum.util.ByteUtil.longToBytes;
 import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
 
 public class PingMessage extends Message {
 
-    String host;
-    int port;
+    String toHost;
+    int toPort;
+    String fromHost;
+    int fromPort;
     long expires;
     int version;
 
-    public static PingMessage create(String host, int port, ECKey privKey) {
-        return create(host, port, privKey, 4);
+    public static PingMessage create(Node fromNode, Node toNode, ECKey privKey) {
+        return create(fromNode, toNode, privKey, 4);
     }
 
-    public static PingMessage create(String host, int port, ECKey privKey, int version) {
+    public static PingMessage create(Node fromNode, Node toNode, ECKey privKey, int version) {
 
         long expiration = 90 * 60 + System.currentTimeMillis() / 1000;
 
         /* RLP Encode data */
-        byte[] rlpIp = RLP.encodeElement(host.getBytes());
-
-        byte[] tmpPort = longToBytes(port);
-        byte[] rlpPort = RLP.encodeElement(stripLeadingZeroes(tmpPort));
-
-        byte[] rlpIpTo = RLP.encodeElement(host.getBytes());
-
-        byte[] tmpPortTo = longToBytes(port);
-        byte[] rlpPortTo = RLP.encodeElement(stripLeadingZeroes(tmpPortTo));
-
         byte[] tmpExp = longToBytes(expiration);
         byte[] rlpExp = RLP.encodeElement(stripLeadingZeroes(tmpExp));
 
         byte[] type = new byte[]{1};
         byte[] rlpVer = RLP.encodeInt(version);
-        byte[] rlpFromList = RLP.encodeList(rlpIp, rlpPort, rlpPort);
-        byte[] rlpToList = RLP.encodeList(rlpIpTo, rlpPortTo, rlpPortTo);
+        byte[] rlpFromList = fromNode.getBriefRLP();
+        byte[] rlpToList = toNode.getBriefRLP();
         byte[] data = RLP.encodeList(rlpVer, rlpFromList, rlpToList, rlpExp);
 
         PingMessage ping = new PingMessage();
         ping.encode(type, data, privKey);
 
         ping.expires = expiration;
-        ping.host = host;
-        ping.port = port;
+        ping.toHost = toNode.getHost();
+        ping.toPort = toNode.getPort();
+        ping.fromHost = fromNode.getHost();
+        ping.fromPort = fromNode.getPort();
 
         return ping;
     }
@@ -61,12 +53,16 @@ public class PingMessage extends Message {
     public void parse(byte[] data) {
 
         RLPList dataList = (RLPList) RLP.decode2OneItem(data, 0);
-        RLPList fromList = (RLPList) dataList.get(2);
 
-        byte[] ipB = fromList.get(0).getRLPData();
-        this.host = new String(ipB, Charset.forName("UTF-8"));
+        RLPList fromList = (RLPList) dataList.get(1);
+        byte[] ipF = fromList.get(0).getRLPData();
+        this.fromHost = bytesToIp(ipF);
+        this.fromPort = ByteUtil.byteArrayToInt(fromList.get(1).getRLPData());
 
-        this.port = ByteUtil.byteArrayToInt(fromList.get(1).getRLPData());
+        RLPList toList = (RLPList) dataList.get(2);
+        byte[] ipT = toList.get(0).getRLPData();
+        this.toHost = bytesToIp(ipT);
+        this.toPort = ByteUtil.byteArrayToInt(toList.get(1).getRLPData());
 
         RLPItem expires = (RLPItem) dataList.get(3);
         this.expires = ByteUtil.byteArrayToLong(expires.getRLPData());
@@ -75,12 +71,20 @@ public class PingMessage extends Message {
     }
 
 
-    public String getHost() {
-        return host;
+    public String getToHost() {
+        return toHost;
     }
 
-    public int getPort() {
-        return port;
+    public int getToPort() {
+        return toPort;
+    }
+
+    public String getFromHost() {
+        return fromHost;
+    }
+
+    public int getFromPort() {
+        return fromPort;
     }
 
     public long getExpires() {
@@ -92,8 +96,8 @@ public class PingMessage extends Message {
 
         long currTime = System.currentTimeMillis() / 1000;
 
-        String out = String.format("[PingMessage] \n host: %s port: %d \n expires in %d seconds \n %s\n",
-                host, port, (expires - currTime), super.toString());
+        String out = String.format("[PingMessage] \n %s:%d ==> %s:%d \n expires in %d seconds \n %s\n",
+                fromHost, fromPort, toHost, toPort, (expires - currTime), super.toString());
 
         return out;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/PongMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/PongMessage.java
@@ -7,8 +7,6 @@ import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
 import org.spongycastle.util.encoders.Hex;
 
-//import java.nio.charset.Charset;
-
 import static org.ethereum.util.ByteUtil.longToBytes;
 import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
 
@@ -17,15 +15,11 @@ public class PongMessage extends Message {
     byte[] token; // token is the MDC of the ping
     long expires;
 
-    public static PongMessage create(byte[] token, String host, int port, ECKey privKey) {
+    public static PongMessage create(byte[] token, Node toNode, ECKey privKey) {
 
         long expiration = 90 * 60 + System.currentTimeMillis() / 1000;
 
-        byte[] rlpIp = RLP.encodeElement(host.getBytes());
-
-        byte[] tmpPort = longToBytes(port);
-        byte[] rlpPort = RLP.encodeElement(stripLeadingZeroes(tmpPort));
-        byte[] rlpToList = RLP.encodeList(rlpIp, rlpPort, rlpPort);
+        byte[] rlpToList = toNode.getBriefRLP();
 
         /* RLP Encode data */
         byte[] rlpToken = RLP.encodeElement(token);

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
@@ -259,8 +259,7 @@ public class NodeHandler {
         }
 //        logMessage("<===  [PING] " + this);
 
-        Message ping = PingMessage.create(nodeManager.table.getNode().getHost(),
-                nodeManager.table.getNode().getPort(), nodeManager.key);
+        Message ping = PingMessage.create(nodeManager.table.getNode(), getNode(), nodeManager.key);
         logMessage(ping, false);
         waitForPong = true;
         pingSent = Util.curTime();
@@ -284,7 +283,7 @@ public class NodeHandler {
 
     void sendPong(byte[] mdc) {
 //        logMessage("<===  [PONG] " + this);
-        Message pong = PongMessage.create(mdc, node.getHost(), node.getPort(), nodeManager.key);
+        Message pong = PongMessage.create(mdc, node, nodeManager.key);
         logMessage(pong, false);
         sendMessage(pong);
         getNodeStatistics().discoverOutPong.add();

--- a/ethereumj-core/src/main/java/org/ethereum/util/ByteUtil.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/ByteUtil.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 
 import java.math.BigInteger;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
 import java.util.Arrays;
@@ -614,5 +616,37 @@ public class ByteUtil {
         if (data.startsWith("0x")) data = data.substring(2);
         if (data.length() % 2 == 1) data = "0" + data;
         return Hex.decode(data);
+    }
+
+    /**
+     * Converts string representation of host/ip to 4-bytes byte[] IPv4
+     */
+    public static byte[] hostToBytes(String ip) {
+        byte[] bytesIp;
+        try {
+            bytesIp = InetAddress.getByName(ip).getAddress();
+        } catch (UnknownHostException e) {
+            bytesIp = new byte[4];  // fall back to invalid 0.0.0.0 address
+        }
+
+        return bytesIp;
+    }
+
+    /**
+     * Converts 4 bytes IPv4 IP to String representation
+     */
+    public static String bytesToIp(byte[] bytesIp) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(bytesIp[0] & 0xFF);
+        sb.append(".");
+        sb.append(bytesIp[1] & 0xFF);
+        sb.append(".");
+        sb.append(bytesIp[2] & 0xFF);
+        sb.append(".");
+        sb.append(bytesIp[3] & 0xFF);
+
+        String ip = sb.toString();
+        return ip;
     }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
@@ -459,4 +459,24 @@ public class ByteUtilTest {
             assertArrayEquals(expected, actuals);
         }
     }
+
+    @Test
+    public void testIpConversion() {
+        String ip1 = "0.0.0.0";
+        byte[] ip1Bytes = ByteUtil.hostToBytes(ip1);
+        assertEquals(ip1, ByteUtil.bytesToIp(ip1Bytes));
+
+        String ip2 = "35.36.37.138";
+        byte[] ip2Bytes = ByteUtil.hostToBytes(ip2);
+        assertEquals(ip2, ByteUtil.bytesToIp(ip2Bytes));
+
+        String ip3 = "255.255.255.255";
+        byte[] ip3Bytes = ByteUtil.hostToBytes(ip3);
+        assertEquals(ip3, ByteUtil.bytesToIp(ip3Bytes));
+
+        // Fallback case
+        String ip4 = "255.255.255.256";
+        byte[] ip4Bytes = ByteUtil.hostToBytes(ip4);
+        assertEquals("0.0.0.0", ByteUtil.bytesToIp(ip4Bytes));
+    }
 }


### PR DESCRIPTION
Specs: https://github.com/ethereum/devp2p/blob/master/rlpx.md

test7 in RLPXTest.java contains strange data (from node = byte[0])
I'm not sure, it's a correct RLP

This fix should fix Parity interaction in discovery
