### PR TITLE
Bumps packaged version of solcJ.

### DIFF
--- a/ethereumj-core/build.gradle
+++ b/ethereumj-core/build.gradle
@@ -121,7 +121,7 @@ dependencies {
 
     compile "org.ethereum:leveldbjni-all:1.18.3"             // native leveldb components
 
-    compile "org.ethereum:solcJ-all:0.4.8"                   // Solidity Compiler win/mac/linux binaries
+    compile "org.ethereum:solcJ-all:0.4.10"                   // Solidity Compiler win/mac/linux binaries
 
     compile "com.cedarsoftware:java-util:1.8.0" // for deep equals
     compile "org.javassist:javassist:3.15.0-GA"


### PR DESCRIPTION
`0.4.10` is the latest release and includes `require` and `assert` built-in functions.