### PR TITLE
Fix Whisper messages being picked up by Eth handler

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/eth/message/EthMessageCodes.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/eth/message/EthMessageCodes.java
@@ -17,12 +17,13 @@
  */
 package org.ethereum.net.eth.message;
 
-import org.ethereum.net.eth.EthVersion;
+import static org.ethereum.net.eth.EthVersion.V62;
+import static org.ethereum.net.eth.EthVersion.V63;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.ethereum.net.eth.EthVersion.*;
+import org.ethereum.net.eth.EthVersion;
 
 /**
  * A list of commands for the Ethereum network protocol.
@@ -231,7 +232,7 @@ public enum EthMessageCodes {
 
     public static boolean inRange(byte code, EthVersion v) {
         EthMessageCodes[] codes = values(v);
-        return code >= codes[0].asByte() && code <= codes[codes.length - 1].asByte();
+        return code >= codes[0].asByte() && code <= maxCode(v);
     }
 
     public byte asByte() {

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
@@ -68,8 +68,6 @@ public class MessageCodesResolver {
                 setBzzOffset(offset);
                 BzzMessageCodes[] codes = BzzMessageCodes.values();
                 offset += codes[codes.length - 1].asByte() + 1;
-//                offset += BzzMessageCodes.values().length + 4;
-                // FIXME: for some reason Go left 4 codes between BZZ and ETH message codes
             }
         }
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
@@ -60,11 +60,13 @@ public class MessageCodesResolver {
 
             if (capability.getName().equals(Capability.SHH)) {
                 setShhOffset(offset);
+                
                 offset += ShhMessageCodes.maxCode(capability.getVersion()) + 1;
             }
 
             if (capability.getName().equals(Capability.BZZ)) {
                 setBzzOffset(offset);
+
                 offset += BzzMessageCodes.maxCode(capability.getVersion()) + 1;
             }
         }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
@@ -17,19 +17,19 @@
  */
 package org.ethereum.net.rlpx;
 
