### PR TITLE
Use ByteUtil to convert bytes to number

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/AccountState.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/AccountState.java
@@ -20,6 +20,7 @@ package org.ethereum.core;
 import org.ethereum.config.BlockchainConfig;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.FastByteComparisons;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -82,10 +83,8 @@ public class AccountState {
         this.rlpEncoded = rlpData;
 
         RLPList items = (RLPList) RLP.decode2(rlpEncoded).get(0);
-        this.nonce = items.get(0).getRLPData() == null ? BigInteger.ZERO
-                : new BigInteger(1, items.get(0).getRLPData());
-        this.balance = items.get(1).getRLPData() == null ? BigInteger.ZERO
-                : new BigInteger(1, items.get(1).getRLPData());
+        this.nonce = ByteUtil.bytesToBigInteger(items.get(0).getRLPData());
+        this.balance = ByteUtil.bytesToBigInteger(items.get(1).getRLPData());
         this.stateRoot = items.get(2).getRLPData();
         this.codeHash = items.get(3).getRLPData();
     }

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -19,10 +19,7 @@ package org.ethereum.core;
 
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.util.FastByteComparisons;
-import org.ethereum.util.RLP;
-import org.ethereum.util.RLPList;
-import org.ethereum.util.Utils;
+import org.ethereum.util.*;
 import org.spongycastle.util.Arrays;
 import org.spongycastle.util.BigIntegers;
 import org.spongycastle.util.encoders.Hex;
@@ -123,11 +120,11 @@ public class BlockHeader {
         byte[] guBytes = rlpHeader.get(10).getRLPData();
         byte[] tsBytes = rlpHeader.get(11).getRLPData();
 
-        this.number = nrBytes == null ? 0 : (new BigInteger(1, nrBytes)).longValue();
+        this.number = ByteUtil.byteArrayToLong(nrBytes);
 
         this.gasLimit = glBytes;
-        this.gasUsed = guBytes == null ? 0 : (new BigInteger(1, guBytes)).longValue();
-        this.timestamp = tsBytes == null ? 0 : (new BigInteger(1, tsBytes)).longValue();
+        this.gasUsed = ByteUtil.byteArrayToLong(guBytes);
+        this.timestamp = ByteUtil.byteArrayToLong(tsBytes);
 
         this.extraData = rlpHeader.get(12).getRLPData();
         this.mixHash = rlpHeader.get(13).getRLPData();

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockSummary.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockSummary.java
@@ -17,6 +17,7 @@
  */
 package org.ethereum.core;
 
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
@@ -28,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 import static org.ethereum.util.ByteUtil.toHexString;
 
 public class BlockSummary {
@@ -174,7 +174,7 @@ public class BlockSummary {
 
     private static Map<byte[], BigInteger> decodeRewards(RLPList rewards) {
         return decodeMap(rewards, bytes -> bytes, bytes ->
-                isEmpty(bytes) ? BigInteger.ZERO : new BigInteger(1, bytes)
+                ByteUtil.bytesToBigInteger(bytes)
         );
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockWrapper.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockWrapper.java
@@ -17,6 +17,7 @@
  */
 package org.ethereum.core;
 
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
@@ -160,8 +161,8 @@ public class BlockWrapper {
         byte[] newBlockBytes = wrapper.get(3).getRLPData();
 
         this.block = new Block(blockBytes);
-        this.importFailedAt = importFailedBytes == null ? 0 : new BigInteger(1, importFailedBytes).longValue();
-        this.receivedAt = receivedAtBytes == null ? 0 : new BigInteger(1, receivedAtBytes).longValue();
+        this.importFailedAt = ByteUtil.byteArrayToLong(importFailedBytes);
+        this.receivedAt = ByteUtil.byteArrayToLong(receivedAtBytes);
         byte newBlock = newBlockBytes == null ? 0 : new BigInteger(1, newBlockBytes).byteValue();
         this.newBlock = newBlock == 1;
         this.nodeId = wrapper.get(4).getRLPData();

--- a/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutionSummary.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutionSummary.java
@@ -17,6 +17,7 @@
  */
 package org.ethereum.core;
 
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
@@ -29,7 +30,6 @@ import java.math.BigInteger;
 import java.util.*;
 
 import static java.util.Collections.*;
-import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
 import static org.ethereum.util.BIUtil.toBI;
 
@@ -93,7 +93,7 @@ public class TransactionExecutionSummary {
     }
 
     private static BigInteger decodeBigInteger(byte[] encoded) {
-        return isEmpty(encoded) ? BigInteger.ZERO : new BigInteger(1, encoded);
+        return ByteUtil.bytesToBigInteger(encoded);
     }
 
     public byte[] getEncoded() {

--- a/ethereumj-core/src/main/java/org/ethereum/db/PeerSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/PeerSource.java
@@ -24,6 +24,7 @@ import org.ethereum.datasource.Serializer;
 import org.ethereum.datasource.Source;
 import org.ethereum.datasource.leveldb.LevelDbDataSource;
 import org.ethereum.net.rlpx.Node;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.slf4j.Logger;
@@ -65,10 +66,9 @@ public class PeerSource {
             Node node = new Node(nodeRlp);
             node.setDiscoveryNode(nodeIsDiscovery != null);
 
-            return Pair.of(node, savedReputation == null ? 0 : (new BigInteger(1, savedReputation)).intValue());
+            return Pair.of(node, ByteUtil.byteArrayToInt(savedReputation));
         }
     };
-
 
     public PeerSource(Source<byte[], byte[]> src) {
         this.src = src;

--- a/ethereumj-core/src/main/java/org/ethereum/util/ByteUtil.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/ByteUtil.java
@@ -104,7 +104,7 @@ public class ByteUtil {
     }
 
     public static BigInteger bytesToBigInteger(byte[] bb) {
-        return bb.length == 0 ? BigInteger.ZERO : new BigInteger(1, bb);
+        return (bb == null || bb.length == 0) ? BigInteger.ZERO : new BigInteger(1, bb);
     }
 
     /**

--- a/ethereumj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
@@ -534,4 +534,11 @@ public class ByteUtilTest {
         assertEquals(64, n7);
 
     }
+
+    @Test
+    public void nullArrayToNumber() {
+        assertEquals(BigInteger.ZERO, ByteUtil.bytesToBigInteger(null));
+        assertEquals(0L, ByteUtil.byteArrayToLong(null));
+        assertEquals(0, ByteUtil.byteArrayToInt(null));
+    }
 }


### PR DESCRIPTION
In the current code, there are some lines where a byte array is converted to a number (integer, long, big integer), with an explicit checking of array null.

That functionality (null checking and convert) is already in ByteUtils.

This pull request change those lines to us e ByteUtil methods

The conversion to BigInteger was modified to consider array null, with an additional test to express expected behavior.