### PR TITLE
fix typo in ethereumj.conf

### DIFF
--- a/ethereumj-core/src/main/resources/ethereumj.conf
+++ b/ethereumj-core/src/main/resources/ethereumj.conf
@@ -314,7 +314,7 @@ mine {
     # minimal timeout between mined blocks
     minBlockTimeoutMsec = 0
 
-    # start mining with specific nonce (might be usefult for testing)
+    # start mining with specific nonce (might be useful for testing)
     # null for random start nonce
     startNonce = null
 }


### PR DESCRIPTION
Change `usefult` to `useful` in `mine` block of ethereumj.conf.