### PR TITLE
Update Repository List in build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ http://ethereumj.io
 ```
    repositories {
        mavenCentral()
+       jcenter()
+       maven { url "https://dl.bintray.com/ethereum/maven/" }
    }
    compile "org.ethereum:ethereumj-core:1.5.+"
 ```


### PR DESCRIPTION
Added missing repositories to avoid the following gradle warning

```
Warning: root project 'GUI-Frontend': Unable to build Kotlin project configuration</b>
Details: java.lang.reflect.InvocationTargetException: null
Caused by: org.gradle.api.artifacts.ResolveException: Could not resolve all dependencies for configuration ':compileClasspath'.
Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.ethereum:ethereumj-core:1.5.0-RELEASE.
Required by:
    project :</i>
```
