### PR TITLE
Issue907: fix encode method to handle Node created from parsedRlp

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/util/RLP.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/RLP.java
@@ -697,6 +697,20 @@ public class RLP {
         public int size() {
             return cnt;
         }
+
+        // starting with a LList structure, reconstruct and return the original RLP
+        public byte[] makeRlp() {
+            assert (cnt == 2 || cnt == 17);
+            byte[][] encoded = (cnt == 2) ? new byte[2][] : new byte[17][];
+            for (int i = 0; i < cnt; i++) {
+                if (isList(i))
+                    encoded[i] = encodeList(getBytes(i));
+                else 
+                    encoded[i] = encodeElement(getBytes(i));
+            }
+            byte[] ret = encodeList(encoded);
+            return ret;
+        }
     }
 
     public static LList decodeLazyList(byte[] data) {

--- a/ethereumj-core/src/main/java/org/ethereum/util/RLP.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/RLP.java
@@ -153,11 +153,18 @@ public class RLP {
     public static int decodeInt(byte[] data, int index) {
         int value = 0;
         // NOTE: there are two ways zero can be encoded - 0x00 and OFFSET_SHORT_ITEM
+        // RESPONSE NOTE: where is the int zero supposed to be encoded as 0x00?
+        // The Ethereum spec should be clear about the conditions under which
+        // the int zero would be encoded as 0x00 and where as OFFSET_SHORT_ITEM.
+        // If the int zero should always be encoded as OFFSET_SHORT_ITEM,
+        // then this routine should really throw an exception if it sees the
+        // byte 0 at index.
 
         if ((data[index] & 0xFF) < OFFSET_SHORT_ITEM) {
+
             return data[index];
-        } else if ((data[index] & 0xFF) >= OFFSET_SHORT_ITEM
-                && (data[index] & 0xFF) < OFFSET_LONG_ITEM) {
+
+	} else if ((data[index] & 0xFF) <= OFFSET_SHORT_ITEM + 4) {
 
             byte length = (byte) (data[index] - OFFSET_SHORT_ITEM);
             byte pow = (byte) (length - 1);
@@ -166,27 +173,48 @@ public class RLP {
                 pow--;
             }
         } else {
-            throw new RuntimeException("wrong decode attempt");
+
+	    // If there are more than 4 bytes, it is not going
+	    // to decode properly into an int.
+	    throw new RuntimeException("wrong decode attempt");
         }
         return value;
     }
 
     private static short decodeShort(byte[] data, int index) {
-        if ((data[index] & 0xFF) > OFFSET_SHORT_ITEM
-                && (data[index] & 0xFF) < OFFSET_LONG_ITEM) {
-            byte length = (byte) (data[index] - OFFSET_SHORT_ITEM);
-            return ByteBuffer.wrap(data, index, length).getShort();
-        } else {
+
+        short value = 0;
+
+        if ((data[index] & 0xFF) < OFFSET_SHORT_ITEM) {
+
             return data[index];
+
+	} else if ((data[index] & 0xFF) <= OFFSET_SHORT_ITEM + 2) {
+
+            byte length = (byte) (data[index] - OFFSET_SHORT_ITEM);
+            byte pow = (byte) (length - 1);
+            for (int i = 1; i <= length; ++i) {
+                value += (data[index + i] & 0xFF) << (8 * pow);
+                pow--;
+            }
+        } else {
+
+	    // If there are more than 2 bytes, it is not going
+	    // to decode properly into a short.
+	    throw new RuntimeException("wrong decode attempt");
         }
+        return value;
     }
 
     private static long decodeLong(byte[] data, int index) {
 
         long value = 0;
 
-        if ((data[index] & 0xFF) > OFFSET_SHORT_ITEM
-                && (data[index] & 0xFF) < OFFSET_LONG_ITEM) {
+        if ((data[index] & 0xFF) < OFFSET_SHORT_ITEM) {
+
+            return data[index];
+
+	} else if ((data[index] & 0xFF) <= OFFSET_SHORT_ITEM + 8) {
 
             byte length = (byte) (data[index] - OFFSET_SHORT_ITEM);
             byte pow = (byte) (length - 1);
@@ -195,6 +223,9 @@ public class RLP {
                 pow--;
             }
         } else {
+
+	    // If there are more than 8 bytes, it is not going
+	    // to decode properly into a long.
             throw new RuntimeException("wrong decode attempt");
         }
         return value;
@@ -202,7 +233,7 @@ public class RLP {
 
     private static String decodeStringItem(byte[] data, int index) {
 
-        if ((data[index] & 0xFF) >= OFFSET_LONG_ITEM
+        if ((data[index] & 0xFF) > OFFSET_LONG_ITEM
                 && (data[index] & 0xFF) < OFFSET_SHORT_LIST) {
 
             byte lengthOfLength = (byte) (data[index] - OFFSET_LONG_ITEM);
@@ -210,12 +241,20 @@ public class RLP {
             return new String(data, index + lengthOfLength + 1, length);
 
         } else if ((data[index] & 0xFF) > OFFSET_SHORT_ITEM
-                && (data[index] & 0xFF) < OFFSET_LONG_ITEM) {
+                && (data[index] & 0xFF) <= OFFSET_LONG_ITEM) {
 
             byte length = (byte) ((data[index] & 0xFF) - OFFSET_SHORT_ITEM);
             return new String(data, index + 1, length);
 
-        } else {
+        } else if ((data[index] & 0xFF) == OFFSET_SHORT_ITEM) {
+
+            return "";
+
+        } else if ((data[index] & 0xFF) < OFFSET_SHORT_ITEM) {
+
+            return new String(data, index, 1);
+
+	} else {
             throw new RuntimeException("wrong decode attempt");
         }
     }
@@ -223,25 +262,65 @@ public class RLP {
     private static byte[] decodeItemBytes(byte[] data, int index) {
 
         final int length = calculateLength(data, index);
-        byte[] valueBytes = new byte[length];
-        System.arraycopy(data, index, valueBytes, 0, length);
-        return valueBytes;
+	if (length == 0) {
+
+	    return new byte[0];
+
+	} else if ((data[index] & 0xFF) < OFFSET_SHORT_ITEM) {
+
+	    byte[] valueBytes = new byte[1];
+	    System.arraycopy(data, index, valueBytes, 0, 1);
+	    return valueBytes;
+
+	} else if ((data[index] & 0xFF) <= OFFSET_LONG_ITEM) {
+
+	    byte[] valueBytes = new byte[length];
+	    System.arraycopy(data, index+1, valueBytes, 0, length);
+	    return valueBytes;
+
+	} else {
+
+	    byte lengthOfLength = (byte) (data[index] - OFFSET_LONG_ITEM);
+	    byte[] valueBytes = new byte[length];
+	    System.arraycopy(data, index + 1 + lengthOfLength, valueBytes, 0, length);
+	    return valueBytes;
+	}
     }
 
     public static BigInteger decodeBigInteger(byte[] data, int index) {
 
         final int length = calculateLength(data, index);
-        byte[] valueBytes = new byte[length];
-        System.arraycopy(data, index, valueBytes, 0, length);
-        return new BigInteger(1, valueBytes);
+	if (length == 0) {
+
+	    // covers the case where the byte at index is OFFSET_SHORT_ITEM
+	    return BigInteger.ZERO;
+
+	} else if ((data[index] & 0xFF) < OFFSET_SHORT_ITEM) {
+
+	    byte[] valueBytes = new byte[1];
+	    System.arraycopy(data, index, valueBytes, 0, 1);
+	    return new BigInteger(1, valueBytes);
+
+	} else if ((data[index] & 0xFF) <= OFFSET_LONG_ITEM) {
+
+	    byte[] valueBytes = new byte[length];
+	    System.arraycopy(data, index+1, valueBytes, 0, length);
+	    return new BigInteger(1, valueBytes);
+
+	} else {
+
+	    // Now we know that the byte at index is > OFFSET_LONG_ITEM (above)
+	    // and < OFFSET_SHORT_LIST (since no exception in calculateLength)
+	    byte lengthOfLength = (byte) (data[index] - OFFSET_LONG_ITEM);
+	    byte[] valueBytes = new byte[length];
+	    System.arraycopy(data, index + 1 + lengthOfLength, valueBytes, 0, length);
+	    return new BigInteger(1, valueBytes);
+	}
     }
 
     private static byte[] decodeByteArray(byte[] data, int index) {
 
-        final int length = calculateLength(data, index);
-        byte[] valueBytes = new byte[length];
-        System.arraycopy(data, index, valueBytes, 0, length);
-        return valueBytes;
+        return decodeItemBytes(data, index);
     }
 
     private static int nextItemLength(byte[] data, int index) {
@@ -249,13 +328,13 @@ public class RLP {
         if (index >= data.length)
             return -1;
 
-        if ((data[index] & 0xFF) >= OFFSET_LONG_LIST) {
+        if ((data[index] & 0xFF) > OFFSET_LONG_LIST) {
             byte lengthOfLength = (byte) (data[index] - OFFSET_LONG_LIST);
 
             return calcLength(lengthOfLength, data, index);
         }
         if ((data[index] & 0xFF) >= OFFSET_SHORT_LIST
-                && (data[index] & 0xFF) < OFFSET_LONG_LIST) {
+                && (data[index] & 0xFF) <= OFFSET_LONG_LIST) {
 
             return (byte) ((data[index] & 0xFF) - OFFSET_SHORT_LIST);
         }
@@ -298,15 +377,15 @@ public class RLP {
         if (pos >= payload.length)
             return -1;
 
-        if ((payload[pos] & 0xFF) >= OFFSET_LONG_LIST) {
+        if ((payload[pos] & 0xFF) > OFFSET_LONG_LIST) {
             byte lengthOfLength = (byte) (payload[pos] - OFFSET_LONG_LIST);
             return pos + lengthOfLength + 1;
         }
         if ((payload[pos] & 0xFF) >= OFFSET_SHORT_LIST
-                && (payload[pos] & 0xFF) < OFFSET_LONG_LIST) {
+                && (payload[pos] & 0xFF) <= OFFSET_LONG_LIST) {
             return pos + 1;
         }
-        if ((payload[pos] & 0xFF) >= OFFSET_LONG_ITEM
+        if ((payload[pos] & 0xFF) > OFFSET_LONG_ITEM
                 && (payload[pos] & 0xFF) < OFFSET_SHORT_LIST) {
             byte lengthOfLength = (byte) (payload[pos] - OFFSET_LONG_ITEM);
             return pos + lengthOfLength + 1;
@@ -319,18 +398,18 @@ public class RLP {
         if (pos >= payload.length)
             return -1;
 
-        if ((payload[pos] & 0xFF) >= OFFSET_LONG_LIST) {
+        if ((payload[pos] & 0xFF) > OFFSET_LONG_LIST) {
             byte lengthOfLength = (byte) (payload[pos] - OFFSET_LONG_LIST);
             int length = calcLength(lengthOfLength, payload, pos);
             return pos + lengthOfLength + length + 1;
         }
         if ((payload[pos] & 0xFF) >= OFFSET_SHORT_LIST
-                && (payload[pos] & 0xFF) < OFFSET_LONG_LIST) {
+                && (payload[pos] & 0xFF) <= OFFSET_LONG_LIST) {
 
             byte length = (byte) ((payload[pos] & 0xFF) - OFFSET_SHORT_LIST);
             return pos + 1 + length;
         }
-        if ((payload[pos] & 0xFF) >= OFFSET_LONG_ITEM
+        if ((payload[pos] & 0xFF) > OFFSET_LONG_ITEM
                 && (payload[pos] & 0xFF) < OFFSET_SHORT_LIST) {
 
             byte lengthOfLength = (byte) (payload[pos] - OFFSET_LONG_ITEM);
@@ -338,7 +417,7 @@ public class RLP {
             return pos + lengthOfLength + length + 1;
         }
         if ((payload[pos] & 0xFF) > OFFSET_SHORT_ITEM
-                && (payload[pos] & 0xFF) < OFFSET_LONG_ITEM) {
+                && (payload[pos] & 0xFF) <= OFFSET_LONG_ITEM) {
 
             byte length = (byte) ((payload[pos] & 0xFF) - OFFSET_SHORT_ITEM);
             return pos + 1 + length;
@@ -372,7 +451,7 @@ public class RLP {
                 // It's a list with a payload more than 55 bytes
                 // data[0] - 0xF7 = how many next bytes allocated
                 // for the length of the list
-                if ((msgData[pos] & 0xFF) >= OFFSET_LONG_LIST) {
+                if ((msgData[pos] & 0xFF) > OFFSET_LONG_LIST) {
 
                     byte lengthOfLength = (byte) (msgData[pos] - OFFSET_LONG_LIST);
                     int length = calcLength(lengthOfLength, msgData, pos);
@@ -387,9 +466,9 @@ public class RLP {
                     pos += lengthOfLength + length + 1;
                     continue;
                 }
-                // It's a list with a payload less than 55 bytes
+                // It's a list with a payload less than or equal to 55 bytes
                 if ((msgData[pos] & 0xFF) >= OFFSET_SHORT_LIST
-                        && (msgData[pos] & 0xFF) < OFFSET_LONG_LIST) {
+                        && (msgData[pos] & 0xFF) <= OFFSET_LONG_LIST) {
 
                     byte length = (byte) ((msgData[pos] & 0xFF) - OFFSET_SHORT_LIST);
 
@@ -405,7 +484,7 @@ public class RLP {
                 // It's an item with a payload more than 55 bytes
                 // data[0] - 0xB7 = how much next bytes allocated for
                 // the length of the string
-                if ((msgData[pos] & 0xFF) >= OFFSET_LONG_ITEM
+                if ((msgData[pos] & 0xFF) > OFFSET_LONG_ITEM
                         && (msgData[pos] & 0xFF) < OFFSET_SHORT_LIST) {
 
                     byte lengthOfLength = (byte) (msgData[pos] - OFFSET_LONG_ITEM);
@@ -421,7 +500,7 @@ public class RLP {
                 // It's an item less than 55 bytes long,
                 // data[0] - 0x80 == length of the item
                 if ((msgData[pos] & 0xFF) > OFFSET_SHORT_ITEM
-                        && (msgData[pos] & 0xFF) < OFFSET_LONG_ITEM) {
+                        && (msgData[pos] & 0xFF) <= OFFSET_LONG_ITEM) {
 
                     byte length = (byte) ((msgData[pos] & 0xFF) - OFFSET_SHORT_ITEM);
 
@@ -705,7 +784,7 @@ public class RLP {
             for (int i = 0; i < cnt; i++) {
                 if (isList(i))
                     encoded[i] = encodeList(getBytes(i));
-                else 
+                else
                     encoded[i] = encodeElement(getBytes(i));
             }
             byte[] ret = encodeList(encoded);
@@ -1113,16 +1192,24 @@ public class RLP {
 
 
     private static int calculateLength(byte[] data, int index) {
-        if ((data[index] & 0xFF) >= OFFSET_LONG_ITEM
+        if ((data[index] & 0xFF) > OFFSET_LONG_ITEM
                 && (data[index] & 0xFF) < OFFSET_SHORT_LIST) {
 
             byte lengthOfLength = (byte) (data[index] - OFFSET_LONG_ITEM);
             return calcLengthRaw(lengthOfLength, data, index);
 
         } else if ((data[index] & 0xFF) > OFFSET_SHORT_ITEM
-                && (data[index] & 0xFF) < OFFSET_LONG_ITEM) {
+                && (data[index] & 0xFF) <= OFFSET_LONG_ITEM) {
 
             return (byte) (data[index] - OFFSET_SHORT_ITEM);
+
+        } else if ((data[index] & 0xFF) == OFFSET_SHORT_ITEM) {
+
+            return (byte) 0;
+
+        } else if ((data[index] & 0xFF) < OFFSET_SHORT_ITEM) {
+
+            return (byte) 1;
 
         } else {
             throw new RuntimeException("wrong decode attempt");

--- a/ethereumj-core/src/test/java/org/ethereum/util/RLPTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/util/RLPTest.java
@@ -112,7 +112,7 @@ public class RLPTest {
         BigInteger peerId = decodeBigInteger(payload, nextIndex);
 
         BigInteger expectedPeerId =
-                new BigInteger("9650128800487972697726795438087510101805200020100629942070155319087371611597658887860952245483247188023303607186148645071838189546969115967896446355306572");
+                new BigInteger("11356629247358725515654715129711890958861491612873043044752814241820167155109073064559464053586837011802513611263556758124445676272172838679152022396871088");
         assertEquals(expectedPeerId, peerId);
 
         nextIndex = getNextElementIndex(payload, nextIndex);
@@ -128,7 +128,7 @@ public class RLPTest {
         peerId = decodeBigInteger(payload, nextIndex);
 
         expectedPeerId =
-                new BigInteger("9650128800487972697726795438087510101805200020100629942070155319087371611597658887860952245483247188023303607186148645071838189546969115967896446355306572");
+                new BigInteger("11356629247358725515654715129711890958861491612873043044752814241820167155109073064559464053586837011802513611263556758124445676272172838679152022396871088");
 
         assertEquals(expectedPeerId, peerId);
 
@@ -1149,5 +1149,14 @@ public class RLPTest {
         byte[] rlpEncoded = encode(testString);
         String res = new String((byte[])decode(rlpEncoded, 0).getDecoded());
         assertEquals(testString, res); //Fails
+    }
+
+    @Test
+    public void encodeDecodeBigInteger() {
+        BigInteger expected = new BigInteger("9650128800487972697726795438087510101805200020100629942070155319087371611597658887860952245483247188023303607186148645071838189546969115967896446355306572");
+        byte[] encoded = encodeBigInteger(expected);
+        BigInteger decoded = decodeBigInteger(encoded, 0);
+        assertNotNull(decoded);
+        assertEquals(expected, decoded);
     }
 }


### PR DESCRIPTION
Allow encode method to handle case of nondirty Node instantiated by a parsedRlp.

Create a new method makeRlp() that reconstructs and returns an rlp from a
parsedRlp LList object.

Add (parsedRlp != null) case to the if (!dirty) section of the encode method.
Note that the newly created rlp length may be >= 32, so it may need to be saved
and returned as a hash.  The last section of the else clause handles saving a
new rlp.  Move this section of code out of the else clause so it can handle a
new rlp from either the if or else clause.