-import org.ethereum.net.client.Capability;
-import org.ethereum.net.eth.EthVersion;
-import org.ethereum.net.eth.message.EthMessageCodes;
-import org.ethereum.net.p2p.P2pMessageCodes;
-import org.ethereum.net.shh.ShhMessageCodes;
-import org.ethereum.net.swarm.bzz.BzzMessageCodes;
+import static org.ethereum.net.eth.EthVersion.fromCode;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.ethereum.net.eth.EthVersion.*;
+import org.ethereum.net.client.Capability;
+import org.ethereum.net.eth.EthVersion;
+import org.ethereum.net.eth.message.EthMessageCodes;
+import org.ethereum.net.p2p.P2pMessageCodes;
+import org.ethereum.net.shh.ShhMessageCodes;
+import org.ethereum.net.swarm.bzz.BzzMessageCodes;
 
 /**
  * @author Mikhail Kalinin
@@ -54,17 +54,21 @@ public class MessageCodesResolver {
             if (capability.getName().equals(Capability.ETH)) {
                 setEthOffset(offset);
                 EthVersion v = fromCode(capability.getVersion());
+                EthMessageCodes[] codes = EthMessageCodes.values(v);
                 offset += EthMessageCodes.maxCode(v) + 1; // +1 is essential cause STATUS code starts from 0x0
             }
 
             if (capability.getName().equals(Capability.SHH)) {
                 setShhOffset(offset);
-                offset += ShhMessageCodes.values().length;
+                ShhMessageCodes[] codes = ShhMessageCodes.values();
+                offset += codes[codes.length - 1].asByte() + 1;
             }
 
             if (capability.getName().equals(Capability.BZZ)) {
                 setBzzOffset(offset);
-                offset += BzzMessageCodes.values().length + 4;
+                BzzMessageCodes[] codes = BzzMessageCodes.values();
+                offset += codes[codes.length].asByte() + 1;
+//                offset += BzzMessageCodes.values().length + 4;
                 // FIXME: for some reason Go left 4 codes between BZZ and ETH message codes
             }
         }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
@@ -60,13 +60,11 @@ public class MessageCodesResolver {
 
             if (capability.getName().equals(Capability.SHH)) {
                 setShhOffset(offset);
-
                 offset += ShhMessageCodes.maxCode(capability.getVersion()) + 1;
             }
 
             if (capability.getName().equals(Capability.BZZ)) {
                 setBzzOffset(offset);
-
                 offset += BzzMessageCodes.maxCode(capability.getVersion()) + 1;
             }
         }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
@@ -60,7 +60,7 @@ public class MessageCodesResolver {
 
             if (capability.getName().equals(Capability.SHH)) {
                 setShhOffset(offset);
-                
+
                 offset += ShhMessageCodes.maxCode(capability.getVersion()) + 1;
             }
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
@@ -67,7 +67,7 @@ public class MessageCodesResolver {
             if (capability.getName().equals(Capability.BZZ)) {
                 setBzzOffset(offset);
                 BzzMessageCodes[] codes = BzzMessageCodes.values();
-                offset += codes[codes.length].asByte() + 1;
+                offset += codes[codes.length - 1].asByte() + 1;
 //                offset += BzzMessageCodes.values().length + 4;
                 // FIXME: for some reason Go left 4 codes between BZZ and ETH message codes
             }

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/MessageCodesResolver.java
@@ -60,14 +60,12 @@ public class MessageCodesResolver {
 
             if (capability.getName().equals(Capability.SHH)) {
                 setShhOffset(offset);
-                ShhMessageCodes[] codes = ShhMessageCodes.values();
-                offset += codes[codes.length - 1].asByte() + 1;
+                offset += ShhMessageCodes.maxCode(capability.getVersion()) + 1;
             }
 
             if (capability.getName().equals(Capability.BZZ)) {
                 setBzzOffset(offset);
-                BzzMessageCodes[] codes = BzzMessageCodes.values();
-                offset += codes[codes.length - 1].asByte() + 1;
+                offset += BzzMessageCodes.maxCode(capability.getVersion()) + 1;
             }
         }
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/shh/ShhMessageCodes.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/shh/ShhMessageCodes.java
@@ -72,4 +72,14 @@ public enum ShhMessageCodes {
     public byte asByte() {
         return (byte) (cmd);
     }
+
+    public static int maxCode(byte version) {
+
+        int max = 0;
+        for (ShhMessageCodes cd : ShhMessageCodes.values())
+            if (max < cd.asByte())
+                max = cd.asByte();
+
+        return max;
+    }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/net/shh/Topic.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/shh/Topic.java
@@ -17,13 +17,12 @@
  */
 package org.ethereum.net.shh;
 
