### PR TITLE
Fix ClassCastException

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/p2p/P2pHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/p2p/P2pHandler.java
@@ -281,7 +281,7 @@ public class P2pHandler extends SimpleChannelInboundHandler<P2pMessage> {
             } catch (Throwable t) {
                 logger.error("Unhandled exception", t);
             }
-        }, 2, config.getProperty("peer.p2p.pingInterval", 5L), TimeUnit.SECONDS);
+        }, 2, config.getProperty("peer.p2p.pingInterval", 5), TimeUnit.SECONDS);
     }
 
     public void killTimers() {


### PR DESCRIPTION
When the "peer.p2p.pingInterval" parameter is configured in the ethereumj.conf file, the exception "java.lang.ClassCastException: java.lang.Integer can not be cast to java.lang.Long" appears. After analyzing the code, we found that in the getAnyRef method of the com.typesafe.config.Config class, the java.lang.Integer type is returned when getting the numeric parameter. And, I think the unit for the pingInterval parameter is seconds, using the Integer type is appropriate.