### PR TITLE
Fixed errors with several constraints checking for new peers

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/Eth62.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/handler/Eth62.java
@@ -534,18 +534,16 @@ public class Eth62 extends EthHandler {
             for (Pair<Long, byte[]> constraint : constraints) {
                 if (constraint.getLeft() <= getBestKnownBlock().getNumber()) {
                     blockHashCheck.put(constraint.getLeft(), constraint.getRight());
-                    sendGetBlockHeaders(constraint.getLeft(), 1, false);
                 }
             }
-
-            logger.trace("Peer " + channel.getPeerIdShort() + ": Requested " + blockHashCheck.size() +
-                    " headers for hash check: " + blockHashCheck.keySet());
+            requestNextHashCheck();
 
         } else {
             byte[] expectedHash = blockHashCheck.get(first.getNumber());
             if (expectedHash != null) {
                 if (FastByteComparisons.equal(expectedHash, first.getHash())) {
                     blockHashCheck.remove(first.getNumber());
+                    requestNextHashCheck();
                 } else {
                     logger.debug("Peer " + channel.getPeerIdShort() + ": wrong fork (expected block " +
                             first.getNumber() + " hash " + Hex.toHexString(expectedHash) + ", but got " +
@@ -560,6 +558,14 @@ public class Eth62 extends EthHandler {
             ethState = EthState.STATUS_SUCCEEDED;
 
             logger.trace("Peer {}: all validations passed", channel.getPeerIdShort());
+        }
+    }
+
+    private void requestNextHashCheck() {
+        if (!blockHashCheck.isEmpty()) {
+            Long checkHeader = blockHashCheck.keySet().iterator().next();
+            sendGetBlockHeaders(checkHeader, 1, false);
+            logger.trace("Peer {}: Requested #{} header for hash check.", channel.getPeerIdShort(), checkHeader);
         }
     }
 


### PR DESCRIPTION
We were unable to check several constraints because of following error:
```
21:18:35.114 WARN [net]  Eth handling failed
java.lang.RuntimeException: The peer is waiting for headers response: org.ethereum.net.eth.handler.Eth63@45db5b
        at org.ethereum.net.eth.handler.Eth62.sendGetBlockHeaders(Eth62.java:211)
        at org.ethereum.net.eth.handler.Eth62.processInitHeaders(Eth62.java:537)
        at org.ethereum.net.eth.handler.Eth62.processBlockHeaders(Eth62.java:420)
        at org.ethereum.net.eth.handler.Eth62.channelRead0(Eth62.java:135)
        at org.ethereum.net.eth.handler.Eth63.channelRead0(Eth63.java:68)
        at org.ethereum.net.eth.handler.Eth63.channelRead0(Eth63.java:38)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:108)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
        at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:111)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:244)
        at org.ethereum.net.rlpx.NettyByteToMessageCodec.channelRead(NettyByteToMessageCodec.java:56)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
        at io.netty.handler.timeout.ReadTimeoutHandler.channelRead(ReadTimeoutHandler.java:152)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:846)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:131)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:511)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:468)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:382)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:354)
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:110)
        at java.lang.Thread.run(Thread.java:745)
```
Because handler was unable to process two or more headers at once. Refactored to process checks one by one.