-import org.ethereum.util.RLP;
-import org.spongycastle.util.encoders.Hex;
+import static org.ethereum.crypto.HashUtil.sha3;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import static org.ethereum.crypto.HashUtil.sha3;
+import org.ethereum.util.RLP;
+import org.spongycastle.util.encoders.Hex;
 
 /**
  * @author by Konstantin Shabalin
@@ -81,6 +80,11 @@ public class Topic {
         if (obj == this) return true;
         if (!(obj instanceof Topic))return false;
         return Arrays.equals(this.abrigedTopic, ((Topic) obj).getBytes());
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(abrigedTopic);
     }
 
     @Override

--- a/ethereumj-core/src/main/java/org/ethereum/net/shh/WhisperImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/shh/WhisperImpl.java
@@ -19,6 +19,7 @@ package org.ethereum.net.shh;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -40,7 +41,8 @@ public class WhisperImpl extends Whisper {
     private Set<MessageWatcher> filters = new HashSet<>();
     private List<Topic> knownTopics = new ArrayList<>();
 
-    private Map<WhisperMessage, ?> known = new LRUMap<>(1024); // essentially Set
+    private Map<WhisperMessage, ?> known = Collections.synchronizedMap(
+            new LRUMap<WhisperMessage, Object>(1024)); // essentially Set
 
     private Map<String, ECKey> identities = new HashMap<>();
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/shh/WhisperImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/shh/WhisperImpl.java
@@ -18,17 +18,20 @@
 package org.ethereum.net.shh;
 
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.collections4.map.LRUMap;
-import org.ethereum.config.SystemProperties;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.stereotype.Component;
-
-import java.nio.charset.StandardCharsets;
-import java.util.*;
 
 @Component
 public class WhisperImpl extends Whisper {

--- a/ethereumj-core/src/main/java/org/ethereum/net/shh/WhisperMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/shh/WhisperMessage.java
@@ -98,9 +98,9 @@ public class WhisperMessage extends ShhMessage {
         if (!(obj instanceof WhisperMessage)) return false;
         WhisperMessage msg = (WhisperMessage) obj;
         if (msg.from == null && msg.from != this.from) return false;
-        if (msg.from == null || !msg.from.equals(this.from)) return false;
+        if (msg.from != null && !msg.from.equals(this.from)) return false;
         if (msg.to == null && msg.to != this.to) return false;
-        if (msg.to == null || !msg.to.equals(this.to)) return false;
+        if (msg.to != null && !msg.to.equals(this.to)) return false;
         if (msg.topics.length != topics.length || !Arrays.asList(msg.topics).containsAll(Arrays.asList(topics))) return false;
         return Hex.toHexString(msg.hash()).equals(Hex.toHexString(this.hash()));
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/shh/WhisperMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/shh/WhisperMessage.java
@@ -85,11 +85,7 @@ public class WhisperMessage extends ShhMessage {
 
     @Override
     public int hashCode() {
-        int result = Arrays.hashCode(topics);
-        result = 31 * result + Arrays.hashCode(payload);
-        result = 31 * result + (to != null ? to.hashCode() : 0);
-        result = 31 * result + (from != null ? from.hashCode() : 0);
-        return result;
+        return Arrays.hashCode(getEncoded());
     }
 
     @Override
@@ -97,12 +93,7 @@ public class WhisperMessage extends ShhMessage {
         if (this == obj) return true;
         if (!(obj instanceof WhisperMessage)) return false;
         WhisperMessage msg = (WhisperMessage) obj;
-        if (msg.from == null && msg.from != this.from) return false;
-        if (msg.from != null && !msg.from.equals(this.from)) return false;
-        if (msg.to == null && msg.to != this.to) return false;
-        if (msg.to != null && !msg.to.equals(this.to)) return false;
-        if (msg.topics.length != topics.length || !Arrays.asList(msg.topics).containsAll(Arrays.asList(topics))) return false;
-        return Hex.toHexString(msg.hash()).equals(Hex.toHexString(this.hash()));
+        return Hex.toHexString(msg.getEncoded()).equals(Hex.toHexString(this.getEncoded()));
     }
 
     public Topic[] getTopics() {

--- a/ethereumj-core/src/main/java/org/ethereum/net/swarm/bzz/BzzMessageCodes.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/swarm/bzz/BzzMessageCodes.java
@@ -72,4 +72,14 @@ public enum BzzMessageCodes {
     public byte asByte() {
         return (byte) (cmd);
     }
+
+    public static int maxCode(byte version) {
+
+        int max = 0;
+        for (BzzMessageCodes cd : BzzMessageCodes.values())
+            if (max < cd.asByte())
+                max = cd.asByte();
+
+        return max;
+    }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/net/wire/AdaptiveMessageIdsTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/wire/AdaptiveMessageIdsTest.java
@@ -17,6 +17,13 @@
  */
 package org.ethereum.net.wire;
 
+import static org.ethereum.net.eth.EthVersion.V62;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.ethereum.net.client.Capability;
 import org.ethereum.net.eth.EthVersion;
 import org.ethereum.net.eth.message.EthMessageCodes;
@@ -24,16 +31,10 @@ import org.ethereum.net.p2p.P2pMessageCodes;
 import org.ethereum.net.rlpx.MessageCodesResolver;
 import org.ethereum.net.shh.ShhHandler;
 import org.ethereum.net.shh.ShhMessageCodes;
