### PR TITLE
Remove redundant call to rlpParse()

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -257,7 +257,6 @@ public class Transaction {
     }
 
     public byte[] getRawHash() {
-        rlpParse();
         byte[] plainMsg = this.getEncodedRaw();
         return HashUtil.sha3(plainMsg);
     }


### PR DESCRIPTION
A proposed change to avoid redundant method invokations. 
Removed redundant call to `rlpParse();` method. It gets called again in `getEncodedRaw()`.