### PR TITLE
Simplicy 'adding as dependency' section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,29 +14,23 @@ http://ethereumj.io
 
 # Running EthereumJ
 
-##### Adding as maven artifact to your project: 
+##### Adding as a dependency to your Maven project: 
+
 ```
-   <repositories>
-     <repository>
-       <id>oss.jfrog.org</id>
-       <name>Repository from Bintray</name>
-       <url>http://dl.bintray.com/ethereum/maven</url>
-     </repository>
-   </repositories>
- 
    <dependency>
      <groupId>org.ethereum</groupId>
      <artifactId>ethereumj-core</artifactId>
-     <version>1.4.0-RELEASE</version>
+     <version>1.4.1-RELEASE</version>
    </dependency>
 ```
 
-or gradle: 
+##### or your Gradle project: 
+
 ```
    repositories {
-       maven {url "http://dl.bintray.com/ethereum/maven"}
+       mavenCentral()
    }
-   compile ("org.ethereum:ethereumj-core:1.4.+")
+   compile "org.ethereum:ethereumj-core:1.4.+"
 ```
 
 As a starting point for your own project take a look at https://github.com/ether-camp/ethereumj.starter


### PR DESCRIPTION
ethereumj is already available in Maven Central.