### PR TITLE
#946 - Fixes for small configuration bugs found by tests

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/NodeFilter.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/NodeFilter.java
@@ -72,8 +72,12 @@ public class NodeFilter {
 
         public boolean accept(Node node) {
             try {
-                return (nodeId == null || Arrays.equals(node.getId(), nodeId))
-                        && (hostIpPattern == null || accept(InetAddress.getByName(node.getHost())));
+                boolean shouldAcceptNodeId = nodeId == null || Arrays.equals(node.getId(), nodeId);
+                if (!shouldAcceptNodeId) {
+                    return false;
+                }
+                InetAddress nodeAddress = InetAddress.getByName(node.getHost());
+                return (hostIpPattern == null || accept(nodeAddress));
             } catch (UnknownHostException e) {
                 return false;
             }

--- a/ethereumj-core/src/main/java/org/ethereum/config/NodeFilter.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/NodeFilter.java
@@ -65,6 +65,7 @@ public class NodeFilter {
         }
 
         public boolean accept(InetAddress nodeAddr) {
+            if (hostIpPattern == null) return true;
             String ip = nodeAddr.getHostAddress();
             return hostIpPattern != null && ip.startsWith(hostIpPattern);
         }

--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -34,6 +34,7 @@ import org.ethereum.net.rlpx.MessageCodec;
 import org.ethereum.net.rlpx.Node;
 import org.ethereum.util.BuildInfo;
 import org.ethereum.util.ByteUtil;
+import org.ethereum.util.Utils;
 import org.ethereum.validator.BlockCustomHashRule;
 import org.ethereum.validator.BlockHeaderValidator;
 import org.slf4j.Logger;
@@ -664,7 +665,7 @@ public class SystemProperties {
     public String privateKey() {
         if (config.hasPath("peer.privateKey")) {
             String key = config.getString("peer.privateKey");
-            if (key.length() != 64) {
+            if (key.length() != 64 || !Utils.isHexEncoded(key)) {
                 throw new RuntimeException("The peer.privateKey needs to be Hex encoded and 32 byte length");
             }
             return key;

--- a/ethereumj-core/src/main/java/org/ethereum/util/Utils.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/Utils.java
@@ -289,4 +289,17 @@ public class Utils {
             Thread.currentThread().interrupt();
         }
     }
+
+    public static boolean isHexEncoded(String value) {
+        if (value == null) return false;
+        if ("".equals(value)) return true;
+
+        try {
+            //noinspection ResultOfMethodCallIgnored
+            new BigInteger(value, 16);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/config/NodeFilterTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/NodeFilterTest.java
@@ -151,19 +151,17 @@ public class NodeFilterTest {
         NodeFilter filter = new NodeFilter();
         filter.add(null, "1.2.3.4");
 
-        Node nodeWithInvalidHostname = new Node(
-                "enode://" + Hex.toHexString(NODE_1) + "@unknown:30303");
+        Node nodeWithInvalidHostname = new Node("enode://" + Hex.toHexString(NODE_1) + "@unknown:30303");
         assertFalse(filter.accept(nodeWithInvalidHostname));
     }
 
     @Test
-    public void acceptInvalidNodeHostnameWhenUsingWildcard() throws Exception {
+    public void doNotAcceptInvalidNodeHostnameWhenUsingWildcard() throws Exception {
         NodeFilter filter = new NodeFilter();
         filter.add(null, null);
 
-        Node nodeWithInvalidHostname = new Node(
-                "enode://" + Hex.toHexString(NODE_1) + "@unknown:30303");
-        assertTrue(filter.accept(nodeWithInvalidHostname));
+        Node nodeWithInvalidHostname = new Node("enode://" + Hex.toHexString(NODE_1) + "@unknown:30303");
+        assertFalse(filter.accept(nodeWithInvalidHostname));
     }
 
     private static Node createTestNode(String nodeName, String hostIpPattern) {

--- a/ethereumj-core/src/test/java/org/ethereum/config/NodeFilterTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/NodeFilterTest.java
@@ -25,11 +25,9 @@ import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class NodeFilterTest {
 
@@ -134,11 +132,11 @@ public class NodeFilterTest {
     }
 
     @Test
-    public void doNotAcceptNullIpPatternAsCatchAllForInetAddresses() throws Exception {
+    public void acceptNullIpPatternAsCatchAllForInetAddresses() throws Exception {
         NodeFilter filter = new NodeFilter();
         filter.add(NODE_1, null);
-        assertFalse(filter.accept(InetAddress.getByName("1.2.3.4")));
-        assertFalse(filter.accept(InetAddress.getByName("255.255.255.255")));
+        assertTrue(filter.accept(InetAddress.getByName("1.2.3.4")));
+        assertTrue(filter.accept(InetAddress.getByName("255.255.255.255")));
     }
 
     @Test

--- a/ethereumj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
@@ -395,7 +395,6 @@ public class SystemPropertiesTest {
         } catch (RuntimeException ignore) { }
     }
 
-    @Ignore
     @Test
     public void testExposeBugWhereNonHexEncodedIsAcceptedWithoutValidation() {
         SystemProperties props = new SystemProperties();

--- a/ethereumj-core/src/test/java/org/ethereum/util/UtilsTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/util/UtilsTest.java
@@ -24,6 +24,8 @@ import org.spongycastle.util.encoders.Hex;
 import java.math.BigInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Roman Mandeleil
@@ -103,6 +105,23 @@ public class UtilsTest {
         expected = null;
         result = Utils.addressStringToBytes(HexStr);
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void testIsHexEncoded() {
+        assertTrue(Utils.isHexEncoded("AAA"));
+        assertTrue(Utils.isHexEncoded("6c386a4b26f73c802f34673f7248bb118f97424a"));
+        assertFalse(Utils.isHexEncoded(null));
+        assertFalse(Utils.isHexEncoded("I am not hex"));
+        assertTrue(Utils.isHexEncoded(""));
+        assertTrue(Utils.isHexEncoded(
+                "6c386a4b26f73c802f34673f7248bb118f97424a" +
+                        "6c386a4b26f73c802f34673f7248bb118f97424a" +
+                        "6c386a4b26f73c802f34673f7248bb118f97424a" +
+                        "6c386a4b26f73c802f34673f7248bb118f97424a" +
+                        "6c386a4b26f73c802f34673f7248bb118f97424a" +
+                        "6c386a4b26f73c802f34673f7248bb118f97424a" +
+                        "6c386a4b26f73c802f34673f7248bb118f97424a"));
     }
 
     @Test


### PR DESCRIPTION
Could you please confirm that my reasoning is correct and that my bug fix is what you expected?

1. No longer accept nodes where the hostname cannot be resolved through `InetAddress.getByName()` **even** when
a `hostIpPattern = null` (wildcard) was provided.
1. Now accepts any InetAddress when `hostIpPattern = null` (wildcard) 
1. Only accept provided privateKey when it's Hex encoded