### PR TITLE
Drop peer if it sends message with framed snappy compression

### DIFF
--- a/ethereumj-core/src/test/java/org/ethereum/net/rlpx/SnappyCodecTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/rlpx/SnappyCodecTest.java
@@ -20,17 +20,20 @@
 
 package org.ethereum.net.rlpx;
 
+import org.ethereum.net.rlpx.discover.NodeStatistics;
 import org.ethereum.net.server.Channel;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.FileCopyUtils;
-
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.ethereum.net.message.ReasonCode.BAD_PROTOCOL;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * EIP-706 provides snappy samples. FrameCodec should be
@@ -38,17 +41,40 @@ import static org.junit.Assert.*;
  */
 public class SnappyCodecTest {
     @Test
-    public void test_decode_go_generated_snappy() throws Exception {
+    public void testDecodeGoGeneratedSnappy() throws Exception {
         Resource golangGeneratedSnappy = new ClassPathResource("/rlp/block.go.snappy");
         List<Object> result = snappyDecode(golangGeneratedSnappy);
         assertEquals(1, result.size());
     }
 
     @Test
-    public void test_decode_python_generated_snappy() throws Exception {
+    public void testDecodePythonGeneratedSnappy() throws Exception {
         Resource pythonGeneratedSnappy = new ClassPathResource("/rlp/block.py.snappy");
         List<Object> result = snappyDecode(pythonGeneratedSnappy);
         assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testFramedDecodeDisconnect() throws Exception {
+        byte[] frameBytes = new byte[] {(byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59};
+        Channel shouldBeDropped = mock(Channel.class);
+        when(shouldBeDropped.getNodeStatistics())
+                .thenReturn(new NodeStatistics(new Node(new byte[0], "", 0)));
+
+        snappyDecode(frameBytes, shouldBeDropped);
+
+        assertTrue(shouldBeDropped.getNodeStatistics().wasDisconnected());
+        String stats = shouldBeDropped.getNodeStatistics().toString();
+        assertTrue(stats.contains(BAD_PROTOCOL.toString()));
+    }
+
+    private void snappyDecode(byte[] payload, Channel channel) throws Exception {
+        SnappyCodec codec = new SnappyCodec(channel);
+
+        FrameCodec.Frame msg = new FrameCodec.Frame(1, payload);
+
+        List<Object> result = newArrayList();
+        codec.decode(null, msg, result);
     }
 
     private List<Object> snappyDecode(Resource hexEncodedSnappyResource) throws Exception {


### PR DESCRIPTION
@mkalinin please, take a look!
I don't like string comparisons in such things but we have no control on errors flow. At least the test should fail if they change something in next versions.