-
+import org.ethereum.net.swarm.bzz.BzzHandler;
+import org.ethereum.net.swarm.bzz.BzzMessageCodes;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-
-import static org.ethereum.net.eth.EthVersion.*;
 
 /**
  * @author Roman Mandeleil
@@ -113,40 +114,133 @@ public class AdaptiveMessageIdsTest {
 
         messageCodesResolver.init(capabilities);
 
-        assertEquals(0x10 + 0, messageCodesResolver.withEthOffset(EthMessageCodes.STATUS.asByte()));
-        assertEquals(0x10 + 1, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK_HASHES.asByte()));
-        assertEquals(0x10 + 2, messageCodesResolver.withEthOffset(EthMessageCodes.TRANSACTIONS.asByte()));
-        assertEquals(0x10 + 3, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_HEADERS.asByte()));
-        assertEquals(0x10 + 4, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_HEADERS.asByte()));
-        assertEquals(0x10 + 5, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_BODIES.asByte()));
-        assertEquals(0x10 + 6, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_BODIES.asByte()));
-        assertEquals(0x10 + 7, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK.asByte()));
+        int ethOffset = P2pMessageCodes.USER.asByte() + 1;
+        int shhOffset = ethOffset + EthMessageCodes.NEW_BLOCK.asByte() + 1;
 
-        assertEquals(0x18 + 0, messageCodesResolver.withShhOffset(ShhMessageCodes.STATUS.asByte()));
-        assertEquals(0x18 + 1, messageCodesResolver.withShhOffset(ShhMessageCodes.MESSAGE.asByte()));
-        assertEquals(0x18 + 2, messageCodesResolver.withShhOffset(ShhMessageCodes.FILTER.asByte()));
+        assertEquals(ethOffset + 0, messageCodesResolver.withEthOffset(EthMessageCodes.STATUS.asByte()));
+        assertEquals(ethOffset + 1, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK_HASHES.asByte()));
+        assertEquals(ethOffset + 2, messageCodesResolver.withEthOffset(EthMessageCodes.TRANSACTIONS.asByte()));
+        assertEquals(ethOffset + 3, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_HEADERS.asByte()));
+        assertEquals(ethOffset + 4, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_HEADERS.asByte()));
+        assertEquals(ethOffset + 5, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_BODIES.asByte()));
+        assertEquals(ethOffset + 6, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_BODIES.asByte()));
+        assertEquals(ethOffset + 7, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK.asByte()));
+
+        assertEquals(shhOffset + 0, messageCodesResolver.withShhOffset(ShhMessageCodes.STATUS.asByte()));
+        assertEquals(shhOffset + 1, messageCodesResolver.withShhOffset(ShhMessageCodes.MESSAGE.asByte()));
+        assertEquals(shhOffset + 2, messageCodesResolver.withShhOffset(ShhMessageCodes.FILTER.asByte()));
     }
 
     @Test // Capabilities should be read in alphabetical order
     public void test5() {
 
+        EthVersion ethVersion = EthVersion.V62;
         List<Capability> capabilities = Arrays.asList(
                 new Capability(Capability.SHH, ShhHandler.VERSION),
-                new Capability(Capability.ETH, EthVersion.V62.getCode()));
+                new Capability(Capability.ETH, ethVersion.getCode()));
 
         messageCodesResolver.init(capabilities);
 
-        assertEquals(0x10 + 0, messageCodesResolver.withEthOffset(EthMessageCodes.STATUS.asByte()));
-        assertEquals(0x10 + 1, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK_HASHES.asByte()));
-        assertEquals(0x10 + 2, messageCodesResolver.withEthOffset(EthMessageCodes.TRANSACTIONS.asByte()));
-        assertEquals(0x10 + 3, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_HEADERS.asByte()));
-        assertEquals(0x10 + 4, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_HEADERS.asByte()));
-        assertEquals(0x10 + 5, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_BODIES.asByte()));
-        assertEquals(0x10 + 6, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_BODIES.asByte()));
-        assertEquals(0x10 + 7, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK.asByte()));
+        int ethOffset = P2pMessageCodes.USER.asByte() + 1;
+        int shhOffset = ethOffset + EthMessageCodes.NEW_BLOCK.asByte() + 1;
 
-        assertEquals(0x18 + 0, messageCodesResolver.withShhOffset(ShhMessageCodes.STATUS.asByte()));
-        assertEquals(0x18 + 1, messageCodesResolver.withShhOffset(ShhMessageCodes.MESSAGE.asByte()));
-        assertEquals(0x18 + 2, messageCodesResolver.withShhOffset(ShhMessageCodes.FILTER.asByte()));
+        assertEquals(ethOffset + 0, messageCodesResolver.withEthOffset(EthMessageCodes.STATUS.asByte()));
+        assertEquals(ethOffset + 1, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK_HASHES.asByte()));
+        assertEquals(ethOffset + 2, messageCodesResolver.withEthOffset(EthMessageCodes.TRANSACTIONS.asByte()));
+        assertEquals(ethOffset + 3, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_HEADERS.asByte()));
+        assertEquals(ethOffset + 4, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_HEADERS.asByte()));
+        assertEquals(ethOffset + 5, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_BODIES.asByte()));
+        assertEquals(ethOffset + 6, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_BODIES.asByte()));
+        assertEquals(ethOffset + 7, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK.asByte()));
+
+        assertFalse(EthMessageCodes.inRange((byte)(shhOffset + 0), ethVersion));
+        assertEquals(shhOffset + 0, messageCodesResolver.withShhOffset(ShhMessageCodes.STATUS.asByte()));
+        assertEquals(shhOffset + 1, messageCodesResolver.withShhOffset(ShhMessageCodes.MESSAGE.asByte()));
+        assertEquals(shhOffset + 2, messageCodesResolver.withShhOffset(ShhMessageCodes.FILTER.asByte()));
+    }
+
+    @Test // Verify that eth63 offset is working correctly
+    public void test6() {
+
+        EthVersion ethVersion = EthVersion.V63;
+        List<Capability> capabilities = Arrays.asList(
+                new Capability(Capability.SHH, ShhHandler.VERSION),
+                new Capability(Capability.ETH, ethVersion.getCode()));
+
+        messageCodesResolver.init(capabilities);
+
+        int ethOffset = P2pMessageCodes.USER.asByte() + 1;
+        int shhOffset = ethOffset + EthMessageCodes.RECEIPTS.asByte() + 1;
+        // Verify Eth Offset Lower Boundary
+        byte ethCode = messageCodesResolver.resolveEth(messageCodesResolver.withP2pOffset(P2pMessageCodes.USER.asByte()));
+        assertFalse(EthMessageCodes.inRange(ethCode, ethVersion));
+        assertEquals(ethOffset + 0, messageCodesResolver.withEthOffset(EthMessageCodes.STATUS.asByte()));
+        assertEquals(ethOffset + 1, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK_HASHES.asByte()));
+        assertEquals(ethOffset + 2, messageCodesResolver.withEthOffset(EthMessageCodes.TRANSACTIONS.asByte()));
+        assertEquals(ethOffset + 3, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_HEADERS.asByte()));
+        assertEquals(ethOffset + 4, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_HEADERS.asByte()));
+        assertEquals(ethOffset + 5, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_BODIES.asByte()));
+        assertEquals(ethOffset + 6, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_BODIES.asByte()));
+        assertEquals(ethOffset + 7, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK.asByte()));
+        assertEquals(ethOffset + 13, messageCodesResolver.withEthOffset(EthMessageCodes.GET_NODE_DATA.asByte()));
+        assertEquals(ethOffset + 14, messageCodesResolver.withEthOffset(EthMessageCodes.NODE_DATA.asByte()));
+        assertEquals(ethOffset + 15, messageCodesResolver.withEthOffset(EthMessageCodes.GET_RECEIPTS.asByte()));
+        assertEquals(ethOffset + 16, messageCodesResolver.withEthOffset(EthMessageCodes.RECEIPTS.asByte()));
+
+        // Verify Eth Upper boundary
+        ethCode = messageCodesResolver.resolveEth((byte)(shhOffset + 0));
+        assertFalse(EthMessageCodes.inRange(ethCode, ethVersion));
+
+        // Verify Shh Lower Boundary
+        byte shhCode = messageCodesResolver.resolveShh((byte)(ethOffset + 16));
+        assertFalse(ShhMessageCodes.inRange(shhCode));
+        assertEquals(shhOffset + 0, messageCodesResolver.withShhOffset(ShhMessageCodes.STATUS.asByte()));
+        assertEquals(shhOffset + 1, messageCodesResolver.withShhOffset(ShhMessageCodes.MESSAGE.asByte()));
+        assertEquals(shhOffset + 2, messageCodesResolver.withShhOffset(ShhMessageCodes.FILTER.asByte()));
+    }
+
+    @Test // Checks that offsets works correctly when all capabilities are activated
+    public void test7() {
+        EthVersion ethVersion = EthVersion.V63;
+        List<Capability> capabilities = Arrays.asList(
+                new Capability(Capability.ETH, ethVersion.getCode()),
+                new Capability(Capability.SHH, ShhHandler.VERSION),
+                new Capability(Capability.BZZ, BzzHandler.VERSION));
+
+        messageCodesResolver.init(capabilities);
+
+        int bzzOffset = P2pMessageCodes.USER.asByte() + 1;
+        int ethOffset = bzzOffset + BzzMessageCodes.PEERS.asByte() + 1;
+        int shhOffset = ethOffset + EthMessageCodes.RECEIPTS.asByte() + 1;
+        // Verify Bzz Offset Lower Boundary
+        byte bzzCode = messageCodesResolver.resolveBzz(messageCodesResolver.withP2pOffset(P2pMessageCodes.USER.asByte()));
+        assertFalse(BzzMessageCodes.inRange(bzzCode));
+        assertEquals(bzzOffset + 0, messageCodesResolver.withBzzOffset(BzzMessageCodes.STATUS.asByte()));
+        assertEquals(bzzOffset + 1, messageCodesResolver.withBzzOffset(BzzMessageCodes.STORE_REQUEST.asByte()));
+        assertEquals(bzzOffset + 2, messageCodesResolver.withBzzOffset(BzzMessageCodes.RETRIEVE_REQUEST.asByte()));
+        assertEquals(bzzOffset + 3, messageCodesResolver.withBzzOffset(BzzMessageCodes.PEERS.asByte()));
+        // Verify Bzz Offset Upper Boundary
+        bzzCode = messageCodesResolver.resolveBzz((byte) (ethOffset + 0));
+        assertFalse(BzzMessageCodes.inRange(bzzCode));
+        // Verify Eth Offset Lower Boundary
+        byte ethCode = messageCodesResolver.resolveEth((byte)(bzzOffset + 3));
+        assertFalse(EthMessageCodes.inRange(ethCode, ethVersion));
+        assertEquals(ethOffset + 0, messageCodesResolver.withEthOffset(EthMessageCodes.STATUS.asByte()));
+        assertEquals(ethOffset + 1, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK_HASHES.asByte()));
+        assertEquals(ethOffset + 2, messageCodesResolver.withEthOffset(EthMessageCodes.TRANSACTIONS.asByte()));
+        assertEquals(ethOffset + 3, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_HEADERS.asByte()));
+        assertEquals(ethOffset + 4, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_HEADERS.asByte()));
+        assertEquals(ethOffset + 5, messageCodesResolver.withEthOffset(EthMessageCodes.GET_BLOCK_BODIES.asByte()));
+        assertEquals(ethOffset + 6, messageCodesResolver.withEthOffset(EthMessageCodes.BLOCK_BODIES.asByte()));
+        assertEquals(ethOffset + 7, messageCodesResolver.withEthOffset(EthMessageCodes.NEW_BLOCK.asByte()));
+        // Verify Eth Offset Upper Boundary
+        ethCode = messageCodesResolver.resolveEth((byte)(shhOffset + 0));
+        assertFalse(EthMessageCodes.inRange(ethCode, ethVersion));
+        // Verify Shh Offset Lower Boundary
+        byte shhCode = messageCodesResolver.resolveShh((byte)(ethOffset + 7));
+        assertFalse(ShhMessageCodes.inRange(shhCode));
+        assertEquals(shhOffset + 0, messageCodesResolver.withShhOffset(ShhMessageCodes.STATUS.asByte()));
+        assertEquals(shhOffset + 1, messageCodesResolver.withShhOffset(ShhMessageCodes.MESSAGE.asByte()));
+        assertEquals(shhOffset + 2, messageCodesResolver.withShhOffset(ShhMessageCodes.FILTER.asByte()));
     }
 }


### PR DESCRIPTION
Simple fix that corrects a error in how offsets are calculated. Changed offsets to apply maximum value + 1 instead of length.

This is needed to resolve https://github.com/ethereum/ethereumj/issues/929

Currently `shh` messages are being picked up by the `eth` message handler. The issue was caused by offsets not calculated correctly, causing whisper messages to be picked up by eth63 handler.

This also seems to resolve the offset hack created for swarm.

Follow up fixes:

* Resolved a concurrency issue where whisper messages were corrupting message data when trying to encode content for sending to multiple peers at the same time.