### PR TITLE
#706 Make DataWord immutable

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/CommonConfig.java
@@ -208,8 +208,7 @@ public class CommonConfig {
                 new Serializer<byte[], byte[]>() {
                     public byte[] serialize(byte[] object) {
                         DataWord ret = new DataWord(object);
-                        ret.add(new DataWord(1));
-                        return ret.getLast20Bytes();
+                        return ret.add(new DataWord(1)).getLast20Bytes();
                     }
                     public byte[] deserialize(byte[] stream) {
                         throw new RuntimeException("Shouldn't be called");

--- a/ethereumj-core/src/main/java/org/ethereum/util/Utils.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/Utils.java
@@ -232,9 +232,7 @@ public class Utils {
     public static DataWord allButOne64th(DataWord dw) {
         DataWord ret = dw.clone();
         DataWord d = dw.clone();
-        d.div(DIVISOR);
-        ret.sub(d);
-        return ret;
+        return ret.sub(d.div(DIVISOR));
     }
 
     /**

--- a/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
@@ -300,8 +300,7 @@ public class VM {
                         throw Program.Exception.notEnoughOpGas(op, callGasWord, program.getGas());
                     }
 
-                    DataWord gasLeft = program.getGas().clone();
-                    gasLeft.sub(new DataWord(gasCost));
+                    DataWord gasLeft = program.getGas().sub(new DataWord(gasCost));
                     adjustedCallGas = blockchainConfig.getCallGas(op, callGasWord, gasLeft);
                     gasCost += adjustedCallGas.longValueSafe();
                     break;
@@ -366,7 +365,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " + " + word2.value();
 
-                    word1.add(word2);
+                    word1 = word1.add(word2);
                     program.stackPush(word1);
                     program.step();
 
@@ -379,7 +378,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " * " + word2.value();
 
-                    word1.mul(word2);
+                    word1 = word1.mul(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -391,7 +390,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " - " + word2.value();
 
-                    word1.sub(word2);
+                    word1 = word1.sub(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -403,7 +402,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " / " + word2.value();
 
-                    word1.div(word2);
+                    word1 = word1.div(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -415,7 +414,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.sValue() + " / " + word2.sValue();
 
-                    word1.sDiv(word2);
+                    word1 = word1.sDiv(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -427,7 +426,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " % " + word2.value();
 
-                    word1.mod(word2);
+                    word1 = word1.mod(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -439,7 +438,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.sValue() + " #% " + word2.sValue();
 
-                    word1.sMod(word2);
+                    word1 = word1.sMod(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -451,7 +450,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " ** " + word2.value();
 
-                    word1.exp(word2);
+                    word1 = word1.exp(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -464,15 +463,14 @@ public class VM {
                         DataWord word2 = program.stackPop();
                         if (logger.isInfoEnabled())
                             hint = word1 + "  " + word2.value();
-                        word2.signExtend(k.byteValue());
+                        word2 = word2.signExtend(k.byteValue());
                         program.stackPush(word2);
                     }
                     program.step();
                 }
                 break;
                 case NOT: {
-                    DataWord word1 = program.stackPop();
-                    word1.bnot();
+                    DataWord word1 = program.stackPop().bnot();
 
                     if (logger.isInfoEnabled())
                         hint = "" + word1.value();
@@ -490,10 +488,9 @@ public class VM {
                         hint = word1.value() + " < " + word2.value();
 
                     if (word1.value().compareTo(word2.value()) == -1) {
-                        word1.and(DataWord.ZERO);
-                        word1.getData()[31] = 1;
+                        word1 = word1.and(DataWord.ZERO).set(31, (byte) 1);
                     } else {
-                        word1.and(DataWord.ZERO);
+                        word1 = word1.and(DataWord.ZERO);
                     }
                     program.stackPush(word1);
                     program.step();
@@ -508,10 +505,9 @@ public class VM {
                         hint = word1.sValue() + " < " + word2.sValue();
 
                     if (word1.sValue().compareTo(word2.sValue()) == -1) {
-                        word1.and(DataWord.ZERO);
-                        word1.getData()[31] = 1;
+                        word1 = word1.and(DataWord.ZERO).set(31, (byte) 1);
                     } else {
-                        word1.and(DataWord.ZERO);
+                        word1 = word1.and(DataWord.ZERO);
                     }
                     program.stackPush(word1);
                     program.step();
@@ -526,10 +522,9 @@ public class VM {
                         hint = word1.sValue() + " > " + word2.sValue();
 
                     if (word1.sValue().compareTo(word2.sValue()) == 1) {
-                        word1.and(DataWord.ZERO);
-                        word1.getData()[31] = 1;
+                        word1 = word1.and(DataWord.ZERO).set(31, (byte) 1);
                     } else {
-                        word1.and(DataWord.ZERO);
+                        word1 = word1.and(DataWord.ZERO);
                     }
                     program.stackPush(word1);
                     program.step();
@@ -544,10 +539,9 @@ public class VM {
                         hint = word1.value() + " > " + word2.value();
 
                     if (word1.value().compareTo(word2.value()) == 1) {
-                        word1.and(DataWord.ZERO);
-                        word1.getData()[31] = 1;
+                        word1 = word1.and(DataWord.ZERO).set(31, (byte) 1);
                     } else {
-                        word1.and(DataWord.ZERO);
+                        word1 = word1.and(DataWord.ZERO);
                     }
                     program.stackPush(word1);
                     program.step();
@@ -561,10 +555,9 @@ public class VM {
                         hint = word1.value() + " == " + word2.value();
 
                     if (word1.xor(word2).isZero()) {
-                        word1.and(DataWord.ZERO);
-                        word1.getData()[31] = 1;
+                        word1 = word1.and(DataWord.ZERO).set(31, (byte) 1);
                     } else {
-                        word1.and(DataWord.ZERO);
+                        word1 = word1.and(DataWord.ZERO);
                     }
                     program.stackPush(word1);
                     program.step();
@@ -573,9 +566,9 @@ public class VM {
                 case ISZERO: {
                     DataWord word1 = program.stackPop();
                     if (word1.isZero()) {
-                        word1.getData()[31] = 1;
+                        word1 = word1.set(31, (byte) 1);
                     } else {
-                        word1.and(DataWord.ZERO);
+                        word1 = word1.and(DataWord.ZERO);
                     }
 
                     if (logger.isInfoEnabled())
@@ -596,7 +589,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " && " + word2.value();
 
-                    word1.and(word2);
+                    word1 = word1.and(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -608,7 +601,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " || " + word2.value();
 
-                    word1.or(word2);
+                    word1 = word1.or(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -620,7 +613,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = word1.value() + " ^ " + word2.value();
 
-                    word1.xor(word2);
+                    word1 = word1.xor(word2);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -631,9 +624,7 @@ public class VM {
                     final DataWord result;
                     if (word1.value().compareTo(_32_) == -1) {
                         byte tmp = word2.getData()[word1.intValue()];
-                        word2.and(DataWord.ZERO);
-                        word2.getData()[31] = tmp;
-                        result = word2;
+                        result = word2.and(DataWord.ZERO).set(31, tmp);
                     } else {
                         result = new DataWord();
                     }
@@ -649,7 +640,7 @@ public class VM {
                     DataWord word1 = program.stackPop();
                     DataWord word2 = program.stackPop();
                     DataWord word3 = program.stackPop();
-                    word1.addmod(word2, word3);
+                    word1 = word1.addmod(word2, word3);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -658,7 +649,7 @@ public class VM {
                     DataWord word1 = program.stackPop();
                     DataWord word2 = program.stackPop();
                     DataWord word3 = program.stackPop();
-                    word1.mulmod(word2, word3);
+                    word1 = word1.mulmod(word2, word3);
                     program.stackPush(word1);
                     program.step();
                 }
@@ -1147,7 +1138,7 @@ public class VM {
                             program.stackPop() : DataWord.ZERO;
 
                     if( !value.isZero()) {
-                        adjustedCallGas.add(new DataWord(gasCosts.getSTIPEND_CALL()));
+                        adjustedCallGas = adjustedCallGas.add(new DataWord(gasCosts.getSTIPEND_CALL()));
                     }
 
                     DataWord inDataOffs = program.stackPop();

--- a/ethereumj-core/src/test/java/org/ethereum/vm/DataWordTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/vm/DataWordTest.java
@@ -41,16 +41,16 @@ public class DataWordTest {
             int ITERATIONS = 10000000;
 
             long now1 = System.currentTimeMillis();
+            DataWord x = new DataWord(one);
             for (int i = 0; i < ITERATIONS; i++) {
-                DataWord x = new DataWord(one);
-                x.add(x);
+                x = x.add(x);
             }
             System.out.println("Add1: " + (System.currentTimeMillis() - now1) + "ms");
 
             long now2 = System.currentTimeMillis();
+            x = new DataWord(one);
             for (int i = 0; i < ITERATIONS; i++) {
-                DataWord x = new DataWord(one);
-                x.add2(x);
+                x = x.add2(x);
             }
             System.out.println("Add2: " + (System.currentTimeMillis() - now2) + "ms");
         } else {
@@ -64,11 +64,11 @@ public class DataWordTest {
         two[31] = (byte) 0xff; // 0x000000000000000000000000000000000000000000000000000000000000ff
 
         DataWord x = new DataWord(two);
-        x.add(new DataWord(two));
+        x = x.add(new DataWord(two));
         System.out.println(Hex.toHexString(x.getData()));
 
         DataWord y = new DataWord(two);
-        y.add2(new DataWord(two));
+        y = y.add2(new DataWord(two));
         System.out.println(Hex.toHexString(y.getData()));
     }
 
@@ -80,7 +80,7 @@ public class DataWordTest {
         }
 
         DataWord x = new DataWord(three);
-        x.add(new DataWord(three));
+        x = x.add(new DataWord(three));
         assertEquals(32, x.getData().length);
         System.out.println(Hex.toHexString(x.getData()));
 
@@ -105,9 +105,9 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);// System.out.println(x.value());
         DataWord y = new DataWord(two);// System.out.println(y.value());
-        y.mod(x);
-        assertEquals(32, y.getData().length);
-        assertEquals(expected, Hex.toHexString(y.getData()));
+        DataWord result = y.mod(x);
+        assertEquals(32, result.getData().length);
+        assertEquals(expected, Hex.toHexString(result.getData()));
     }
 
     @Test
@@ -152,10 +152,10 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
-        x.div(y);
+        DataWord result = x.div(y);
 
-        assertEquals(32, x.getData().length);
-        assertEquals("0000000000000000000000000000000000000000000000000000000000000014", Hex.toHexString(x.getData()));
+        assertEquals(32, result.getData().length);
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000014", Hex.toHexString(result.getData()));
     }
 
     @Test
@@ -167,10 +167,10 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
-        x.div(y);
+        DataWord result = x.div(y);
 
-        assertEquals(32, x.getData().length);
-        assertTrue(x.isZero());
+        assertEquals(32, result.getData().length);
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -184,10 +184,10 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
-        x.sDiv(y);
+        DataWord result = x.sDiv(y);
 
-        assertEquals(32, x.getData().length);
-        assertEquals("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffec", x.toString());
+        assertEquals(32, result.getData().length);
+        assertEquals("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffec", result.toString());
     }
 
     @Test
@@ -209,9 +209,9 @@ public class DataWordTest {
         byte k = 0;
         String expected = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff2";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -220,9 +220,9 @@ public class DataWordTest {
         byte k = 1;
         String expected = "00000000000000000000000000000000000000000000000000000000000000f2";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -232,9 +232,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("0f00ab"));
         String expected = "00000000000000000000000000000000000000000000000000000000000000ab";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -244,9 +244,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ffff"));
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -256,9 +256,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ffffffff"));
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -268,9 +268,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ab02345678"));
         String expected = "0000000000000000000000000000000000000000000000000000000002345678";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -280,9 +280,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ab82345678"));
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff82345678";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -292,9 +292,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ff34567882345678823456788234567882345678823456788234567882345678"));
         String expected = "0034567882345678823456788234567882345678823456788234567882345678";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -333,9 +333,9 @@ public class DataWordTest {
         BigInteger bv2 = new BigInteger(v2, 16);
         BigInteger bv3 = new BigInteger(v3, 16);
 
-        dv1.addmod(dv2, dv3);
+        DataWord result  = dv1.addmod(dv2, dv3);
         BigInteger br = bv1.add(bv2).mod(bv3);
-        assertEquals(dv1.value(), br);
+        assertEquals(result.value(), br);
     }
 
     @Test
@@ -344,10 +344,10 @@ public class DataWordTest {
         DataWord w1 = new DataWord(Hex.decode("01"));
         DataWord w2 = new DataWord(Hex.decode("9999999999999999999999999999999999999999999999999999999999999998"));
 
-        wr.mulmod(w1, w2);
+        DataWord result = wr.mulmod(w1, w2);
 
-        assertEquals(32, wr.getData().length);
-        assertEquals("0000000000000000000000000000000000000000000000000000000000000001", Hex.toHexString(wr.getData()));
+        assertEquals(32, result.getData().length);
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000001", Hex.toHexString(result.getData()));
     }
 
     @Test
@@ -356,10 +356,10 @@ public class DataWordTest {
         DataWord w1 = new DataWord(Hex.decode("01"));
         DataWord w2 = new DataWord(Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
 
-        wr.mulmod(w1, w2);
+        DataWord result = wr.mulmod(w1, w2);
 
-        assertEquals(32, wr.getData().length);
-        assertTrue(wr.isZero());
+        assertEquals(32, result.getData().length);
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -380,10 +380,10 @@ public class DataWordTest {
         DataWord w1 = new DataWord(Hex.decode("00"));
         DataWord w2 = new DataWord(Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
-        wr.mulmod(w1, w2);
+        DataWord result = wr.mulmod(w1, w2);
 
-        assertEquals(32, wr.getData().length);
-        assertTrue(wr.isZero());
+        assertEquals(32, result.getData().length);
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -392,10 +392,10 @@ public class DataWordTest {
         DataWord w1 = new DataWord(Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
         DataWord w2 = new DataWord(Hex.decode("00"));
 
-        wr.mulmod(w1, w2);
+        DataWord result = wr.mulmod(w1, w2);
 
-        assertEquals(32, wr.getData().length);
-        assertTrue(wr.isZero());
+        assertEquals(32, result.getData().length);
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -404,10 +404,10 @@ public class DataWordTest {
         DataWord w1 = new DataWord(Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
         DataWord w2 = new DataWord(Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
-        wr.mulmod(w1, w2);
+        DataWord result = wr.mulmod(w1, w2);
 
-        assertEquals(32, wr.getData().length);
-        assertTrue(wr.isZero());
+        assertEquals(32, result.getData().length);
+        assertTrue(result.isZero());
     }
 
     public static BigInteger pow(BigInteger x, BigInteger y) {


### PR DESCRIPTION
This makes instances of DataWord immutable - calling public methods to change objects
of this type will no longer change the internal data array, but instead
return new instances of DataWord.

First go at contributing to ethereumj, so feedback with brutal honesty is appreciated!