### PR TITLE
Add an option for obligate System.exit in BlockchainImpl

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.*;
 
+import static java.lang.Math.PI;
 import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
 import static java.math.BigInteger.ONE;
@@ -542,8 +543,12 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
             BlockSummary summary1 = addImpl(repo.getSnapshotTo(getBestBlock().getStateRoot()), block);
             stateLogger.warn("Second import trial " + (summary1 == null ? "FAILED" : "OK"));
             if (summary1 != null) {
-                stateLogger.error("Inconsistent behavior, exiting...");
-                System.exit(-1);
+                if (config.exitOnBlockConflict()) {
+                    stateLogger.error("Inconsistent behavior, exiting...");
+                    System.exit(-1);
+                } else {
+                    return summary1;
+                }
             }
         }
         return summary;


### PR DESCRIPTION
System used to exist each time when second import attempt happened
Now it uses exitOnBlockConflict flag to decide exit or not