### PR TITLE
Keep Ethereum.close() from trying to shut down twice

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -149,8 +149,7 @@ public class EthereumImpl implements Ethereum, SmartLifecycle {
 
     @Override
     public void close() {
-        logger.info("Shutting down Ethereum instance...");
-        worldManager.close();
+        logger.info("### Shutdown initiated ### ");
         ((AbstractApplicationContext) getApplicationContext()).close();
     }
 
@@ -380,8 +379,8 @@ public class EthereumImpl implements Ethereum, SmartLifecycle {
      */
     @Override
     public void stop(Runnable callback) {
-        logger.info("### Shutdown initiated ### ");
-        close();
+        logger.info("Shutting down Ethereum instance...");
+        worldManager.close();
         callback.run();
     }
 


### PR DESCRIPTION
As reported at https://gitter.im/ethereum/ethereumj?at=5890fb0edcb66e4f76d5367d, currently `EthereumImpl.close()` calls `ApplicationContext.close()`, which calls `EthereumImpl.stop()`, which calls `EthereumImpl.close()` again.

This breaks the loop so that EthereumJ only attempts to shut down once.