### PR TITLE
Support for Ethereum Recovery Proposals

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) [2016] [ <ether.camp> ]
+ * This file is part of the ethereumJ library.
+ *
+ * The ethereumJ library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ethereumJ library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.config.blockchain;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.ethereum.config.BlockchainConfig;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.erp.ErpExecutor;
+import org.ethereum.erp.ErpLoader;
+import org.ethereum.erp.ErpLoader.ErpMetadata;
+import org.ethereum.erp.StateChangeObject;
+import org.ethereum.validator.BlockHeaderRule;
+import org.ethereum.validator.BlockHeaderValidator;
+import org.ethereum.validator.ExtraDataPresenceRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Created by Dan Phifer, 2018-02-01.
+ */
+public class ErpConfig extends FrontierConfig {
+
+    private final long EXTRA_DATA_AFFECTS_BLOCKS_NUMBER = 10;
+    public static final Logger logger = LoggerFactory.getLogger("config");
+
+    private BlockchainConfig parent;
+    private Map<Long, ErpMetadata> erpDataByTargetBlock;
+    private ErpLoader erpLoader = new ErpLoader();
+    private ErpExecutor erpExecutor = new ErpExecutor();
+
+    public ErpConfig() {
+        this(new HomesteadConfig(), "/erps");
+    }
+
+    public ErpConfig(BlockchainConfig parent, String erpResourceDir) {
+        try {
+            initErpConfig(parent, erpResourceDir);
+        } catch (IOException e) {
+            // TODO: not sure what to do here.
+            logger.error("Failed to load the ERPConfig", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    void initErpConfig(BlockchainConfig parent, String erpResourceDir) throws IOException {
+        this.parent = parent;
+        this.constants = parent.getConstants();
+
+        // load the config block numbers
+        final Collection<ErpMetadata> allErps = erpLoader.loadErpMetadata(erpResourceDir);
+        this.erpDataByTargetBlock = allErps
+            .stream()
+            .collect(toMap(ErpMetadata::getTargetBlock, Function.identity()));
+
+        logger.info("Found %d ERPs", allErps.size());
+
+        // add the header validators for each known ERP
+        final List<Pair<Long, BlockHeaderValidator>> headerValidators = headerValidators();
+        erpDataByTargetBlock.forEach((targetBlock, erpMetadata) -> {
+            BlockHeaderRule rule = new ExtraDataPresenceRule(erpMetadata.getErpMarker(), true);
+            headerValidators.add(Pair.of(erpMetadata.getTargetBlock(), new BlockHeaderValidator(rule)));
+        });
+    }
+
+    /**
+     * Miners should include marker for initial 10 blocks. Either "dao-hard-fork" or ""
+     */
+    @Override
+    public byte[] getExtraData(byte[] minerExtraData, long blockNumber) {
+        // TODO: is EXTRA_DATA_AFFECTS_BLOCKS_NUMBER needed?
+        final ErpMetadata erpMetadata = erpDataByTargetBlock.get(blockNumber);
+        return erpMetadata != null
+            ? erpMetadata.getErpMarker()
+            : minerExtraData;
+    }
+
+    @Override
+    public void hardForkTransfers(Block block, Repository repo) {
+        final ErpMetadata erpMetadata = erpDataByTargetBlock.get(block.getNumber());
+        if (erpMetadata != null) {
+            logger.info("Found ERP %s for block %d", erpMetadata.getId(), block.getNumber());
+            final StateChangeObject sco;
+            try {
+                sco = erpLoader.loadStateChangeObject(erpMetadata);
+            } catch (IOException e) {
+                logger.error("Failed to load state change object for " + erpMetadata.getId(), e);
+                throw new RuntimeException("Failed to load state change object for " + erpMetadata.getId(), e);
+            }
+
+            // TODO: Is this the right way to apply changes in  batch?
+            final Repository track = repo.startTracking();
+            try {
+                erpExecutor.applyStateChanges(sco, repo);
+                track.commit();
+                logger.info("Successfully applied ERP '%s' to block %d", erpMetadata.getId(), block.getNumber());
+            }
+            catch (Exception e) {
+                track.rollback();
+                logger.info("Failed to apply ERP '%s' to block %d", erpMetadata.getId(), block.getNumber(), e);
+            }
+            finally {
+                track.close();
+            }
+        }
+    }
+
+    @Override
+    public BigInteger calcDifficulty(BlockHeader curBlock, BlockHeader parent) {
+        return this.parent.calcDifficulty(curBlock, parent);
+    }
+
+    @Override
+    public long getTransactionCost(Transaction tx) {
+        return parent.getTransactionCost(tx);
+    }
+
+    @Override
+    public boolean acceptTransactionSignature(Transaction tx) {
+        return parent.acceptTransactionSignature(tx);
+    }
+}

--- a/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
@@ -62,9 +62,11 @@ public class ErpConfig extends FrontierConfig /* TODO: Is FrontierConfig correct
     public ErpConfig(BlockchainConfig parent, ErpLoader erpLoader, ErpExecutor erpExecutor) {
         this.erpLoader = erpLoader;
         this.erpExecutor = erpExecutor;
+        this.parent = parent;
+        this.constants = parent.getConstants();
 
         try {
-            initErpConfig(parent);
+            initErpConfig();
         } catch (IOException e) {
             // TODO: not sure what to do here.
             logger.error("Failed to load the ERPConfig", e);
@@ -72,10 +74,7 @@ public class ErpConfig extends FrontierConfig /* TODO: Is FrontierConfig correct
         }
     }
 
-    void initErpConfig(BlockchainConfig parent) throws IOException {
-        this.parent = parent;
-        this.constants = parent.getConstants();
-
+    void initErpConfig() throws IOException {
         // load the config block numbers
         final Collection<ErpMetadata> allErps = erpLoader.loadErpMetadata();
         this.erpDataByTargetBlock = allErps

--- a/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
@@ -39,7 +39,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toMap;
 
@@ -122,9 +121,14 @@ public class ErpConfig extends FrontierConfig {
                 track.commit();
                 logger.info("Successfully applied ERP '%s' to block %d", erpMetadata.getId(), block.getNumber());
             }
+            catch (ErpExecutor.ErpExecutionException e) {
+                track.rollback();
+                logger.error("Failed to apply ERP '%s' to block %d", erpMetadata.getId(), block.getNumber(), e);
+            }
             catch (Exception e) {
                 track.rollback();
-                logger.info("Failed to apply ERP '%s' to block %d", erpMetadata.getId(), block.getNumber(), e);
+                logger.error("Failed to apply ERP '%s' to block %d", erpMetadata.getId(), block.getNumber(), e);
+                throw e;
             }
             finally {
                 track.close();

--- a/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
@@ -124,17 +124,17 @@ public class ErpConfig extends FrontierConfig {
             // TODO: Is this the right way to apply changes in  batch?
             final Repository track = repo.startTracking();
             try {
-                erpExecutor.applyStateChanges(sco, repo);
+                erpExecutor.applyStateChanges(sco, track);
                 track.commit();
-                logger.info("Successfully applied ERP '%s' to block %d", erpMetadata.getId(), blockNumber);
+                logger.info("Successfully applied ERP '{}' to block {}", erpMetadata.getId(), blockNumber);
             }
             catch (ErpExecutor.ErpExecutionException e) {
                 track.rollback();
-                logger.error("Failed to apply ERP '%s' to block %d", erpMetadata.getId(), blockNumber, e);
+                logger.error("Failed to apply ERP '{}' to block {}", erpMetadata.getId(), blockNumber, e);
             }
             catch (Exception e) {
                 track.rollback();
-                logger.error("Failed to apply ERP '%s' to block %d", erpMetadata.getId(), blockNumber, e);
+                logger.error("Failed to apply ERP '{}' to block {}", erpMetadata.getId(), blockNumber, e);
                 throw e;
             }
             finally {

--- a/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/blockchain/ErpConfig.java
@@ -107,7 +107,7 @@ public class ErpConfig extends FrontierConfig /* TODO: Is FrontierConfig correct
     public void hardForkTransfers(Block block, Repository repo) {
         final ErpMetadata erpMetadata = erpDataByTargetBlock.get(block.getNumber());
         if (erpMetadata != null) {
-            logger.info("Found ERP %s for block %d", erpMetadata.getId(), erpMetadata.getTargetBlock());
+            logger.info("Found ERP {} for block {}", erpMetadata.getId(), erpMetadata.getTargetBlock());
             doHardForkTransfers(erpMetadata, repo);
         }
     }
@@ -117,7 +117,7 @@ public class ErpConfig extends FrontierConfig /* TODO: Is FrontierConfig correct
         try {
             sco = erpLoader.loadStateChangeObject(erpMetadata);
         } catch (IOException e) {
-            logger.error("Failed to load state change object for " + erpMetadata.getId(), e);
+            logger.error("Failed to load state change object for {}", erpMetadata.getId(), e);
             throw new RuntimeException("Failed to load state change object for " + erpMetadata.getId(), e);
         }
 

--- a/ethereumj-core/src/main/java/org/ethereum/config/net/MainNetConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/net/MainNetConfig.java
@@ -32,6 +32,6 @@ public class MainNetConfig extends BaseNetConfig {
         add(2_463_000, new Eip150HFConfig(new DaoHFConfig()));
         add(2_675_000, new Eip160HFConfig(new DaoHFConfig()));
         add(4_370_000, new ByzantiumConfig(new DaoHFConfig()));
-        add(5_000_000, new ErpConfig());
+        add(6_000_000, new ErpConfig());
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
@@ -63,7 +63,7 @@ public class ErpExecutor {
     }
 
     void applyStoreCode(StateChangeAction action, Repository repo) {
-        if (action.toAddress == EMPTY_BYTE_ARRAY)
+        if (Arrays.equals(action.toAddress , EMPTY_BYTE_ARRAY))
             throw new IllegalArgumentException("storeCode cannot store code at an empty address");
 
         if (!Arrays.equals(action.expectedCodeHash, repo.getCodeHash(action.toAddress)))
@@ -73,7 +73,7 @@ public class ErpExecutor {
     }
 
     void applyWeiTransfer(StateChangeAction action, Repository repo) {
-        if (action.toAddress == EMPTY_BYTE_ARRAY)
+        if (Arrays.equals(action.toAddress , EMPTY_BYTE_ARRAY))
             throw new IllegalArgumentException("weiTransfer cannot transfer to the an empty address");
 
         // is this needed here?  Seems like this check should happen at a lower level (i.e. in the repo)

--- a/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) [2016] [ <ether.camp> ]
+ * This file is part of the ethereumJ library.
+ *
+ * The ethereumJ library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ethereumJ library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.erp;
+
+import org.ethereum.core.Repository;
+import org.ethereum.erp.StateChangeObject.StateChangeAction;
+import org.spongycastle.util.encoders.Hex;
+
+import java.util.Arrays;
+
+import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
+
+/**
+ * The ERP Executor applies State Change Actions to a Repository.
+ */
+public class ErpExecutor {
+    public static final String WEI_TRANSFER = "weiTransfer";
+    public static final String STORE_CODE = "storeCode";
+
+    public void applyStateChanges(StateChangeObject sco, Repository repo) {
+        for (StateChangeAction action : sco.actions) {
+            applyStateChangeAction(action, repo);
+        }
+    }
+
+    void applyStateChangeAction(StateChangeAction action, Repository repo) {
+        switch (action.type) {
+            case WEI_TRANSFER:
+                applyWeiTransfer(action, repo);
+                break;
+            case STORE_CODE:
+                applyStoreCode(action, repo);
+                break;
+            default:
+                throw new UnsupportedOperationException("ERP action type not supported. " + action.type);
+        }
+    }
+
+    void applyStoreCode(StateChangeAction action, Repository repo) {
+        if (action.toAddress == EMPTY_BYTE_ARRAY)
+            throw new IllegalArgumentException("storeCode cannot store code at an empty address");
+
+        if (!Arrays.equals(action.expectedCodeHash, repo.getCodeHash(action.toAddress)))
+            throw new IllegalStateException(String.format("ERP storeCode did not find the expected hash.  Expected %s, found %s", Hex.toHexString(action.expectedCodeHash), Hex.toHexString(repo.getCodeHash(action.toAddress))));
+
+        repo.saveCode(action.toAddress, action.code);
+    }
+
+    void applyWeiTransfer(StateChangeAction action, Repository repo) {
+        if (action.toAddress == EMPTY_BYTE_ARRAY)
+            throw new IllegalArgumentException("weiTransfer cannot transfer to the an empty address");
+
+        // is this needed here?  Seems like this check should happen at a lower level (i.e. in the repo)
+        if (repo.getBalance(action.fromAddress).compareTo(action.valueInWei) < 0)
+            throw new IllegalStateException(String.format("ERP insufficient balance for weiTransfer.  Sender balance of %s less than transfer amount of %s", repo.getBalance(action.fromAddress).toString(), action.valueInWei.toString()));
+
+        repo.addBalance(action.fromAddress, action.valueInWei.negate());
+        repo.addBalance(action.toAddress, action.valueInWei);
+    }
+}

--- a/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
@@ -19,11 +19,12 @@ package org.ethereum.erp;
 
 import org.ethereum.core.Repository;
 import org.ethereum.erp.StateChangeObject.StateChangeAction;
-import org.spongycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import java.util.Arrays;
 
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
+import static org.ethereum.util.ByteUtil.toHexString;
 
 /**
  * The ERP Executor applies State Change Actions to a Repository.
@@ -56,7 +57,7 @@ public class ErpExecutor {
             throw new IllegalArgumentException("storeCode cannot store code at an empty address");
 
         if (!Arrays.equals(action.expectedCodeHash, repo.getCodeHash(action.toAddress)))
-            throw new IllegalStateException(String.format("ERP storeCode did not find the expected hash.  Expected %s, found %s", Hex.toHexString(action.expectedCodeHash), Hex.toHexString(repo.getCodeHash(action.toAddress))));
+            throw new IllegalStateException(String.format("ERP storeCode did not find the expected hash.  Expected %s, found %s", toHexString(action.expectedCodeHash), toHexString(repo.getCodeHash(action.toAddress))));
 
         repo.saveCode(action.toAddress, action.code);
     }

--- a/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
@@ -74,7 +74,7 @@ public class ErpExecutor {
 
     void applyWeiTransfer(StateChangeAction action, Repository repo) {
         if (Arrays.equals(action.toAddress, EMPTY_BYTE_ARRAY))
-            throw new IllegalArgumentException("weiTransfer cannot transfer to the an empty address");
+            throw new IllegalArgumentException("weiTransfer cannot transfer to an empty address");
 
         // is this needed here?  Seems like this check should happen at a lower level (i.e. in the repo)
         if (repo.getBalance(action.fromAddress).compareTo(action.valueInWei) < 0)

--- a/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
@@ -19,7 +19,6 @@ package org.ethereum.erp;
 
 import org.ethereum.core.Repository;
 import org.ethereum.erp.StateChangeObject.StateChangeAction;
-import org.ethereum.util.ByteUtil;
 
 import java.util.Arrays;
 
@@ -33,9 +32,20 @@ public class ErpExecutor {
     public static final String WEI_TRANSFER = "weiTransfer";
     public static final String STORE_CODE = "storeCode";
 
-    public void applyStateChanges(StateChangeObject sco, Repository repo) {
-        for (StateChangeAction action : sco.actions) {
-            applyStateChangeAction(action, repo);
+    public static class ErpExecutionException extends Exception {
+        ErpExecutionException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public void applyStateChanges(StateChangeObject sco, Repository repo) throws ErpExecutionException {
+        try {
+            for (StateChangeAction action : sco.actions) {
+                applyStateChangeAction(action, repo);
+            }
+        }
+        catch (IllegalArgumentException | UnsupportedOperationException e) {
+            throw new ErpExecutionException(e);
         }
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/ErpExecutor.java
@@ -63,7 +63,7 @@ public class ErpExecutor {
     }
 
     void applyStoreCode(StateChangeAction action, Repository repo) {
-        if (Arrays.equals(action.toAddress , EMPTY_BYTE_ARRAY))
+        if (Arrays.equals(action.toAddress, EMPTY_BYTE_ARRAY))
             throw new IllegalArgumentException("storeCode cannot store code at an empty address");
 
         if (!Arrays.equals(action.expectedCodeHash, repo.getCodeHash(action.toAddress)))
@@ -73,7 +73,7 @@ public class ErpExecutor {
     }
 
     void applyWeiTransfer(StateChangeAction action, Repository repo) {
-        if (Arrays.equals(action.toAddress , EMPTY_BYTE_ARRAY))
+        if (Arrays.equals(action.toAddress, EMPTY_BYTE_ARRAY))
             throw new IllegalArgumentException("weiTransfer cannot transfer to the an empty address");
 
         // is this needed here?  Seems like this check should happen at a lower level (i.e. in the repo)

--- a/ethereumj-core/src/main/java/org/ethereum/erp/ErpLoader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/ErpLoader.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) [2016] [ <ether.camp> ]
+ * This file is part of the ethereumJ library.
+ *
+ * The ethereumJ library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ethereumJ library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.erp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ethereum.util.ByteUtil;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ErpLoader {
+    public static final String SCO_EXTENSION = ".sco.json";
+    private static final FilenameFilter SCO_FILE_FILTER = (dir, name) -> name.endsWith(SCO_EXTENSION);
+
+    /**
+     * A lightweight object that can be held in memory
+     */
+    public static class ErpMetadata {
+        Long targetBlock;
+        File resourceFile;
+        String erpId;
+        byte[] erpMarker;
+
+        ErpMetadata(String erpId, Long targetBlock, File resourceFile) {
+            this.erpId = erpId;
+            this.targetBlock = targetBlock;
+            this.resourceFile = resourceFile;
+            this.erpMarker = ByteUtil.hexStringToBytes(asciiToHex(erpId));
+        }
+
+        private static String asciiToHex(String asciiValue){
+            char[] chars = asciiValue.toCharArray();
+            StringBuilder hex = new StringBuilder();
+            for (int i = 0; i < chars.length; i++) {
+                hex.append(Integer.toHexString((int) chars[i]));
+            }
+            return hex.toString();
+        }
+
+        public byte[] getErpMarker() {
+            return erpMarker;
+        }
+
+        public String getId() {
+            return erpId;
+        }
+
+        public long getTargetBlock() {
+            return targetBlock;
+        }
+    }
+
+    /**
+     * This method returns a collection of lightweight objects, but it parses each
+     * file to pull out the erpId and the target block as well as sanity check the actions
+     *
+     * @param erpResourceDir The resource directory where ERP objects are stored
+     * @return A collection of ERPs that are available
+     * @throws IOException if any of the ERP files could not be loaded
+     */
+    public Collection<ErpMetadata> loadErpMetadata(String erpResourceDir) throws IOException {
+        // this is somewhat inefficient, but the goal is to ensure that all important
+        // data is loaded from the SCO object itself
+        List<ErpMetadata> allMetadata = new LinkedList<>();
+        for (File f : loadERPResourceFiles(erpResourceDir)) {
+            final StateChangeObject sco = loadStateChangeObject(f);
+            allMetadata.add(new ErpMetadata(sco.erpId, sco.targetBlock, f));
+        }
+        return allMetadata;
+    }
+
+    /**
+     * Loads the StateChangeObject from a file synchronously
+     * @param metadata The ERP metadata object
+     * @return A StateChangeObject that can be executed against a repo by the ErpExecutor
+     * @throws IOException if the StateChangeObject cannot be loaded.
+     */
+    public StateChangeObject loadStateChangeObject(ErpMetadata metadata) throws IOException {
+        return loadStateChangeObject(metadata.resourceFile);
+    }
+
+    File[] loadERPResourceFiles(String erpResourceDir) throws IOException {
+        URL url = getClass().getResource(erpResourceDir);
+
+        File[] files = url != null
+            ? new File(url.getPath()).listFiles(SCO_FILE_FILTER)
+            : null;
+
+        // an empty array is ok (which would mean there are no files in the directory)
+        if (files == null)
+            throw new IOException("The specified resource directory does not exists: " + erpResourceDir);
+
+        return files;
+    }
+
+    StateChangeObject loadStateChangeObject(File f) throws IOException   {
+        return StateChangeObject.parse(loadRawStateChangeObject(f));
+    }
+
+    RawStateChangeObject loadRawStateChangeObject(File f) throws IOException   {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(f, RawStateChangeObject.class);
+    }
+}

--- a/ethereumj-core/src/main/java/org/ethereum/erp/ErpLoader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/ErpLoader.java
@@ -31,6 +31,11 @@ import java.util.List;
 public class ErpLoader {
     public static final String SCO_EXTENSION = ".sco.json";
     private static final FilenameFilter SCO_FILE_FILTER = (dir, name) -> name.endsWith(SCO_EXTENSION);
+    private final String resourceDir;
+
+    public ErpLoader(String resourceDir) {
+        this.resourceDir = resourceDir;
+    }
 
     /**
      * A lightweight object that can be held in memory
@@ -74,15 +79,14 @@ public class ErpLoader {
      * This method returns a collection of lightweight objects, but it parses each
      * file to pull out the erpId and the target block as well as sanity check the actions
      *
-     * @param erpResourceDir The resource directory where ERP objects are stored
      * @return A collection of ERPs that are available
      * @throws IOException if any of the ERP files could not be loaded
      */
-    public Collection<ErpMetadata> loadErpMetadata(String erpResourceDir) throws IOException {
+    public Collection<ErpMetadata> loadErpMetadata() throws IOException {
         // this is somewhat inefficient, but the goal is to ensure that all important
         // data is loaded from the SCO object itself
         List<ErpMetadata> allMetadata = new LinkedList<>();
-        for (File f : loadERPResourceFiles(erpResourceDir)) {
+        for (File f : loadERPResourceFiles(this.resourceDir)) {
             final StateChangeObject sco = loadStateChangeObject(f);
             allMetadata.add(new ErpMetadata(sco.erpId, sco.targetBlock, f));
         }

--- a/ethereumj-core/src/main/java/org/ethereum/erp/RawStateChangeObject.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/RawStateChangeObject.java
@@ -30,7 +30,7 @@ public class RawStateChangeObject {
         public String type;
         public String fromAddress;
         public String toAddress;
-        public long valueInWei;
+        public String valueInWei;
         public String code;
         public String expectedCodeHash;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/erp/RawStateChangeObject.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/RawStateChangeObject.java
@@ -23,6 +23,7 @@ package org.ethereum.erp;
 public class RawStateChangeObject {
     public String erpId;
     public long targetBlock;
+    public RawMetadata metadata;
     public RawStateChangeAction[] actions;
 
     public static class RawStateChangeAction {
@@ -32,6 +33,11 @@ public class RawStateChangeObject {
         public long valueInWei;
         public String code;
         public String expectedCodeHash;
+    }
+
+    public static class RawMetadata {
+        public long sourceBlock;
+        public String version;
     }
 }
 

--- a/ethereumj-core/src/main/java/org/ethereum/erp/RawStateChangeObject.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/RawStateChangeObject.java
@@ -15,23 +15,24 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.ethereum.config.net;
-
-import org.ethereum.config.blockchain.*;
+package org.ethereum.erp;
 
 /**
- * Created by Anton Nashatyrev on 25.02.2016.
+ * This class maps directly to the SCO file format.
  */
-public class MainNetConfig extends BaseNetConfig {
-    public static final MainNetConfig INSTANCE = new MainNetConfig();
+public class RawStateChangeObject {
+    public String erpId;
+    public long targetBlock;
+    public RawStateChangeAction[] actions;
 
-    public MainNetConfig() {
-        add(0, new FrontierConfig());
-        add(1_150_000, new HomesteadConfig());
-        add(1_920_000, new DaoHFConfig());
-        add(2_463_000, new Eip150HFConfig(new DaoHFConfig()));
-        add(2_675_000, new Eip160HFConfig(new DaoHFConfig()));
-        add(4_370_000, new ByzantiumConfig(new DaoHFConfig()));
-        add(5_000_000, new ErpConfig());
+    public static class RawStateChangeAction {
+        public String type;
+        public String fromAddress;
+        public String toAddress;
+        public long valueInWei;
+        public String code;
+        public String expectedCodeHash;
     }
 }
+
+

--- a/ethereumj-core/src/main/java/org/ethereum/erp/StateChangeObject.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/StateChangeObject.java
@@ -22,6 +22,7 @@ import org.ethereum.erp.RawStateChangeObject.RawStateChangeAction;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+import static org.ethereum.crypto.HashUtil.EMPTY_DATA_HASH;
 import static org.ethereum.util.ByteUtil.hexStringToBytes;
 
 public class StateChangeObject {
@@ -57,7 +58,9 @@ public class StateChangeObject {
             result.toAddress = hexStringToBytes(raw.toAddress);
             result.valueInWei = BigInteger.valueOf(raw.valueInWei);
             result.code = hexStringToBytes(raw.code);
-            result.expectedCodeHash = hexStringToBytes(raw.expectedCodeHash);
+            result.expectedCodeHash = raw.expectedCodeHash == null || raw.expectedCodeHash.isEmpty()
+                    ? EMPTY_DATA_HASH
+                    : hexStringToBytes(raw.expectedCodeHash);
             return result;
         }
     }

--- a/ethereumj-core/src/main/java/org/ethereum/erp/StateChangeObject.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/StateChangeObject.java
@@ -17,6 +17,7 @@
  */
 package org.ethereum.erp;
 
+import org.apache.commons.lang3.StringUtils;
 import org.ethereum.erp.RawStateChangeObject.RawStateChangeAction;
 
 import java.math.BigInteger;
@@ -56,7 +57,11 @@ public class StateChangeObject {
             result.type = raw.type;
             result.fromAddress = hexStringToBytes(raw.fromAddress);
             result.toAddress = hexStringToBytes(raw.toAddress);
-            result.valueInWei = BigInteger.valueOf(raw.valueInWei);
+
+            result.valueInWei = StringUtils.isNotBlank(raw.valueInWei)
+                    ? new BigInteger(raw.valueInWei)
+                    : BigInteger.ZERO;
+
             result.code = hexStringToBytes(raw.code);
             result.expectedCodeHash = raw.expectedCodeHash == null || raw.expectedCodeHash.isEmpty()
                     ? EMPTY_DATA_HASH

--- a/ethereumj-core/src/main/java/org/ethereum/erp/StateChangeObject.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/StateChangeObject.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) [2016] [ <ether.camp> ]
+ * This file is part of the ethereumJ library.
+ *
+ * The ethereumJ library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ethereumJ library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.erp;
+
+import org.ethereum.erp.RawStateChangeObject.RawStateChangeAction;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static org.ethereum.util.ByteUtil.hexStringToBytes;
+
+public class StateChangeObject {
+    public String erpId;
+    public long targetBlock;
+    public StateChangeAction[] actions;
+
+    public static StateChangeObject parse(RawStateChangeObject raw) {
+        StateChangeObject result = new StateChangeObject();
+        result.erpId = raw.erpId;
+        result.targetBlock = raw.targetBlock;
+        result.actions = Arrays.stream(raw.actions)
+                .map(StateChangeAction::parse)
+                .toArray(StateChangeAction[]::new);
+
+        return result;
+    }
+
+    public static class StateChangeAction {
+        String type;
+        byte[] fromAddress;
+        byte[] toAddress;
+
+        BigInteger valueInWei;
+
+        byte[] code;
+        byte[] expectedCodeHash;
+
+        public static StateChangeAction parse(RawStateChangeAction raw) {
+            StateChangeAction result = new StateChangeAction();
+            result.type = raw.type;
+            result.fromAddress = hexStringToBytes(raw.fromAddress);
+            result.toAddress = hexStringToBytes(raw.toAddress);
+            result.valueInWei = BigInteger.valueOf(raw.valueInWei);
+            result.code = hexStringToBytes(raw.code);
+            result.expectedCodeHash = hexStringToBytes(raw.expectedCodeHash);
+            return result;
+        }
+    }
+}
+

--- a/ethereumj-core/src/main/java/org/ethereum/erp/StateChangeObject.java
+++ b/ethereumj-core/src/main/java/org/ethereum/erp/StateChangeObject.java
@@ -62,6 +62,9 @@ public class StateChangeObject {
                     ? new BigInteger(raw.valueInWei)
                     : BigInteger.ZERO;
 
+            if (!result.valueInWei.abs().equals(result.valueInWei))
+                throw new IllegalArgumentException("valueInWei cannot be negative: " + raw.valueInWei);
+
             result.code = hexStringToBytes(raw.code);
             result.expectedCodeHash = raw.expectedCodeHash == null || raw.expectedCodeHash.isEmpty()
                     ? EMPTY_DATA_HASH

--- a/ethereumj-core/src/test/java/org/ethereum/config/blockchain/ErpConfigTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/blockchain/ErpConfigTest.java
@@ -1,7 +1,10 @@
 package org.ethereum.config.blockchain;
 
+import org.ethereum.config.BlockchainConfig;
 import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
 import org.ethereum.datasource.inmem.HashMapDB;
 import org.ethereum.db.RepositoryRoot;
 import org.ethereum.erp.ErpExecutor;
@@ -188,5 +191,32 @@ public class ErpConfigTest
         Mockito.verify(mockRepo, Mockito.never()).commit();
         Mockito.verify(mockRepo, Mockito.never()).rollback();
         Mockito.verify(mockRepo, Mockito.never()).close();
+    }
+
+    /**
+     * Not sure if these delegate methods are needed (or if more are needed).  However, adding this here
+     * to indicate that whatever delegate method calls should be supported, they should be covered in the
+     * test cases.
+     * @throws IOException
+     */
+    @Test
+    public void delegateMethodCalls() throws IOException {
+        BlockchainConfig parent = mock(BlockchainConfig.class);
+        ErpLoader mockLoader = mock(ErpLoader.class);
+        ErpExecutor mockExecutor = mock(ErpExecutor.class);
+        BlockHeader header1 = mock(BlockHeader.class);
+        BlockHeader header2 = mock(BlockHeader.class);
+        Transaction tx = mock(Transaction.class);
+
+        when(mockLoader.loadErpMetadata()).thenReturn(Collections.emptyList());
+
+        ErpConfig config = new ErpConfig(parent, mockLoader, mockExecutor);
+        config.calcDifficulty(header1, header2);
+        config.getTransactionCost(tx);
+        config.acceptTransactionSignature(tx);
+
+        Mockito.verify(parent, Mockito.times(1)).calcDifficulty(header1, header2);
+        Mockito.verify(parent, Mockito.times(1)).getTransactionCost(tx);
+        Mockito.verify(parent, Mockito.times(1)).acceptTransactionSignature(tx);
     }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/config/blockchain/ErpConfigTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/blockchain/ErpConfigTest.java
@@ -1,0 +1,92 @@
+package org.ethereum.config.blockchain;
+
+import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
+import org.ethereum.datasource.inmem.HashMapDB;
+import org.ethereum.db.RepositoryRoot;
+import org.ethereum.util.ByteUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+
+import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ErpConfigTest
+{
+
+    private ErpConfig config;
+    private Repository repo;
+    private static byte[] account1 = Hex.decode("11113D9F938E13CD947EC05ABC7FE734DF8DD826");
+    private static byte[] account2 = Hex.decode("22228AEE95F38490E9769C39B2773ED763D9CD5F");
+    private static byte[] account3 = Hex.decode("33338AEE95F38490E9769C39B2773ED763D9CD5E");
+    private static byte[] account4 = Hex.decode("44448AEE95F38490E9769C39B2773ED763D9CD5E");
+
+    @Before
+    public void setUp() throws Exception {
+        this.config = new ErpConfig();
+        this.repo = new RepositoryRoot(new HashMapDB<>());
+    }
+
+    @Test
+    public void getExtraData_nonTargetBlocks() {
+        final byte[] minerData = Hex.decode("deadbeef");
+        assertArrayEquals(minerData, this.config.getExtraData(minerData, 1));
+        assertArrayEquals(minerData, this.config.getExtraData(minerData, 4_000_000));
+        assertArrayEquals(minerData, this.config.getExtraData(minerData, 7_000_000));
+    }
+
+    @Test
+    public void getExtraData_targetBlock() {
+        final byte[] minerData = Hex.decode("deadbeef");
+        final byte[] expected = ByteUtil.hexStringToBytes("6572702d383838");
+        assertArrayEquals(expected, this.config.getExtraData(minerData, 6000000));
+    }
+
+    @Test
+    public void hardForkTransfers_targetBlock() {
+        repo.addBalance(account1, BigInteger.valueOf(1234L));
+        repo.saveCode(account3, ByteUtil.hexStringToBytes("0xdada"));
+
+        final Block block = Mockito.mock(Block.class);
+        Mockito.when(block.getNumber()).thenReturn(6000000L);
+        Repository spyRepo = Mockito.spy(repo);
+
+        this.config.hardForkTransfers(block, spyRepo);
+
+        assertEquals(BigInteger.ZERO, repo.getBalance(account1));
+        assertEquals(BigInteger.valueOf(1234L), repo.getBalance(account2));
+
+        assertArrayEquals(ByteUtil.hexStringToBytes("0xdeadbeef3"), repo.getCode(account3));
+        assertArrayEquals(ByteUtil.hexStringToBytes("0xdeadbeef4"), repo.getCode(account4));
+
+        Mockito.verify(spyRepo, Mockito.times(2)).saveCode(Mockito.any(), Mockito.any());
+        Mockito.verify(spyRepo, Mockito.times(2)).addBalance(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void hardForkTransfers_nonTargetBlock() {
+        repo.addBalance(account1, BigInteger.valueOf(1234L));
+        repo.saveCode(account3, ByteUtil.hexStringToBytes("0xdada"));
+
+        final Block block = Mockito.mock(Block.class);
+        Mockito.when(block.getNumber()).thenReturn(456L);
+
+        Repository spyRepo = Mockito.spy(repo);
+
+        this.config.hardForkTransfers(block, spyRepo);
+
+        assertEquals(BigInteger.valueOf(1234L), repo.getBalance(account1));
+        assertEquals(BigInteger.ZERO, repo.getBalance(account2));
+
+        assertArrayEquals(ByteUtil.hexStringToBytes("0xdada"), repo.getCode(account3));
+        assertArrayEquals(EMPTY_BYTE_ARRAY, repo.getCode(account4));
+
+        Mockito.verify(spyRepo, Mockito.never()).saveCode(Mockito.any(), Mockito.any());
+        Mockito.verify(spyRepo, Mockito.never()).addBalance(Mockito.any(), Mockito.any());
+    }
+}

--- a/ethereumj-core/src/test/java/org/ethereum/erp/ErpExecutorTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/erp/ErpExecutorTest.java
@@ -19,9 +19,9 @@ import static org.junit.Assert.assertEquals;
 
 public class ErpExecutorTest
 {
-    private static byte[] account1 = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
-    private static byte[] account2 = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
-    private static byte[] account3 = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5E");
+    private static byte[] account1 = Hex.decode("11113D9F938E13CD947EC05ABC7FE734DF8DD826");
+    private static byte[] account2 = Hex.decode("22228AEE95F38490E9769C39B2773ED763D9CD5F");
+    private static byte[] account3 = Hex.decode("33338AEE95F38490E9769C39B2773ED763D9CD5E");
     private ErpExecutor executor;
     private RepositoryRoot repo;
 

--- a/ethereumj-core/src/test/java/org/ethereum/erp/ErpExecutorTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/erp/ErpExecutorTest.java
@@ -1,0 +1,222 @@
+package org.ethereum.erp;
+
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.datasource.inmem.HashMapDB;
+import org.ethereum.db.RepositoryRoot;
+import org.ethereum.erp.StateChangeObject.StateChangeAction;
+import org.ethereum.util.ByteUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class ErpExecutorTest
+{
+    static byte[] account1   = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
+    static byte[] account2 = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
+    static byte[] account3 = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5E");
+    private ErpExecutor executor;
+    private RepositoryRoot repo;
+
+    @Before
+    public void setup() {
+        this.executor = new ErpExecutor();
+        this.repo = new RepositoryRoot(new HashMapDB<>());
+    }
+
+    @After
+    public void cleanup() {
+        this.repo.close();
+    }
+
+    @Test
+    public void applyStateChanges() {
+        byte[] existingCode = Hex.decode("deadbeef");
+        repo.saveCode(account3, existingCode);
+        repo.addBalance(account1, BigInteger.TEN);
+        byte[] currentHash = repo.getCodeHash(account3);
+
+        byte[] newCode = Hex.decode("deadbeef1234");
+
+        executor.applyStateChanges(
+                createStateChangeObject(
+                        createTransferAction(account1, account2, BigInteger.ONE),
+                        createStoreCodeAction(account3, currentHash, newCode),
+                        createTransferAction(account1, account3, BigInteger.ONE)
+                ),
+                repo);
+
+        assertEquals(repo.getBalance(account1), BigInteger.valueOf(8L));
+        assertEquals(repo.getBalance(account2), BigInteger.valueOf(1L));
+        assertEquals(repo.getBalance(account3), BigInteger.valueOf(1L));
+        assertEquals(repo.getCode(account3), newCode);
+    }
+
+    @Test
+    public void applyWeiTransfer() {
+        repo.addBalance(account1, BigInteger.TEN);
+
+        executor.applyWeiTransfer(
+                createTransferAction(account1, account2, BigInteger.valueOf(3L)),
+                repo);
+
+        assertEquals(repo.getBalance(account1), BigInteger.valueOf(7L));
+        assertEquals(repo.getBalance(account2), BigInteger.valueOf(3L));
+    }
+
+    @Test
+    public void applyStoreCode(){
+        byte[] existingCode = Hex.decode("deadbeef");
+        repo.saveCode(account1, existingCode);
+        byte[] currentHash = repo.getCodeHash(account1);
+
+        byte[] newCode = Hex.decode("deadbeef1234");
+
+        // calling storeCode directly
+        executor.applyStoreCode(
+                createStoreCodeAction(account1, currentHash, newCode),
+                repo);
+
+        assertEquals(repo.getCode(account1), newCode);
+    }
+
+
+
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void applyStateChanges_failsWithUnkOp() {
+        byte[] existingCode = Hex.decode("deadbeef");
+        repo.saveCode(account3, existingCode);
+        repo.addBalance(account1, BigInteger.TEN);
+        byte[] currentHash = repo.getCodeHash(account3);
+
+        byte[] newCode = Hex.decode("deadbeef1234");
+
+        executor.applyStateChanges(
+                createStateChangeObject(
+                        createTransferAction(account1, account2, BigInteger.ONE),
+                        createStoreCodeAction(account3, currentHash, newCode),
+                        createUnsupportedAction(account2),
+                        createTransferAction(account1, account3, BigInteger.ONE)
+                ),
+                repo);
+    }
+
+    @Test
+    public void applyStateChangeAction_transfer() {
+        repo.addBalance(account1, BigInteger.TEN);
+
+        // calling weiTransfer via applyStateChangeAction
+        executor.applyStateChangeAction(
+                createTransferAction(account1, account2, BigInteger.valueOf(3L)),
+                repo);
+
+        assertEquals(repo.getBalance(account1), BigInteger.valueOf(7L));
+        assertEquals(repo.getBalance(account2), BigInteger.valueOf(3L));
+    }
+
+    @Test
+    public void applyStateChangeAction_store() {
+        byte[] existingCode = Hex.decode("deadbeef");
+        repo.saveCode(account1, existingCode);
+        byte[] currentHash = repo.getCodeHash(account1);
+
+        byte[] newCode = Hex.decode("deadbeef1234");
+
+        // calling storeCode via applyStateChangeAction
+        executor.applyStateChangeAction(
+                createStoreCodeAction(account1, currentHash, newCode),
+                repo);
+
+        assertEquals(repo.getCode(account1), newCode);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void applyStateChangeAction_Unk() {
+        executor.applyStateChangeAction(
+                createUnsupportedAction(account1),
+                repo);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void applyStoreCode_BadAddress() {
+        byte[] existingCode = Hex.decode("deadbeef");
+        repo.saveCode(account1, existingCode);
+        byte[] currentHash = repo.getCodeHash(account1);
+
+        byte[] newCode = Hex.decode("deadbeef1234");
+
+        executor.applyStoreCode(
+                createStoreCodeAction(ByteUtil.hexStringToBytes(null), currentHash, newCode),
+                repo);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void applyStoreCode_WrongHash(){
+        byte[] existingCode = Hex.decode("deadbeef");
+        repo.saveCode(account1, existingCode);
+
+
+        byte[] newCode = Hex.decode("deadbeef1234");
+        byte[] wrongHash = HashUtil.sha3(Hex.decode("deadbeefdeadbeef"));
+
+        executor.applyStoreCode(
+                createStoreCodeAction(account1, wrongHash, newCode),
+                repo);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void applyWeiTransfer_InsufficientFunds() {
+        repo.addBalance(account1, BigInteger.TEN);
+
+        executor.applyWeiTransfer(
+                createTransferAction(account1, account2, BigInteger.valueOf(20L)),
+                repo);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void applyWeiTransfer_BadAddress() {
+        repo.addBalance(account1, BigInteger.TEN);
+
+        executor.applyWeiTransfer(
+                createTransferAction(account1, ByteUtil.hexStringToBytes(null), BigInteger.valueOf(1L)),
+                repo);
+    }
+
+    private static StateChangeAction createTransferAction(byte[] fromAddress, byte[] toAddress, BigInteger value) {
+        final StateChangeAction action = new StateChangeAction();
+        action.toAddress = toAddress;
+        action.fromAddress = fromAddress;
+        action.type = ErpExecutor.WEI_TRANSFER;
+        action.valueInWei = value;
+        return action;
+    }
+
+    private static StateChangeAction createStoreCodeAction(byte[] toAddress, byte[] expectedHash, byte[] code) {
+        final StateChangeAction action = new StateChangeAction();
+        action.toAddress = toAddress;
+        action.type = ErpExecutor.STORE_CODE;
+        action.code = code;
+        action.expectedCodeHash = expectedHash;
+        return action;
+    }
+
+    private static StateChangeAction createUnsupportedAction(byte[] toAddress) {
+        final StateChangeAction action = new StateChangeAction();
+        action.toAddress = toAddress;
+        action.type = "doSomethingNaughty";
+        return action;
+    }
+
+    private static StateChangeObject createStateChangeObject(StateChangeAction ... actions) {
+        final StateChangeObject sco = new StateChangeObject();
+        sco.targetBlock = 1234;
+        sco.erpId = "eip-999";
+        sco.actions = actions;
+        return sco;
+    }
+}

--- a/ethereumj-core/src/test/java/org/ethereum/erp/ErpExecutorTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/erp/ErpExecutorTest.java
@@ -12,13 +12,16 @@ import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
+import static org.ethereum.erp.ErpExecutor.ErpExecutionException;
+import static org.ethereum.erp.ErpExecutor.STORE_CODE;
+import static org.ethereum.erp.ErpExecutor.WEI_TRANSFER;
 import static org.junit.Assert.assertEquals;
 
 public class ErpExecutorTest
 {
-    static byte[] account1   = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
-    static byte[] account2 = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
-    static byte[] account3 = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5E");
+    private static byte[] account1 = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
+    private static byte[] account2 = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
+    private static byte[] account3 = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5E");
     private ErpExecutor executor;
     private RepositoryRoot repo;
 
@@ -34,7 +37,7 @@ public class ErpExecutorTest
     }
 
     @Test
-    public void applyStateChanges() {
+    public void applyStateChanges() throws ErpExecutionException {
         byte[] existingCode = Hex.decode("deadbeef");
         repo.saveCode(account3, existingCode);
         repo.addBalance(account1, BigInteger.TEN);
@@ -87,8 +90,8 @@ public class ErpExecutorTest
 
 
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void applyStateChanges_failsWithUnkOp() {
+    @Test(expected = ErpExecutor.ErpExecutionException.class)
+    public void applyStateChanges_failsWithUnkOp() throws ErpExecutionException {
         byte[] existingCode = Hex.decode("deadbeef");
         repo.saveCode(account3, existingCode);
         repo.addBalance(account1, BigInteger.TEN);
@@ -191,7 +194,7 @@ public class ErpExecutorTest
         final StateChangeAction action = new StateChangeAction();
         action.toAddress = toAddress;
         action.fromAddress = fromAddress;
-        action.type = ErpExecutor.WEI_TRANSFER;
+        action.type = WEI_TRANSFER;
         action.valueInWei = value;
         return action;
     }
@@ -199,7 +202,7 @@ public class ErpExecutorTest
     private static StateChangeAction createStoreCodeAction(byte[] toAddress, byte[] expectedHash, byte[] code) {
         final StateChangeAction action = new StateChangeAction();
         action.toAddress = toAddress;
-        action.type = ErpExecutor.STORE_CODE;
+        action.type = STORE_CODE;
         action.code = code;
         action.expectedCodeHash = expectedHash;
         return action;

--- a/ethereumj-core/src/test/java/org/ethereum/erp/ErpExecutorTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/erp/ErpExecutorTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.erp;
 
+import org.ethereum.core.Repository;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.datasource.inmem.HashMapDB;
 import org.ethereum.db.RepositoryRoot;
@@ -8,6 +9,8 @@ import org.ethereum.util.ByteUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;

--- a/ethereumj-core/src/test/java/org/ethereum/erp/ErpLoaderTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/erp/ErpLoaderTest.java
@@ -20,13 +20,13 @@ public class ErpLoaderTest
 
     @Before
     public void setUp() throws Exception {
-        this.loader = new ErpLoader();
+        this.loader = new ErpLoader("/erps");
     }
 
 
     @Test
     public void loadErpMetadata() throws IOException {
-        final Collection<ErpMetadata> erpMetadata = loader.loadErpMetadata("/erps");
+        final Collection<ErpMetadata> erpMetadata = loader.loadErpMetadata();
         assertEquals(2, erpMetadata.size());
 
         final Iterator<ErpMetadata> iterator = erpMetadata.iterator();

--- a/ethereumj-core/src/test/java/org/ethereum/erp/ErpLoaderTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/erp/ErpLoaderTest.java
@@ -1,0 +1,83 @@
+package org.ethereum.erp;
+
+import org.ethereum.erp.ErpLoader.ErpMetadata;
+import org.ethereum.util.ByteUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ErpLoaderTest
+{
+
+    private ErpLoader loader;
+
+    @Before
+    public void setUp() throws Exception {
+        this.loader = new ErpLoader();
+    }
+
+
+    @Test
+    public void loadErpMetadata() throws IOException {
+        final Collection<ErpMetadata> erpMetadata = loader.loadErpMetadata("/erps");
+        assertEquals(2, erpMetadata.size());
+
+        final Iterator<ErpMetadata> iterator = erpMetadata.iterator();
+        ErpMetadata metadata1 = iterator.next();
+        ErpMetadata metadata2 = iterator.next();
+
+        assertEquals(6000000, metadata1.getTargetBlock());
+        assertEquals("erp-888", metadata1.getId());
+        assertArrayEquals(ByteUtil.hexStringToBytes("6572702d383838"), metadata1.getErpMarker());
+    }
+
+    @Test
+    public void loadERPResourceFiles() throws IOException {
+        final File[] files = loader.loadERPResourceFiles("/erps");
+        assertEquals(2, files.length);
+        assertEquals("erp888.sco.json", files[0].getName());
+        assertEquals("erp999.sco.json", files[1].getName());
+    }
+
+    @Test(expected = IOException.class)
+    public void loadERPResourceFiles_BadDirectory() throws IOException {
+        loader.loadERPResourceFiles("/xxx");
+    }
+
+    @Test
+    public void loadStateChangeObject_metadata() throws IOException {
+        final File file = new File(getClass().getResource("/erps/erp999.sco.json").getPath());
+        final StateChangeObject sco = loader.loadStateChangeObject(new ErpMetadata("ignored", 0L, file));
+
+        assertEquals("erp-999", sco.erpId);
+        assertEquals(5000000L, sco.targetBlock);
+        assertEquals(2,sco.actions.length);
+    }
+
+    @Test
+    public void loadStateChangeObject_file() throws IOException {
+        final File file = new File(getClass().getResource("/erps/erp999.sco.json").getPath());
+        final StateChangeObject sco = loader.loadStateChangeObject(file);
+
+        assertEquals("erp-999", sco.erpId);
+        assertEquals(5000000L, sco.targetBlock);
+        assertEquals(2,sco.actions.length);
+    }
+
+    @Test
+    public void loadRawStateChangeObject_file() throws IOException {
+        final File file = new File(getClass().getResource("/erps/erp999.sco.json").getPath());
+        final RawStateChangeObject sco = loader.loadRawStateChangeObject(file);
+
+        assertEquals("erp-999", sco.erpId);
+        assertEquals(5000000L, sco.targetBlock);
+        assertEquals(2,sco.actions.length);
+    }
+}

--- a/ethereumj-core/src/test/java/org/ethereum/erp/ErpLoaderTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/erp/ErpLoaderTest.java
@@ -7,11 +7,15 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static java.util.stream.Collectors.toMap;
+import static org.junit.Assert.*;
 
 public class ErpLoaderTest
 {
@@ -29,21 +33,25 @@ public class ErpLoaderTest
         final Collection<ErpMetadata> erpMetadata = loader.loadErpMetadata();
         assertEquals(2, erpMetadata.size());
 
-        final Iterator<ErpMetadata> iterator = erpMetadata.iterator();
-        ErpMetadata metadata1 = iterator.next();
-        ErpMetadata metadata2 = iterator.next();
+        final Map<String, ErpMetadata> erpsById = erpMetadata.stream()
+                .collect(toMap(ErpMetadata::getId, Function.identity()));
 
-        assertEquals(6000000, metadata1.getTargetBlock());
-        assertEquals("erp-888", metadata1.getId());
-        assertArrayEquals(ByteUtil.hexStringToBytes("6572702d383838"), metadata1.getErpMarker());
+        ErpMetadata erp888 = erpsById.get("erp-888");
+        ErpMetadata erp999 = erpsById.get("erp-999");
+        assertNotNull("Did not find erp888", erp888);
+        assertNotNull("Did not find erp999", erp999);
+
+        assertEquals(6000000, erp888.getTargetBlock());
+        assertArrayEquals(ByteUtil.hexStringToBytes("6572702d383838"), erp888.getErpMarker());
     }
 
     @Test
     public void loadERPResourceFiles() throws IOException {
         final File[] files = loader.loadERPResourceFiles("/erps");
         assertEquals(2, files.length);
-        assertEquals("erp888.sco.json", files[0].getName());
-        assertEquals("erp999.sco.json", files[1].getName());
+        List<String> fileNames = Arrays.stream(files).map(File::getName).collect(Collectors.toList());
+        assertTrue(fileNames.contains("erp888.sco.json"));
+        assertTrue(fileNames.contains("erp999.sco.json"));
     }
 
     @Test(expected = IOException.class)

--- a/ethereumj-core/src/test/java/org/ethereum/erp/StateChangeObjectTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/erp/StateChangeObjectTest.java
@@ -1,0 +1,47 @@
+package org.ethereum.erp;
+
+import org.ethereum.erp.RawStateChangeObject.RawStateChangeAction;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import static org.ethereum.crypto.HashUtil.EMPTY_DATA_HASH;
+import static org.junit.Assert.*;
+
+public class StateChangeObjectTest {
+
+    private static String strAccount1 = "11113D9F938E13CD947EC05ABC7FE734DF8DD826";
+    private static String strAccount2 = "22223D9F938E13CD947EC05ABC7FE734DF8DD826";
+    private static byte[] account1 = Hex.decode(strAccount1);
+    private static byte[] account2 = Hex.decode(strAccount2);
+
+    @Test
+    public void parseOk() {
+        RawStateChangeObject raw = new RawStateChangeObject();
+        raw.erpId = "eip-1234";
+        raw.targetBlock = 1234L;
+        RawStateChangeAction rawAction = new RawStateChangeAction();
+        rawAction.fromAddress = strAccount1;
+        rawAction.toAddress = strAccount2;
+        rawAction.valueInWei = "123";
+        rawAction.type = "weiTransfer";
+        raw.actions = new RawStateChangeAction[]{ rawAction };
+
+        final StateChangeObject sco = StateChangeObject.parse(raw);
+
+        assertEquals(1234L, sco.targetBlock);
+        assertEquals("eip-1234", sco.erpId);
+        assertEquals(EMPTY_DATA_HASH, sco.actions[0].expectedCodeHash);
+        assertArrayEquals(account1, sco.actions[0].fromAddress);
+        assertArrayEquals(account2, sco.actions[0].toAddress);
+        assertEquals("weiTransfer", sco.actions[0].type);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFailsOnNegativeValue() {
+        RawStateChangeObject raw = new RawStateChangeObject();
+        RawStateChangeAction rawAction = new RawStateChangeAction();
+        rawAction.valueInWei = "-1";
+        raw.actions = new RawStateChangeAction[]{ rawAction };
+        StateChangeObject.parse(raw);
+    }
+}

--- a/ethereumj-core/src/test/resources/erps/erp888.sco.json
+++ b/ethereumj-core/src/test/resources/erps/erp888.sco.json
@@ -4,21 +4,21 @@
   "actions": [
     {
       "type": "weiTransfer",
-      "fromAddress": "CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826",
-      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "fromAddress": "11113D9F938E13CD947EC05ABC7FE734DF8DD826",
+      "toAddress": "22228AEE95F38490E9769C39B2773ED763D9CD5F",
       "valueInWei": 1234
     },
     {
       "type": "storeCode",
-      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
-      "expectedCodeHash": "0xF38490",
-      "code": "0xdeadbeef"
+      "toAddress": "33338AEE95F38490E9769C39B2773ED763D9CD5E",
+      "expectedCodeHash": "880dc19d7dcdd8b388fe5f987bb2495eea5f4ca1cb2879eecdacf2bc48a34265",
+      "code": "0xdeadbeef3"
     },
     {
       "type": "storeCode",
-      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "toAddress": "44448AEE95F38490E9769C39B2773ED763D9CD5E",
       "expectedCodeHash": "",
-      "code": "0xdeadbeef"
+      "code": "0xdeadbeef4"
     }
   ]
 }

--- a/ethereumj-core/src/test/resources/erps/erp888.sco.json
+++ b/ethereumj-core/src/test/resources/erps/erp888.sco.json
@@ -8,19 +8,19 @@
   "actions": [
     {
       "type": "weiTransfer",
-      "fromAddress": "11113D9F938E13CD947EC05ABC7FE734DF8DD826",
-      "toAddress": "22228AEE95F38490E9769C39B2773ED763D9CD5F",
+      "fromAddress": "0x11113D9F938E13CD947EC05ABC7FE734DF8DD826",
+      "toAddress": "0x22228AEE95F38490E9769C39B2773ED763D9CD5F",
       "valueInWei": 1234
     },
     {
       "type": "storeCode",
-      "toAddress": "33338AEE95F38490E9769C39B2773ED763D9CD5E",
-      "expectedCodeHash": "880dc19d7dcdd8b388fe5f987bb2495eea5f4ca1cb2879eecdacf2bc48a34265",
+      "toAddress": "0x33338AEE95F38490E9769C39B2773ED763D9CD5E",
+      "expectedCodeHash": "0x880dc19d7dcdd8b388fe5f987bb2495eea5f4ca1cb2879eecdacf2bc48a34265",
       "code": "0xdeadbeef3"
     },
     {
       "type": "storeCode",
-      "toAddress": "44448AEE95F38490E9769C39B2773ED763D9CD5E",
+      "toAddress": "0x44448AEE95F38490E9769C39B2773ED763D9CD5E",
       "expectedCodeHash": "",
       "code": "0xdeadbeef4"
     }

--- a/ethereumj-core/src/test/resources/erps/erp888.sco.json
+++ b/ethereumj-core/src/test/resources/erps/erp888.sco.json
@@ -1,6 +1,10 @@
 {
   "erpId": "erp-888",
   "targetBlock": 6000000,
+  "metadata": {
+    "sourceBlock": 5000000,
+    "version": "1.0.0"
+  },
   "actions": [
     {
       "type": "weiTransfer",

--- a/ethereumj-core/src/test/resources/erps/erp888.sco.json
+++ b/ethereumj-core/src/test/resources/erps/erp888.sco.json
@@ -1,0 +1,24 @@
+{
+  "erpId": "erp-888",
+  "targetBlock": 6000000,
+  "actions": [
+    {
+      "type": "weiTransfer",
+      "fromAddress": "CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826",
+      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "valueInWei": 1234
+    },
+    {
+      "type": "storeCode",
+      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "expectedCodeHash": "0xF38490",
+      "code": "0xdeadbeef"
+    },
+    {
+      "type": "storeCode",
+      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "expectedCodeHash": "",
+      "code": "0xdeadbeef"
+    }
+  ]
+}

--- a/ethereumj-core/src/test/resources/erps/erp999.sco.json
+++ b/ethereumj-core/src/test/resources/erps/erp999.sco.json
@@ -1,0 +1,18 @@
+{
+  "erpId": "erp-999",
+  "targetBlock": 5000000,
+  "actions": [
+    {
+      "type": "weiTransfer",
+      "fromAddress": "CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826",
+      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "valueInWei": 1234
+    },
+    {
+      "type": "storeCode",
+      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "expectedCodeHash": "0xF38490",
+      "code": "0xdeadbeef"
+    }
+  ]
+}

--- a/ethereumj-core/src/test/resources/erps/erp999.sco.json
+++ b/ethereumj-core/src/test/resources/erps/erp999.sco.json
@@ -4,13 +4,13 @@
   "actions": [
     {
       "type": "weiTransfer",
-      "fromAddress": "CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826",
-      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "fromAddress": "11113D9F938E13CD947EC05ABC7FE734DF8DD826",
+      "toAddress": "22228AEE95F38490E9769C39B2773ED763D9CD5F",
       "valueInWei": 1234
     },
     {
       "type": "storeCode",
-      "toAddress": "13978AEE95F38490E9769C39B2773ED763D9CD5F",
+      "toAddress": "33338AEE95F38490E9769C39B2773ED763D9CD5E",
       "expectedCodeHash": "0xF38490",
       "code": "0xdeadbeef"
     }

--- a/ethereumj-core/src/test/resources/erps/erp999.sco.json
+++ b/ethereumj-core/src/test/resources/erps/erp999.sco.json
@@ -8,13 +8,13 @@
   "actions": [
     {
       "type": "weiTransfer",
-      "fromAddress": "11113D9F938E13CD947EC05ABC7FE734DF8DD826",
-      "toAddress": "22228AEE95F38490E9769C39B2773ED763D9CD5F",
+      "fromAddress": "0x11113D9F938E13CD947EC05ABC7FE734DF8DD826",
+      "toAddress": "0x22228AEE95F38490E9769C39B2773ED763D9CD5F",
       "valueInWei": 1234
     },
     {
       "type": "storeCode",
-      "toAddress": "33338AEE95F38490E9769C39B2773ED763D9CD5E",
+      "toAddress": "0x33338AEE95F38490E9769C39B2773ED763D9CD5E",
       "expectedCodeHash": "0xF38490",
       "code": "0xdeadbeef"
     }

--- a/ethereumj-core/src/test/resources/erps/erp999.sco.json
+++ b/ethereumj-core/src/test/resources/erps/erp999.sco.json
@@ -1,6 +1,10 @@
 {
   "erpId": "erp-999",
   "targetBlock": 5000000,
+  "metadata": {
+    "sourceBlock": 4000000,
+    "version": "1.3.0"
+  },
   "actions": [
     {
       "type": "weiTransfer",


### PR DESCRIPTION
This PR contains the proposed reference implementation for supporting Ethereum Recovery Proposals (ERPs).  There are a number of places where I'm unclear about the right approach, so your guidance is appreciated.  

Please see the associated EIP issue for details:  https://github.com/ethereum/EIPs/issues/866

TL;DR the proposed ERP process provides a standard mechanism to support irregular state changes in uncontentious recovery cases where ownership is clear and supported by strong evidence.   It can support https://github.com/ethereum/EIPs/issues/156, as well as other issues.