### PR TITLE
Fix duplicate node names when discovery is turned off

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -36,8 +36,6 @@ import static java.lang.Math.min;
 public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
     static final org.slf4j.Logger logger = LoggerFactory.getLogger("discover");
 
-    // to avoid checking for null
-    private static NodeStatistics DUMMY_STAT = new NodeStatistics(new Node(new byte[0], "dummy.node", 0));
     private final boolean PERSIST;
 
     private static final long LISTENER_REFRESH_RATE = 1000;
@@ -248,7 +246,7 @@ public class NodeManager implements Functional.Consumer<DiscoveryEvent>{
     }
 
     public NodeStatistics getNodeStatistics(Node n) {
-        return discoveryEnabled ? getNodeHandler(n).getNodeStatistics() : DUMMY_STAT;
+        return getNodeHandler(n).getNodeStatistics();
     }
 
     @Override


### PR DESCRIPTION
Fix #737 when nodes had same name in private networks
Fix #736 when sync doesn't happen in private network when other node initiated connection.