### PR TITLE
fixTestInitialInsertTest

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/Memory.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/Memory.java
@@ -111,7 +111,6 @@ public class Memory implements ProgramListenerAware {
     }
 
     public void extend(int address, int size) {
-        if (size <= 0) return;
 
         final int newSize = address + size;
 

--- a/ethereumj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
@@ -341,15 +341,11 @@ public class ProgramMemoryTest {
         assertEquals(32, program.getMemSize());
     }
 
-    @Ignore
     @Test
     public void testInitialInsert() {
-
-
-        // todo: fix the array out of bound here
         int offset = 32;
-        int size = 00;
-        program.memorySave(32, 0, new byte[0]);
+        int size = 0;
+        program.memorySave(offset,size, new byte[0]);
         assertEquals(32, program.getMemSize());
     }
 }


### PR DESCRIPTION
Fixed test for initial insert in ProgramMemoryTest
There was a senseless if statement which returned 0 if size <= 0
causing the test to break. 
Unless that if is meant to be there, please advise.