### PR TITLE
Remove duplicated hash value in Block#toString()

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/net/BaseNetConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/net/BaseNetConfig.java
@@ -26,7 +26,7 @@ import java.util.*;
 /**
  * Created by Anton Nashatyrev on 25.02.2016.
  */
-    public class BaseNetConfig implements BlockchainNetConfig {
+public class BaseNetConfig implements BlockchainNetConfig {
     private long[] blockNumbers = new long[64];
     private BlockchainConfig[] configs = new BlockchainConfig[64];
     private int count;

--- a/ethereumj-core/src/main/java/org/ethereum/core/Block.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Block.java
@@ -304,7 +304,6 @@ public class Block {
         toStringBuff.setLength(0);
         toStringBuff.append(Hex.toHexString(this.getEncoded())).append("\n");
         toStringBuff.append("BlockData [ ");
-        toStringBuff.append("hash=").append(ByteUtil.toHexString(this.getHash())).append("\n");
         toStringBuff.append(header.toString());
 
         if (!getUncleList().isEmpty()) {
@@ -337,7 +336,6 @@ public class Block {
 
         toStringBuff.setLength(0);
         toStringBuff.append("BlockData [");
-        toStringBuff.append("hash=").append(ByteUtil.toHexString(this.getHash()));
         toStringBuff.append(header.toFlatString());
 
         for (Transaction tx : getTransactionsList()) {

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -358,7 +358,7 @@ public class NodeManager implements Consumer<DiscoveryEvent>{
                 sb.append(nodeHandler).append("\t").append(nodeHandler.getNodeStatistics()).append("\n");
             } else {
                 zeroReputCount++;
-        }
+            }
         }
         sb.append("0 reputation: ").append(zeroReputCount).append(" nodes.\n");
         return sb.toString();


### PR DESCRIPTION
When converting `Block` to `String` representation, hash value is added to the string twice.

Since in [`toStringBuff.append(header.toString())`](https://github.com/ethereum/ethereumj/blob/develop/ethereumj-core/src/main/java/org/ethereum/core/Block.java#L308), the header string contains the same hash value of the Block.

Currently, calling `toString` of `Block` gives result like

```
f901fbf901f6a0548911f91c652dd110641a55f09fa4fa8......
BlockData [ hash=ed1b6f07d738ad92c5bdc3b98fe25afea9c863dd351711776d9ce1ffb9e3d276  ### HERE DUPLICATED
  hash=ed1b6f07d738ad92c5bdc3b98fe25afea9c863dd351711776d9ce1ffb9e3d276
  parentHash=548911f91c652dd110641a55f09fa4fa83d9c28d3afddce60a64256fb58468e9
  unclesHash=1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347

  ...

  extraData=
  mixHash=9ad2540261dbd5dca7ca6a59d9ee28484619e853aef09dcd1f18d91a3b014fb3
  nonce=99a9e3c99c902cbc
Uncles []
Txs []
]
```
So the first hash value can be removed I think :)

`toString()` and `toFlatString()` are both fixed.