### PR TITLE
Include home node in NeighborsMessage according to config

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
@@ -1,6 +1,7 @@
 package org.ethereum.net.rlpx.discover;
 
 import org.ethereum.net.rlpx.*;
+import org.ethereum.net.rlpx.discover.table.KademliaOptions;
 import org.ethereum.net.swarm.Util;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
@@ -233,7 +234,12 @@ public class NodeHandler {
 //        logMessage(" ===> [FIND_NODE] " + this);
         getNodeStatistics().discoverInFind.add();
         List<Node> closest = nodeManager.table.getClosestNodes(msg.getTarget());
-        closest.add(nodeManager.homeNode);
+
+        Node publicHomeNode = nodeManager.getPublicHomeNode();
+        if (publicHomeNode != null) {
+            if (closest.size() == KademliaOptions.BUCKET_SIZE) closest.remove(closest.size() - 1);
+            closest.add(publicHomeNode);
+        }
 
         sendNeighbours(closest);
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -384,6 +384,16 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
         return sb.toString();
     }
 
+    /**
+     * @return home node if config defines it as public, otherwise null
+     */
+    Node getPublicHomeNode() {
+        if (config.isPublicHomeNode()) {
+            return homeNode;
+        }
+        return null;
+    }
+
     public void close() {
         peerConnectionManager.close();
         try {

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/table/KademliaOptions.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/table/KademliaOptions.java
@@ -4,7 +4,7 @@ package org.ethereum.net.rlpx.discover.table;
  * Created by kest on 5/25/15.
  */
 public class KademliaOptions {
-    public static final int BUCKET_SIZE = 15;
+    public static final int BUCKET_SIZE = 16;
     public static final int ALPHA = 3;
     public static final int BINS = 256;
     public static final int MAX_STEPS = 8;


### PR DESCRIPTION
When fixing size of NeighborsMessage didn't noticed that homeNode was added to it without respect to config. Fixing it.