### PR TITLE
Allow 'reset' to a specific block instead of back to genesis

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/Initializer.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/Initializer.java
@@ -82,7 +82,7 @@ class Initializer implements BeanPostProcessor {
         }
 
         public void process(SystemProperties config) {
-            if (config.databaseReset()){
+            if (config.databaseReset() && config.databaseResetBlock() == 0){
                 FileUtil.recursiveDelete(config.databaseDir());
                 putDatabaseVersion(config, config.databaseVersion());
                 logger.info("Database reset done");

--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -384,6 +384,11 @@ public class SystemProperties {
     }
 
     @ValidateMe
+    public long databaseResetBlock() {
+        return config.getLong("database.resetBlock");
+    }
+
+    @ValidateMe
     public int databasePruneDepth() {
         return config.getBoolean("database.prune.enabled") ? config.getInt("database.prune.maxDepth") : -1;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -142,7 +142,7 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
     private void dbRead() {
         try {
             db = mapDBFactory.createTransactionalDB("network/discovery");
-            if (config.databaseReset()) {
+            if (config.databaseReset() && config.databaseResetBlock() == 0) {
                 logger.info("Resetting DB Node statistics...");
                 db.delete("nodeStats");
             }

--- a/ethereumj-core/src/main/resources/ethereumj.conf
+++ b/ethereumj-core/src/main/resources/ethereumj.conf
@@ -182,6 +182,12 @@ database {
     # downloaded from peers again [true/false]
     reset = false
 
+    # If reset=true, every time the application
+    # starts the database will reset itself to
+    # this block number and sync again from there.
+    # Set to 0 for a 'full' reset.
+    resetBlock = 0
+
     # handling incompatible database version:
     #  * EXIT   - (default) show error in std out and exit by throwing Error
     #  * RESET  - clear database directory and continue working


### PR DESCRIPTION
This was a solution I whipped up for #681 and implemented with success on my Ropsten nodes, which were all stuck on the wrong side of a long fork.  It probably only worked because I had database pruning disabled, but I thought I should post it back here in case it's useful to you.  Feel free to close if it's not a good idea.

I wasn't sure how to detect if the old state had been pruned without doing a whole trie dump, so I left it as a `TODO` in the code.