### PR TITLE
FastSync with skipHistory fixes

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -1084,7 +1084,7 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         }
     }
 
-    public void updateBlockTotDifficulties(int startFrom) {
+    public void updateBlockTotDifficulties(long startFrom) {
         // no synchronization here not to lock instance for long period
         while(true) {
             synchronized (this) {

--- a/ethereumj-core/src/main/java/org/ethereum/core/Chain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Chain.java
@@ -59,7 +59,7 @@ public class Chain {
 
     public void add(Block block) {
         logger.info("adding block to alt chain block.hash: [{}] ", block.getShortHash());
-        totalDifficulty = totalDifficulty.add(block.getCumulativeDifficulty());
+        totalDifficulty = totalDifficulty.add(block.getDifficultyBI());
         logger.info("total difficulty on alt chain is: [{}] ", totalDifficulty);
         chain.add(block);
         index.put(new ByteArrayWrapper(block.getHash()), block);

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/Serializers.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/Serializers.java
@@ -121,9 +121,9 @@ public class Serializers {
     };
 
     /**
-     * Dummy serializer (doesn't change anything)
+     * No change serializer (doesn't change anything)
      */
-    public final static Serializer<byte[], byte[]> DummySerializer = new Serializer<byte[], byte[]>() {
+    public final static Serializer<byte[], byte[]> NoChangeSerializer = new Serializer<byte[], byte[]>() {
         @Override
         public byte[] serialize(byte[] object) {
             return object;

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/Serializers.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/Serializers.java
@@ -121,9 +121,9 @@ public class Serializers {
     };
 
     /**
-     * No change serializer (doesn't change anything)
+     * AS IS serializer (doesn't change anything)
      */
-    public final static Serializer<byte[], byte[]> NoChangeSerializer = new Serializer<byte[], byte[]>() {
+    public final static Serializer<byte[], byte[]> AsIsSerializer = new Serializer<byte[], byte[]>() {
         @Override
         public byte[] serialize(byte[] object) {
             return object;

--- a/ethereumj-core/src/main/java/org/ethereum/datasource/Serializers.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/Serializers.java
@@ -119,4 +119,19 @@ public class Serializers {
             return stream == null ? null : new BlockHeader(stream);
         }
     };
+
+    /**
+     * Dummy serializer (doesn't change anything)
+     */
+    public final static Serializer<byte[], byte[]> DummySerializer = new Serializer<byte[], byte[]>() {
+        @Override
+        public byte[] serialize(byte[] object) {
+            return object;
+        }
+
+        @Override
+        public byte[] deserialize(byte[] stream) {
+            return stream;
+        }
+    };
 }

--- a/ethereumj-core/src/main/java/org/ethereum/db/BlockStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/BlockStore.java
@@ -49,7 +49,7 @@ public interface BlockStore {
 
     List<Block> getListBlocksEndWith(byte[] hash, long qty);
 
-    void saveBlock(Block block, BigInteger cummDifficulty, boolean mainChain);
+    void saveBlock(Block block, BigInteger totalDifficulty, boolean mainChain);
 
     BigInteger getTotalDifficultyForHash(byte[] hash);
 

--- a/ethereumj-core/src/main/java/org/ethereum/db/BlockStoreDummy.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/BlockStoreDummy.java
@@ -74,7 +74,7 @@ public class BlockStoreDummy implements BlockStore {
     }
 
     @Override
-    public void saveBlock(Block block, BigInteger cummDifficulty, boolean mainChain) {
+    public void saveBlock(Block block, BigInteger totalDifficulty, boolean mainChain) {
 
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/db/HeaderStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/HeaderStore.java
@@ -46,7 +46,7 @@ public class HeaderStore {
     public void init(Source<byte[], byte[]> index, Source<byte[], byte[]> headers) {
         indexDS = index;
         this.index = new DataSourceArray<>(
-                new ObjectDataSource<>(index,Serializers.NoChangeSerializer, 2048));
+                new ObjectDataSource<>(index,Serializers.AsIsSerializer, 2048));
         this.headersDS = headers;
         this.headers = new ObjectDataSource<>(headers, Serializers.BlockHeaderSerializer, 512);
     }

--- a/ethereumj-core/src/main/java/org/ethereum/db/HeaderStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/HeaderStore.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) [2016] [ <ether.camp> ]
+ * This file is part of the ethereumJ library.
+ *
+ * The ethereumJ library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ethereumJ library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.db;
+
+import org.ethereum.core.BlockHeader;
+import org.ethereum.datasource.DataSourceArray;
+import org.ethereum.datasource.ObjectDataSource;
+import org.ethereum.datasource.Serializers;
+import org.ethereum.datasource.Source;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * BlockHeaders store
+ * Assumes one chain
+ * Uses indexes by header hash and block number
+ */
+public class HeaderStore {
+
+    private static final Logger logger = LoggerFactory.getLogger("general");
+
+    Source<byte[], byte[]> indexDS;
+    DataSourceArray<byte[]> index;
+    Source<byte[], byte[]> headersDS;
+    ObjectDataSource<BlockHeader> headers;
+
+    public HeaderStore() {
+    }
+
+    public void init(Source<byte[], byte[]> index, Source<byte[], byte[]> headers) {
+        indexDS = index;
+        this.index = new DataSourceArray<>(
+                new ObjectDataSource<>(index,Serializers.DummySerializer, 2048));
+        this.headersDS = headers;
+        this.headers = new ObjectDataSource<>(headers, Serializers.BlockHeaderSerializer, 512);
+    }
+
+
+    public synchronized BlockHeader getBestHeader() {
+
+        long maxNumber = getMaxNumber();
+        if (maxNumber < 0) return null;
+
+        return getHeaderByNumber(maxNumber);
+    }
+
+    public synchronized void flush() {
+        headers.flush();
+        index.flush();
+        headersDS.flush();
+        indexDS.flush();
+    }
+
+    public synchronized void saveHeader(BlockHeader header) {
+        index.set((int) header.getNumber(), header.getHash());
+        headers.put(header.getHash(), header);
+    }
+
+    public synchronized BlockHeader getHeaderByNumber(long number) {
+        if (number < 0 || number >= index.size()) {
+            return null;
+        }
+
+        byte[] hash = index.get((int) number);
+        if (hash == null) {
+            return null;
+        }
+
+        return headers.get(hash);
+    }
+
+    public synchronized int size() {
+        return index.size();
+    }
+
+    public synchronized BlockHeader getHeaderByHash(byte[] hash) {
+        return headers.get(hash);
+    }
+
+    public synchronized long getMaxNumber(){
+        if (index.size() > 0) {
+            return (long) index.size() - 1;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/ethereumj-core/src/main/java/org/ethereum/db/HeaderStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/HeaderStore.java
@@ -46,7 +46,7 @@ public class HeaderStore {
     public void init(Source<byte[], byte[]> index, Source<byte[], byte[]> headers) {
         indexDS = index;
         this.index = new DataSourceArray<>(
-                new ObjectDataSource<>(index,Serializers.DummySerializer, 2048));
+                new ObjectDataSource<>(index,Serializers.NoChangeSerializer, 2048));
         this.headersDS = headers;
         this.headers = new ObjectDataSource<>(headers, Serializers.BlockHeaderSerializer, 512);
     }

--- a/ethereumj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -106,17 +106,17 @@ public class IndexedBlockStore extends AbstractBlockstore{
 
 
     @Override
-    public synchronized void saveBlock(Block block, BigInteger cummDifficulty, boolean mainChain){
-        addInternalBlock(block, cummDifficulty, mainChain);
+    public synchronized void saveBlock(Block block, BigInteger totalDifficulty, boolean mainChain){
+        addInternalBlock(block, totalDifficulty, mainChain);
     }
 
-    private void addInternalBlock(Block block, BigInteger cummDifficulty, boolean mainChain){
+    private void addInternalBlock(Block block, BigInteger totalDifficulty, boolean mainChain){
 
         List<BlockInfo> blockInfos = block.getNumber() >= index.size() ?  null : index.get((int) block.getNumber());
         blockInfos = blockInfos == null ? new ArrayList<BlockInfo>() : blockInfos;
 
         BlockInfo blockInfo = new BlockInfo();
-        blockInfo.setCummDifficulty(cummDifficulty);
+        blockInfo.setTotalDifficulty(totalDifficulty);
         blockInfo.setHash(block.getHash());
         blockInfo.setMainChain(mainChain); // FIXME:maybe here I should force reset main chain for all uncles on that level
 
@@ -206,7 +206,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
         List<BlockInfo> blockInfos =  index.get(level.intValue());
         for (BlockInfo blockInfo : blockInfos)
                  if (areEqual(blockInfo.getHash(), hash)) {
-                     return blockInfo.cummDifficulty;
+                     return blockInfo.totalDifficulty;
                  }
 
         return ZERO;
@@ -220,7 +220,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
         List<BlockInfo> blockInfos = index.get((int) maxNumber);
         for (BlockInfo blockInfo : blockInfos){
             if (blockInfo.isMainChain()){
-                return blockInfo.getCummDifficulty();
+                return blockInfo.getTotalDifficulty();
             }
         }
 
@@ -230,7 +230,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
 
             for (BlockInfo blockInfo : infos) {
                 if (blockInfo.isMainChain()) {
-                    return blockInfo.getCummDifficulty();
+                    return blockInfo.getTotalDifficulty();
                 }
             }
         }
@@ -242,7 +242,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
             Block block = getBlockByHash(blockInfo.getHash());
             List<BlockInfo> parentInfos = getBlockInfoForLevel(index - 1);
             BlockInfo parentInfo = getBlockInfoForHash(parentInfos, block.getParentHash());
-            blockInfo.setCummDifficulty(parentInfo.getCummDifficulty().add(block.getDifficultyBI()));
+            blockInfo.setTotalDifficulty(parentInfo.getTotalDifficulty().add(block.getDifficultyBI()));
         }
         this.index.set((int) index, level);
     }
@@ -399,7 +399,7 @@ public class IndexedBlockStore extends AbstractBlockstore{
 
     public static class BlockInfo implements Serializable {
         byte[] hash;
-        BigInteger cummDifficulty;
+        BigInteger totalDifficulty;
         boolean mainChain;
 
         public byte[] getHash() {
@@ -410,12 +410,12 @@ public class IndexedBlockStore extends AbstractBlockstore{
             this.hash = hash;
         }
 
-        public BigInteger getCummDifficulty() {
-            return cummDifficulty;
+        public BigInteger getTotalDifficulty() {
+            return totalDifficulty;
         }
 
-        public void setCummDifficulty(BigInteger cummDifficulty) {
-            this.cummDifficulty = cummDifficulty;
+        public void setTotalDifficulty(BigInteger totalDifficulty) {
+            this.totalDifficulty = totalDifficulty;
         }
 
         public boolean isMainChain() {
@@ -436,12 +436,12 @@ public class IndexedBlockStore extends AbstractBlockstore{
                 for (BlockInfo blockInfo : value) {
                     byte[] hash = RLP.encodeElement(blockInfo.getHash());
                     // Encoding works correctly only with positive BigIntegers
-                    if (blockInfo.getCummDifficulty() == null || blockInfo.getCummDifficulty().compareTo(BigInteger.ZERO) < 0) {
-                        throw new RuntimeException("BlockInfo cummDifficulty should be positive BigInteger");
+                    if (blockInfo.getTotalDifficulty() == null || blockInfo.getTotalDifficulty().compareTo(BigInteger.ZERO) < 0) {
+                        throw new RuntimeException("BlockInfo totalDifficulty should be positive BigInteger");
                     }
-                    byte[] cummDiff = RLP.encodeBigInteger(blockInfo.getCummDifficulty());
+                    byte[] totalDiff = RLP.encodeBigInteger(blockInfo.getTotalDifficulty());
                     byte[] isMainChain = RLP.encodeInt(blockInfo.isMainChain() ? 1 : 0);
-                    rlpBlockInfoList.add(RLP.encodeList(hash, cummDiff, isMainChain));
+                    rlpBlockInfoList.add(RLP.encodeList(hash, totalDiff, isMainChain));
                 }
                 byte[][] elements = rlpBlockInfoList.toArray(new byte[rlpBlockInfoList.size()][]);
 
@@ -459,8 +459,8 @@ public class IndexedBlockStore extends AbstractBlockstore{
                 BlockInfo blockInfo = new BlockInfo();
                 byte[] rlpHash = rlpBlock.get(0).getRLPData();
                 blockInfo.setHash(rlpHash == null ? new byte[0] : rlpHash);
-                byte[] rlpCummDiff = rlpBlock.get(1).getRLPData();
-                blockInfo.setCummDifficulty(rlpCummDiff == null ? BigInteger.ZERO : ByteUtil.bytesToBigInteger(rlpCummDiff));
+                byte[] rlpTotalDiff = rlpBlock.get(1).getRLPData();
+                blockInfo.setTotalDifficulty(rlpTotalDiff == null ? BigInteger.ZERO : ByteUtil.bytesToBigInteger(rlpTotalDiff));
                 blockInfo.setMainChain(ByteUtil.byteArrayToInt(rlpBlock.get(2).getRLPData()) == 1);
                 blockInfoList.add(blockInfo);
             }

--- a/ethereumj-core/src/main/java/org/ethereum/db/migrate/MigrateHeaderSourceTotalDiff.java
+++ b/ethereumj-core/src/main/java/org/ethereum/db/migrate/MigrateHeaderSourceTotalDiff.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) [2016] [ <ether.camp> ]
+ * This file is part of the ethereumJ library.
+ *
+ * The ethereumJ library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ethereumJ library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the ethereumJ library. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.db.migrate;
+
+import org.ethereum.config.SystemProperties;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Blockchain;
+import org.ethereum.core.BlockchainImpl;
+import org.ethereum.datasource.DataSourceArray;
+import org.ethereum.datasource.DbSource;
+import org.ethereum.datasource.ObjectDataSource;
+import org.ethereum.datasource.Serializers;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.DbFlushManager;
+import org.ethereum.db.HeaderStore;
+import org.ethereum.sync.FastSyncManager;
+import org.ethereum.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * @deprecated
+ * TODO: Remove after a few versions (current: 1.7.3) or with DB version update
+ * Also remove CommonConfig.headerSource with it as no more used
+ *
+ * - Repairs Headers DB after FastSync with skipHistory to be usable
+ *    a) Updates incorrect total difficulty
+ *    b) Migrates headers without index to usable scheme with index
+ * - Removes headers DB otherwise as it's not needed
+ *   TODO: move DB removal to main logic. Not done yet to prevent any conflicts
+ */
+@Deprecated
+public class MigrateHeaderSourceTotalDiff implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger("general");
+
+    private ApplicationContext ctx;
+
+    private BlockStore blockStore;
+
+    private Blockchain blockchain;
+
+    private SystemProperties systemProperties;
+
+    public MigrateHeaderSourceTotalDiff(ApplicationContext ctx, BlockStore blockStore,
+                                        Blockchain blockchain, SystemProperties systemProperties) {
+        this.ctx = ctx;
+        this.blockStore = blockStore;
+        this.blockchain = blockchain;
+        this.systemProperties = systemProperties;
+    }
+
+    @Override
+    public void run() {
+        // checking whether we should do any kind of migration:
+        if (!systemProperties.isFastSyncEnabled()) {
+            return;
+        }
+
+        FastSyncManager fastSyncManager = ctx.getBean(FastSyncManager.class);
+        if (fastSyncManager.isInProgress()|| blockStore.getBestBlock().getNumber() == 0) { // Fast sync is not over
+            return;
+        }
+
+        logger.info("Fast Sync was used. Checking if migration required.");
+        if (blockStore.getBestBlock().getNumber() > 0 &&
+                blockStore.getChainBlockByNumber(1) != null) {
+            // Everything is cool but maybe we could remove unused DB?
+            Path headersDbPath = Paths.get(systemProperties.databaseDir(), "headers");
+            if (Files.exists(headersDbPath)) {
+                logger.info("Headers DB was used during FastSync but not required any more. Removing.");
+                FileUtil.recursiveDelete(headersDbPath.toString());
+                logger.info("Headers DB removed. Migration is over");
+            } else {
+                logger.info("No migration required.");
+                return;
+            }
+        } else if (blockStore.getBestBlock().getNumber() > 0) {
+            // Maybe migration of headerStore and totalDifficulty is required?
+            HeaderStore headerStore = ctx.getBean(HeaderStore.class);
+            if (headerStore.getHeaderByNumber(1) != null) {
+                logger.info("No migration required.");
+                return;
+            }
+
+            logger.info("Migration required. Updating total difficulty.");
+            logger.info("=== Don't stop or exit from application, migration could not be resumed ===");
+            long firstFullBlockNum = blockStore.getMaxNumber();
+            while (blockStore.getChainBlockByNumber(firstFullBlockNum - 1) != null) {
+                --firstFullBlockNum;
+            }
+            Block firstFullBlock = blockStore.getChainBlockByNumber(firstFullBlockNum);
+            DbSource<byte[]> headerDbSource = (DbSource<byte[]>) ctx.getBean("headerSource");
+            ObjectDataSource<BlockHeader> objectDataSource = new ObjectDataSource<>(headerDbSource, Serializers.BlockHeaderSerializer, 0);
+            DataSourceArray<BlockHeader> headerSource = new DataSourceArray<>(objectDataSource);
+            BigInteger totalDifficulty = blockStore.getChainBlockByNumber(0).getDifficultyBI();
+            for (int i = 1; i < firstFullBlockNum; ++i) {
+                totalDifficulty = totalDifficulty.add(headerSource.get(i).getDifficultyBI());
+            }
+            blockStore.saveBlock(firstFullBlock, totalDifficulty.add(firstFullBlock.getDifficultyBI()), true);
+            ((BlockchainImpl) blockchain).updateBlockTotDifficulties(firstFullBlockNum + 1);
+            logger.info("Total difficulty updated");
+            logger.info("Migrating headerStore");
+            int maxHeaderNumber = headerSource.size() - 1;
+            DbFlushManager flushManager = ctx.getBean(DbFlushManager.class);
+            for (int i = 1; i < headerSource.size(); ++i) {
+                BlockHeader curHeader = headerSource.get(i);
+                headerStore.saveHeader(curHeader);
+                headerSource.set(i, null);
+                if (i % 10000 == 0) {
+                    logger.info("#{} of {} headers moved. Flushing...", i, maxHeaderNumber);
+                    flushManager.commit();
+                    flushManager.flush();
+                }
+            }
+            flushManager.commit();
+            flushManager.flush();
+            logger.info("headerStore migration finished. No more migrations required");
+        }
+    }
+}

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -19,9 +19,10 @@ package org.ethereum.manager;
 
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
+import org.ethereum.datasource.DataSourceArray;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.db.DbFlushManager;
+import org.ethereum.db.HeaderStore;
 import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.client.PeerClient;
@@ -31,6 +32,7 @@ import org.ethereum.sync.SyncManager;
 import org.ethereum.net.rlpx.discover.NodeManager;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.sync.SyncPool;
+import org.ethereum.util.FileUtil;
 import org.ethereum.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +43,9 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -118,6 +123,7 @@ public class WorldManager {
 
     @PostConstruct
     private void init() {
+        fastSyncDbJobs();
         syncManager.init(channelManager, pool);
     }
 
@@ -249,6 +255,103 @@ public class WorldManager {
             System.exit(-1); //  todo: reset the repository and blockchain
         }
 */
+    }
+
+    /**
+     * After introducing skipHistory in FastSync this method
+     * adds additional headerSource to Blockchain
+     * as Blockstore is incomplete in this mode
+     */
+    private void fastSyncDbJobs() {
+        // checking if fast sync ran sometime ago with "skipHistory flag"
+        if (blockStore.getBestBlock().getNumber() > 0 &&
+                blockStore.getChainBlockByNumber(1) == null) {
+            FastSyncManager fastSyncManager = ctx.getBean(FastSyncManager.class);
+            if (!fastSyncManager.isEndedOrNotStarted()) {
+                return;
+            }
+            logger.info("DB is filled using Fast Sync with skipHistory, adopting headerStore");
+            ((BlockchainImpl) blockchain).setHeaderStore(ctx.getBean(HeaderStore.class));
+        }
+        fastSyncDbMigrateHeadersUpdateTotalDiff();
+    }
+
+    /**
+     * @deprecated
+     * TODO: Remove after a few versions (current: 1.7.3) or with DB version update
+     * Also remove CommonConfig.headerSource with it as no more used
+     *
+     * - Repairs Headers DB after FastSync with skipHistory to be usable
+     *    a) Updates incorrect total difficulty
+     *    b) Migrates headers without index to usable scheme with index
+     * - Removes headers DB otherwise as it's not needed
+     *   TODO: move DB removal to main logic. Not done yet to prevent any conflicts
+     */
+    @Deprecated
+    private void fastSyncDbMigrateHeadersUpdateTotalDiff() {
+        // checking whether we should do any kind of migration:
+        if (!config.isFastSyncEnabled()) {
+            return;
+        }
+
+        FastSyncManager fastSyncManager = ctx.getBean(FastSyncManager.class);
+        if (!fastSyncManager.isEndedOrNotStarted()|| blockStore.getBestBlock().getNumber() == 0) { // Fast sync is not over
+            return;
+        }
+
+        logger.info("Fast Sync was used. Checking if migration required.");
+        if (blockStore.getBestBlock().getNumber() > 0 &&
+                blockStore.getChainBlockByNumber(1) != null) {
+            // Everything is cool but maybe we could remove unused DB?
+            Path headersDbPath = Paths.get(config.databaseDir(), "headers");
+            if (Files.exists(headersDbPath)) {
+                logger.info("Headers DB was used during FastSync but not required any more. Removing.");
+                FileUtil.recursiveDelete(headersDbPath.toString());
+                logger.info("Headers DB removed. Migration is over");
+            } else {
+                logger.info("No migration required.");
+                return;
+            }
+        } else if (blockStore.getBestBlock().getNumber() > 0) {
+            // Maybe migration of headerStore and totalDifficulty is required?
+            HeaderStore headerStore = ctx.getBean(HeaderStore.class);
+            if (headerStore.getHeaderByNumber(1) != null) {
+                logger.info("No migration required.");
+                return;
+            }
+
+            logger.info("Migration required. Updating total difficulty.");
+            logger.info("=== Don't stop or exit from application, migration could not be resumed ===");
+            long firstFullBlockNum = blockStore.getMaxNumber();
+            while (blockStore.getChainBlockByNumber(firstFullBlockNum - 1) != null) {
+                --firstFullBlockNum;
+            }
+            Block firstFullBlock = blockStore.getChainBlockByNumber(firstFullBlockNum);
+            DataSourceArray<BlockHeader> headerSource = (DataSourceArray<BlockHeader>) ctx.getBean("headerSource");
+            BigInteger totalDifficulty = blockStore.getChainBlockByNumber(0).getDifficultyBI();
+            for (int i = 1; i < firstFullBlockNum; ++i) {
+                totalDifficulty = totalDifficulty.add(headerSource.get(i).getDifficultyBI());
+            }
+            blockStore.saveBlock(firstFullBlock, totalDifficulty.add(firstFullBlock.getDifficultyBI()), true);
+            ((BlockchainImpl) blockchain).updateBlockTotDifficulties(firstFullBlockNum + 1);
+            logger.info("Total difficulty updated");
+            logger.info("Migrating headerStore");
+            int maxHeaderNumber = headerSource.size() - 1;
+            DbFlushManager flushManager = ctx.getBean(DbFlushManager.class);
+            for (int i = 1; i < headerSource.size(); ++i) {
+                BlockHeader curHeader = headerSource.get(i);
+                headerStore.saveHeader(curHeader);
+                headerSource.set(i, null);
+                if (i % 10000 == 0) {
+                    logger.info("#{} of {} headers moved. Flushing...", i, maxHeaderNumber);
+                    flushManager.commit();
+                    flushManager.flush();
+                }
+            }
+            flushManager.commit();
+            flushManager.flush();
+            logger.info("headerStore migration finished. No more migrations required");
+        }
     }
 
     public void close() {

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -181,10 +181,10 @@ public class WorldManager {
 //            repository.commitBlock(genesis.getHeader());
             repository.commit();
 
-            blockStore.saveBlock(Genesis.getInstance(config), Genesis.getInstance(config).getCumulativeDifficulty(), true);
+            blockStore.saveBlock(Genesis.getInstance(config), Genesis.getInstance(config).getDifficultyBI(), true);
 
             blockchain.setBestBlock(Genesis.getInstance(config));
-            blockchain.setTotalDifficulty(Genesis.getInstance(config).getCumulativeDifficulty());
+            blockchain.setTotalDifficulty(Genesis.getInstance(config).getDifficultyBI());
 
             listener.onBlock(new BlockSummary(Genesis.getInstance(config), new HashMap<byte[], BigInteger>(), new ArrayList<TransactionReceipt>(), new ArrayList<TransactionExecutionSummary>()));
 //            repository.dumpState(Genesis.getInstance(config), 0, 0, null);

--- a/ethereumj-core/src/main/java/org/ethereum/sync/BlockBodiesDownloader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/BlockBodiesDownloader.java
@@ -20,8 +20,8 @@ package org.ethereum.sync;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.datasource.DataSourceArray;
 import org.ethereum.db.DbFlushManager;
+import org.ethereum.db.HeaderStore;
 import org.ethereum.db.IndexedBlockStore;
 import org.ethereum.net.server.Channel;
 import org.ethereum.util.FastByteComparisons;
@@ -29,7 +29,6 @@ import org.ethereum.validator.BlockHeaderValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
@@ -54,8 +53,8 @@ public class BlockBodiesDownloader extends BlockDownloader {
     @Autowired
     IndexedBlockStore blockStore;
 
-    @Autowired @Qualifier("headerSource")
-    DataSourceArray<BlockHeader> headerStore;
+    @Autowired
+    HeaderStore headerStore;
 
     @Autowired
     DbFlushManager dbFlushManager;
@@ -95,7 +94,8 @@ public class BlockBodiesDownloader extends BlockDownloader {
             List<BlockHeaderWrapper> wrappers = new ArrayList<>();
             List<BlockHeader> emptyBodyHeaders =  new ArrayList<>();
             for (int i = 0; i < getMaxHeadersInQueue() - syncQueue.getHeadersCount() && curBlockIdx < headerStore.size(); i++) {
-                BlockHeader header = headerStore.get(curBlockIdx++);
+                BlockHeader header = headerStore.getHeaderByNumber(curBlockIdx);
+                ++curBlockIdx;
                 wrappers.add(new BlockHeaderWrapper(header, new byte[0]));
 
                 // Skip bodies download for blocks with empty body

--- a/ethereumj-core/src/main/java/org/ethereum/sync/FastSyncManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/FastSyncManager.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.datasource.DataSourceArray;
 import org.ethereum.datasource.DbSource;
 import org.ethereum.datasource.NodeKeyCompositor;
 import org.ethereum.datasource.rocksdb.RocksDbDataSource;
@@ -615,6 +616,9 @@ public class FastSyncManager {
             logger.info("FastSync: Block bodies downloaded");
         } else {
             logger.info("FastSync: skip bodies downloading");
+            logger.info("Fixing total difficulty which is usually updated during block bodies download");
+            fixTotalDiff();
+            logger.info("Total difficulty fixed for full blocks");
         }
 
         if (!config.fastSyncSkipHistory()) {
@@ -632,7 +636,7 @@ public class FastSyncManager {
         }
 
         logger.info("FastSync: updating totDifficulties starting from the pivot block...");
-        blockchain.updateBlockTotDifficulties((int) pivot.getNumber());
+        blockchain.updateBlockTotDifficulties(pivot.getNumber());
         synchronized (blockchain) {
             Block bestBlock = blockchain.getBestBlock();
             BigInteger totalDifficulty = blockchain.getTotalDifficulty();
@@ -642,6 +646,25 @@ public class FastSyncManager {
         blockchainDB.delete(FASTSYNC_DB_KEY_PIVOT);
         dbFlushManager.commit();
         dbFlushManager.flush();
+    }
+
+    /**
+     * Fixing total difficulty which is usually updated during block bodies download
+     * Executed if {@link BlockBodiesDownloader} stage is skipped
+     */
+    private void fixTotalDiff() {
+        long firstFullBlockNum = pivot.getNumber();
+        while (blockStore.getChainBlockByNumber(firstFullBlockNum - 1) != null) {
+            --firstFullBlockNum;
+        }
+        Block firstFullBlock = blockStore.getChainBlockByNumber(firstFullBlockNum);
+        DataSourceArray<BlockHeader> headersStore = (DataSourceArray<BlockHeader>) applicationContext.getBean("headerSource");
+        BigInteger totalDifficulty = blockStore.getChainBlockByNumber(0).getDifficultyBI();
+        for (int i = 1; i < firstFullBlockNum; ++i) {
+            totalDifficulty = totalDifficulty.add(headersStore.get(i).getDifficultyBI());
+        }
+        blockStore.saveBlock(firstFullBlock, totalDifficulty.add(firstFullBlock.getDifficultyBI()), true);
+        blockchain.updateBlockTotDifficulties(firstFullBlockNum + 1);
     }
 
     public void main() {

--- a/ethereumj-core/src/main/java/org/ethereum/sync/FastSyncManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/FastSyncManager.java
@@ -898,8 +898,8 @@ public class FastSyncManager {
         return null;
     }
 
-    public boolean isEndedOrNotStarted() {
-        return blockchainDB.get(FASTSYNC_DB_KEY_PIVOT) == null;
+    public boolean isInProgress() {
+        return blockchainDB.get(FASTSYNC_DB_KEY_PIVOT) != null;
     }
 
     public void close() {

--- a/ethereumj-core/src/main/java/org/ethereum/sync/HeadersDownloader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/HeadersDownloader.java
@@ -17,12 +17,11 @@
  */
 package org.ethereum.sync;
 
-import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockHeaderWrapper;
 import org.ethereum.core.BlockWrapper;
 import org.ethereum.core.Blockchain;
-import org.ethereum.datasource.DataSourceArray;
 import org.ethereum.db.DbFlushManager;
+import org.ethereum.db.HeaderStore;
 import org.ethereum.db.IndexedBlockStore;
 import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
@@ -31,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -54,8 +52,8 @@ public class HeadersDownloader extends BlockDownloader {
     @Autowired
     IndexedBlockStore blockStore;
 
-    @Autowired @Qualifier("headerSource")
-    DataSourceArray<BlockHeader> headerStore;
+    @Autowired
+    HeaderStore headerStore;
 
     @Autowired
     DbFlushManager dbFlushManager;
@@ -95,7 +93,7 @@ public class HeadersDownloader extends BlockDownloader {
         }
         logger.info(name + ": " + headers.size() + " headers loaded: " + headers.get(0).getNumber() + " - " + headers.get(headers.size() - 1).getNumber());
         for (BlockHeaderWrapper header : headers) {
-            headerStore.set((int) header.getNumber(), header.getHeader());
+            headerStore.saveHeader(header.getHeader());
             headersLoaded++;
         }
         dbFlushManager.commit();

--- a/ethereumj-core/src/main/java/org/ethereum/sync/ReceiptsDownloader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/ReceiptsDownloader.java
@@ -24,7 +24,6 @@ import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.datasource.DataSourceArray;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.db.DbFlushManager;
 import org.ethereum.db.IndexedBlockStore;
@@ -35,7 +34,6 @@ import org.ethereum.util.FastByteComparisons;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
@@ -71,9 +69,6 @@ public class ReceiptsDownloader {
     @Autowired
     TransactionStore txStore;
 
-    @Autowired @Qualifier("headerSource")
-    DataSourceArray<BlockHeader> headerStore;
-
     long fromBlock, toBlock;
     LinkedHashMap<ByteArrayWrapper, QueuedBlock> queuedBlocks = new LinkedHashMap<>();
     AtomicInteger blocksInMem = new AtomicInteger(0);
@@ -101,7 +96,7 @@ public class ReceiptsDownloader {
     private synchronized List<byte[]> getHashesForRequest(int maxSize) {
         List<byte[]> ret = new ArrayList<>();
         for (; fromBlock < toBlock && maxSize > 0; fromBlock++) {
-            BlockHeader header = headerStore.get((int) fromBlock);
+            BlockHeader header = blockStore.getChainBlockByNumber(fromBlock).getHeader();
 
             // Skipping download for blocks with no transactions
             if (FastByteComparisons.equal(header.getReceiptsRoot(), HashUtil.EMPTY_TRIE_HASH)) {

--- a/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/blockchain/StandaloneBlockchain.java
@@ -500,10 +500,10 @@ public class StandaloneBlockchain implements LocalBlockchain {
 
         repository.commit();
 
-        blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
+        blockStore.saveBlock(genesis, genesis.getDifficultyBI(), true);
 
         blockchain.setBestBlock(genesis);
-        blockchain.setTotalDifficulty(genesis.getCumulativeDifficulty());
+        blockchain.setTotalDifficulty(genesis.getDifficultyBI());
 
         pruneManager.blockCommitted(genesis.getHeader());
 

--- a/ethereumj-core/src/main/resources/version.properties
+++ b/ethereumj-core/src/main/resources/version.properties
@@ -1,2 +1,3 @@
 versionNumber='1.8.0'
+# Remove org.ethereum.db.migrate.MigrateHeaderSourceTotalDiff with databaseVersion > 6
 databaseVersion=6

--- a/ethereumj-core/src/main/resources/version.properties
+++ b/ethereumj-core/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 versionNumber='1.8.0'
-# Remove org.ethereum.db.migrate.MigrateHeaderSourceTotalDiff with databaseVersion > 6
+// Remove org.ethereum.db.migrate.MigrateHeaderSourceTotalDiff with databaseVersion > 6
 databaseVersion=6

--- a/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -913,10 +913,10 @@ public class ImportLightTest {
         track.commit();
         repository.commit();
 
-        blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
+        blockStore.saveBlock(genesis, genesis.getDifficultyBI(), true);
 
         blockchain.setBestBlock(genesis);
-        blockchain.setTotalDifficulty(genesis.getCumulativeDifficulty());
+        blockchain.setTotalDifficulty(genesis.getDifficultyBI());
 
         return blockchain;
     }

--- a/ethereumj-core/src/test/java/org/ethereum/core/PendingStateLongRunTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/core/PendingStateLongRunTest.java
@@ -142,10 +142,10 @@ public class PendingStateLongRunTest {
 
         track.commit();
 
-        blockStore.saveBlock(Genesis.getInstance(), Genesis.getInstance().getCumulativeDifficulty(), true);
+        blockStore.saveBlock(Genesis.getInstance(), Genesis.getInstance().getDifficultyBI(), true);
 
         blockchain.setBestBlock(Genesis.getInstance());
-        blockchain.setTotalDifficulty(Genesis.getInstance().getCumulativeDifficulty());
+        blockchain.setTotalDifficulty(Genesis.getInstance().getDifficultyBI());
 
         return blockchain;
     }

--- a/ethereumj-core/src/test/java/org/ethereum/datasource/BlockSerializerTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/datasource/BlockSerializerTest.java
@@ -44,7 +44,7 @@ public class BlockSerializerTest {
         for (int i = 0; i < count; i++) {
             BlockInfo blockInfo = new BlockInfo();
             blockInfo.setHash(sha3(ByteUtil.intToBytes(i)));
-            blockInfo.setCummDifficulty(BigInteger.probablePrime(512, rnd));
+            blockInfo.setTotalDifficulty(BigInteger.probablePrime(512, rnd));
             blockInfo.setMainChain(rnd.nextBoolean());
             blockInfos.add(blockInfo);
         }
@@ -62,7 +62,7 @@ public class BlockSerializerTest {
         assert blockInfoList.size() == blockInfoList2.size();
         for (int i = 0; i < blockInfoList2.size(); i++) {
             assert FastByteComparisons.equal(blockInfoList2.get(i).getHash(), blockInfoList.get(i).getHash());
-            assert blockInfoList2.get(i).getCummDifficulty().compareTo(blockInfoList.get(i).getCummDifficulty()) == 0;
+            assert blockInfoList2.get(i).getTotalDifficulty().compareTo(blockInfoList.get(i).getTotalDifficulty()) == 0;
             assert blockInfoList2.get(i).isMainChain() == blockInfoList.get(i).isMainChain();
         }
     }
@@ -85,37 +85,37 @@ public class BlockSerializerTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testNullCummDifficulty() {
+    public void testNullTotalDifficulty() {
         BlockInfo blockInfo = new BlockInfo();
         blockInfo.setMainChain(true);
-        blockInfo.setCummDifficulty(null);
+        blockInfo.setTotalDifficulty(null);
         blockInfo.setHash(new byte[0]);
         byte[] data = IndexedBlockStore.BLOCK_INFO_SERIALIZER.serialize(Collections.singletonList(blockInfo));
         List<BlockInfo> blockInfos = IndexedBlockStore.BLOCK_INFO_SERIALIZER.deserialize(data);
     }
 
     @Test(expected = RuntimeException.class)
-    public void testNegativeCummDifficulty() {
+    public void testNegativeTotalDifficulty() {
         BlockInfo blockInfo = new BlockInfo();
         blockInfo.setMainChain(true);
-        blockInfo.setCummDifficulty(BigInteger.valueOf(-1));
+        blockInfo.setTotalDifficulty(BigInteger.valueOf(-1));
         blockInfo.setHash(new byte[0]);
         byte[] data = IndexedBlockStore.BLOCK_INFO_SERIALIZER.serialize(Collections.singletonList(blockInfo));
         List<BlockInfo> blockInfos = IndexedBlockStore.BLOCK_INFO_SERIALIZER.deserialize(data);
     }
 
     @Test
-    public void testZeroCummDifficultyEmptyHash() {
+    public void testZeroTotalDifficultyEmptyHash() {
         BlockInfo blockInfo = new BlockInfo();
         blockInfo.setMainChain(true);
-        blockInfo.setCummDifficulty(BigInteger.ZERO);
+        blockInfo.setTotalDifficulty(BigInteger.ZERO);
         blockInfo.setHash(new byte[0]);
         byte[] data = IndexedBlockStore.BLOCK_INFO_SERIALIZER.serialize(Collections.singletonList(blockInfo));
         List<BlockInfo> blockInfos = IndexedBlockStore.BLOCK_INFO_SERIALIZER.deserialize(data);
         assert blockInfos.size() == 1;
         BlockInfo actualBlockInfo = blockInfos.get(0);
         assert actualBlockInfo.isMainChain();
-        assert actualBlockInfo.getCummDifficulty().compareTo(BigInteger.ZERO) == 0;
+        assert actualBlockInfo.getTotalDifficulty().compareTo(BigInteger.ZERO) == 0;
         assert actualBlockInfo.getHash().length == 0;
     }
 }

--- a/ethereumj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
@@ -18,8 +18,6 @@
 package org.ethereum.db;
 
 import org.ethereum.config.SystemProperties;
-import org.ethereum.config.blockchain.FrontierConfig;
-import org.ethereum.config.net.MainNetConfig;
 import org.ethereum.core.Block;
 import org.ethereum.core.Genesis;
 import org.ethereum.datasource.DbSource;
@@ -52,7 +50,7 @@ public class IndexedBlockStoreTest {
 
     private static final Logger logger = LoggerFactory.getLogger("test");
     private List<Block> blocks = new ArrayList<>();
-    private BigInteger cumDifficulty = ZERO;
+    private BigInteger totDifficulty = ZERO;
 
     @AfterClass
     public static void cleanup() {
@@ -70,7 +68,7 @@ public class IndexedBlockStoreTest {
 
         Block genesis = Genesis.getInstance();
         blocks.add(genesis);
-        cumDifficulty = cumDifficulty.add(genesis.getCumulativeDifficulty());
+        totDifficulty = totDifficulty.add(genesis.getDifficultyBI());
 
         for (String blockRLP : strData) {
 
@@ -83,10 +81,10 @@ public class IndexedBlockStoreTest {
                         block.getNumber());
 
             blocks.add(block);
-            cumDifficulty = cumDifficulty.add(block.getCumulativeDifficulty());
+            totDifficulty = totDifficulty.add(block.getDifficultyBI());
         }
 
-        logger.info("total difficulty: {}", cumDifficulty);
+        logger.info("total difficulty: {}", totDifficulty);
         logger.info("total blocks loaded: {}", blocks.size());
     }
 
@@ -96,10 +94,10 @@ public class IndexedBlockStoreTest {
         IndexedBlockStore indexedBlockStore = new IndexedBlockStore();
         indexedBlockStore.init(new HashMapDB<byte[]>(), new HashMapDB<byte[]>());
 
-        BigInteger cummDiff = BigInteger.ZERO;
+        BigInteger totalDiff = BigInteger.ZERO;
         for (Block block : blocks){
-            cummDiff = cummDiff.add( block.getCumulativeDifficulty() );
-            indexedBlockStore.saveBlock(block, cummDiff, true);
+            totalDiff = totalDiff.add( block.getDifficultyBI() );
+            indexedBlockStore.saveBlock(block, totalDiff, true);
         }
 
         //  testing:   getTotalDifficulty()
@@ -107,7 +105,7 @@ public class IndexedBlockStoreTest {
 
         long bestIndex = blocks.get(blocks.size() - 1).getNumber();
         assertEquals(bestIndex, indexedBlockStore.getMaxNumber());
-        assertEquals(cumDifficulty, indexedBlockStore.getTotalDifficulty());
+        assertEquals(totDifficulty, indexedBlockStore.getTotalDifficulty());
 
         //  testing:  getBlockByHash(byte[])
 
@@ -205,10 +203,10 @@ public class IndexedBlockStoreTest {
         IndexedBlockStore indexedBlockStore = new IndexedBlockStore();
         indexedBlockStore.init(new HashMapDB<byte[]>(), new HashMapDB<byte[]>());
 
-        BigInteger cummDiff = BigInteger.ZERO;
+        BigInteger totalDiff = BigInteger.ZERO;
         for (Block block : blocks){
-            cummDiff = cummDiff.add( block.getCumulativeDifficulty() );
-            indexedBlockStore.saveBlock(block, cummDiff, true);
+            totalDiff = totalDiff.add( block.getDifficultyBI() );
+            indexedBlockStore.saveBlock(block, totalDiff, true);
         }
 
         //  testing:   getTotalDifficulty()
@@ -216,7 +214,7 @@ public class IndexedBlockStoreTest {
 
         long bestIndex = blocks.get(blocks.size() - 1).getNumber();
         assertEquals(bestIndex, indexedBlockStore.getMaxNumber());
-        assertEquals(cumDifficulty, indexedBlockStore.getTotalDifficulty());
+        assertEquals(totDifficulty, indexedBlockStore.getTotalDifficulty());
 
         //  testing:  getBlockByHash(byte[])
 
@@ -316,10 +314,10 @@ public class IndexedBlockStoreTest {
         IndexedBlockStore indexedBlockStore = new IndexedBlockStore();
         indexedBlockStore.init(new HashMapDB<byte[]>(), new HashMapDB<byte[]>());
 
-        BigInteger cummDiff = BigInteger.ZERO;
+        BigInteger totalDiff = BigInteger.ZERO;
         for (Block block : blocks){
-            cummDiff = cummDiff.add( block.getCumulativeDifficulty() );
-            indexedBlockStore.saveBlock(block, cummDiff, true);
+            totalDiff = totalDiff.add( block.getDifficultyBI() );
+            indexedBlockStore.saveBlock(block, totalDiff, true);
         }
 
         indexedBlockStore.flush();
@@ -329,7 +327,7 @@ public class IndexedBlockStoreTest {
 
         long bestIndex = blocks.get(blocks.size() - 1).getNumber();
         assertEquals(bestIndex, indexedBlockStore.getMaxNumber());
-        assertEquals(cumDifficulty, indexedBlockStore.getTotalDifficulty());
+        assertEquals(totDifficulty, indexedBlockStore.getTotalDifficulty());
 
         //  testing:  getBlockByHash(byte[])
 
@@ -437,10 +435,10 @@ public class IndexedBlockStoreTest {
         indexedBlockStore.init(indexDB, blocksDB);
 
 
-        BigInteger cummDiff = BigInteger.ZERO;
+        BigInteger totalDiff = BigInteger.ZERO;
         for (Block block : blocks){
-            cummDiff = cummDiff.add( block.getCumulativeDifficulty() );
-            indexedBlockStore.saveBlock(block, cummDiff, true);
+            totalDiff = totalDiff.add( block.getDifficultyBI() );
+            indexedBlockStore.saveBlock(block, totalDiff, true);
         }
 
         //  testing:   getTotalDifficulty()
@@ -448,7 +446,7 @@ public class IndexedBlockStoreTest {
 
         long bestIndex = blocks.get(blocks.size() - 1).getNumber();
         assertEquals(bestIndex, indexedBlockStore.getMaxNumber());
-        assertEquals(cumDifficulty, indexedBlockStore.getTotalDifficulty());
+        assertEquals(totDifficulty, indexedBlockStore.getTotalDifficulty());
 
         //  testing:  getBlockByHash(byte[])
 
@@ -588,20 +586,20 @@ public class IndexedBlockStoreTest {
             indexedBlockStore.init(indexDB, blocksDB);
 
 
-            BigInteger cummDiff = BigInteger.ZERO;
+            BigInteger totalDiff = BigInteger.ZERO;
             int preloadSize = blocks.size() / 2;
             for (int i = 0; i < preloadSize; ++i){
                 Block block = blocks.get(i);
-                cummDiff = cummDiff.add( block.getCumulativeDifficulty() );
-                indexedBlockStore.saveBlock(block, cummDiff, true);
+                totalDiff = totalDiff.add( block.getDifficultyBI() );
+                indexedBlockStore.saveBlock(block, totalDiff, true);
             }
 
             indexedBlockStore.flush();
 
             for (int i = preloadSize; i < blocks.size(); ++i){
                 Block block = blocks.get(i);
-                cummDiff = cummDiff.add( block.getCumulativeDifficulty() );
-                indexedBlockStore.saveBlock(block, cummDiff, true);
+                totalDiff = totalDiff.add( block.getDifficultyBI() );
+                indexedBlockStore.saveBlock(block, totalDiff, true);
             }
 
             //  testing:   getTotalDifficulty()
@@ -609,7 +607,7 @@ public class IndexedBlockStoreTest {
 
             long bestIndex = blocks.get(blocks.size() - 1).getNumber();
             assertEquals(bestIndex, indexedBlockStore.getMaxNumber());
-            assertEquals(cumDifficulty, indexedBlockStore.getTotalDifficulty());
+            assertEquals(totDifficulty, indexedBlockStore.getTotalDifficulty());
 
             //  testing:  getBlockByHash(byte[])
 
@@ -750,13 +748,13 @@ public class IndexedBlockStoreTest {
 
             List<Block> bestLine = getRandomChain(Genesis.getInstance().getHash(), 1, 100);
 
-            indexedBlockStore.saveBlock(Genesis.getInstance(), Genesis.getInstance().getCumulativeDifficulty(), true);
+            indexedBlockStore.saveBlock(Genesis.getInstance(), Genesis.getInstance().getDifficultyBI(), true);
 
             for (int i = 0; i < bestLine.size(); ++i){
 
                 BigInteger td = indexedBlockStore.getTotalDifficulty();
                 Block newBlock = bestLine.get(i);
-                td = td.add(newBlock.getCumulativeDifficulty());
+                td = td.add(newBlock.getDifficultyBI());
 
                 indexedBlockStore.saveBlock(newBlock, td, true);
             }
@@ -772,16 +770,16 @@ public class IndexedBlockStoreTest {
                 Block parentBlock = indexedBlockStore.getBlockByHash(newBlock.getParentHash());
                 BigInteger td = indexedBlockStore.getTotalDifficultyForHash(parentBlock.getHash());
 
-                td = td.add(newBlock.getCumulativeDifficulty());
+                td = td.add(newBlock.getDifficultyBI());
                 indexedBlockStore.saveBlock(newBlock, td, false);
             }
 
 
             // calc all TDs
             Map<ByteArrayWrapper, BigInteger> tDiffs = new HashMap<>();
-            BigInteger td = Genesis.getInstance().getCumulativeDifficulty();
+            BigInteger td = Genesis.getInstance().getDifficultyBI();
             for (Block block : bestLine){
-                td = td.add(block.getCumulativeDifficulty());
+                td = td.add(block.getDifficultyBI());
                 tDiffs.put(wrap(block.getHash()), td);
             }
 
@@ -789,7 +787,7 @@ public class IndexedBlockStoreTest {
             Block block = forkLine.get(0);
             td = tDiffs.get(wrap(block.getParentHash()));
             for (Block currBlock : forkLine){
-                td = td.add(currBlock.getCumulativeDifficulty());
+                td = td.add(currBlock.getDifficultyBI());
                 tForkDiffs.put(wrap(currBlock.getHash()), td);
             }
 
@@ -859,13 +857,13 @@ public class IndexedBlockStoreTest {
 
             List<Block> bestLine = getRandomChain(Genesis.getInstance().getHash(), 1, 100);
 
-            indexedBlockStore.saveBlock(Genesis.getInstance(), Genesis.getInstance().getCumulativeDifficulty(), true);
+            indexedBlockStore.saveBlock(Genesis.getInstance(), Genesis.getInstance().getDifficultyBI(), true);
 
             for (int i = 0; i < bestLine.size(); ++i){
 
                 BigInteger td = indexedBlockStore.getTotalDifficulty();
                 Block newBlock = bestLine.get(i);
-                td = td.add(newBlock.getCumulativeDifficulty());
+                td = td.add(newBlock.getDifficultyBI());
 
                 indexedBlockStore.saveBlock(newBlock, td, true);
             }
@@ -881,7 +879,7 @@ public class IndexedBlockStoreTest {
                 Block parentBlock = indexedBlockStore.getBlockByHash(newBlock.getParentHash());
                 BigInteger td = indexedBlockStore.getTotalDifficultyForHash(parentBlock.getHash());
 
-                td = td.add(newBlock.getCumulativeDifficulty());
+                td = td.add(newBlock.getDifficultyBI());
                 indexedBlockStore.saveBlock(newBlock, td, false);
             }
 
@@ -929,13 +927,13 @@ public class IndexedBlockStoreTest {
 
             List<Block> bestLine = getRandomChain(Genesis.getInstance().getHash(), 1, 100);
 
-            indexedBlockStore.saveBlock(Genesis.getInstance(), Genesis.getInstance().getCumulativeDifficulty(), true);
+            indexedBlockStore.saveBlock(Genesis.getInstance(), Genesis.getInstance().getDifficultyBI(), true);
 
             for (int i = 0; i < bestLine.size(); ++i){
 
                 BigInteger td = indexedBlockStore.getTotalDifficulty();
                 Block newBlock = bestLine.get(i);
-                td = td.add(newBlock.getCumulativeDifficulty());
+                td = td.add(newBlock.getDifficultyBI());
 
                 indexedBlockStore.saveBlock(newBlock, td, true);
             }
@@ -951,7 +949,7 @@ public class IndexedBlockStoreTest {
                 Block parentBlock = indexedBlockStore.getBlockByHash(newBlock.getParentHash());
                 BigInteger td = indexedBlockStore.getTotalDifficultyForHash(parentBlock.getHash());
 
-                td = td.add(newBlock.getCumulativeDifficulty());
+                td = td.add(newBlock.getDifficultyBI());
                 indexedBlockStore.saveBlock(newBlock, td, false);
             }
 
@@ -1016,14 +1014,14 @@ public class IndexedBlockStoreTest {
         Block block1 = new Block(Hex.decode("f90202f901fda0ad0d51e8d64c364a7b77ef2fe252f3f4df0940c7cfa69cedc1fbd6ea66894936a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479414a3bc0f103706650a19c5d24e5c4cf1ea5af78ea0e0580f4fdd1e3ae8346efaa6b1018605361f6e2fb058580e31414c8cbf5b0d49a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008605065cf2c43a8303e52e832fefd8808455fcbe1b80a017247341fd5d2f1d384682fea9302065a95dbd3e4f8260dde88a386f3cb95be3880f3fc8d5e0c87378c0c0"));
         Block block2 = new Block(Hex.decode("f90218f90213a0c63fc3626abc6f6ba695064e973126cccc6fd513d4f53485e11794a8855e8b2ba01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347941dcb8d1f0fcc8cbc8c2d76528e877f915e299fbea0ccb2ed2a8c585409fe5530d36320bc8c1406454b32a9e419e890ea49489e534aa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008605079eb238d88303e52e832fefd8808455fcbe2596d583010103844765746885676f312e35856c696e7578a0a673a429161eb32e6d0887b2bce2b12b1edd6e4b4cf55371853cba13d57118bd88d44d3609c7e203c7c0c0"));
 
-        indexedBlockStore.saveBlock(block1, block1.getCumulativeDifficulty(), true);
+        indexedBlockStore.saveBlock(block1, block1.getDifficultyBI(), true);
         indexedBlockStore.flush();
 
-        indexedBlockStore.saveBlock(block2, block2.getCumulativeDifficulty(), true);
+        indexedBlockStore.saveBlock(block2, block2.getDifficultyBI(), true);
         indexedBlockStore.flush();
 
-        assertEquals(block1.getCumulativeDifficulty(), indexedBlockStore.getTotalDifficultyForHash(block1.getHash()));
-        assertEquals(block2.getCumulativeDifficulty(), indexedBlockStore.getTotalDifficultyForHash(block2.getHash()));
+        assertEquals(block1.getDifficultyBI(), indexedBlockStore.getTotalDifficultyForHash(block1.getHash()));
+        assertEquals(block2.getDifficultyBI(), indexedBlockStore.getTotalDifficultyForHash(block2.getHash()));
     }
 
     @Test

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/suite/TestRunner.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/suite/TestRunner.java
@@ -95,7 +95,7 @@ public class TestRunner {
 
         IndexedBlockStore blockStore = new IndexedBlockStore();
         blockStore.init(new HashMapDB<byte[]>(), new HashMapDB<byte[]>());
-        blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
+        blockStore.saveBlock(genesis, genesis.getDifficultyBI(), true);
 
         ProgramInvokeFactoryImpl programInvokeFactory = new ProgramInvokeFactoryImpl();
 
@@ -106,7 +106,7 @@ public class TestRunner {
         PendingStateImpl pendingState = new PendingStateImpl(new EthereumListenerAdapter());
 
         blockchain.setBestBlock(genesis);
-        blockchain.setTotalDifficulty(genesis.getCumulativeDifficulty());
+        blockchain.setTotalDifficulty(genesis.getDifficultyBI());
         blockchain.setParentHeaderValidator(new CommonConfig().parentHeaderValidator());
         blockchain.setProgramInvokeFactory(programInvokeFactory);
 
@@ -148,7 +148,7 @@ public class TestRunner {
 
             ImportResult importResult = blockchain.tryToConnect(block);
             logger.debug("{} ~ {} difficulty: {} ::: {}", block.getShortHash(), shortHash(block.getParentHash()),
-                    block.getCumulativeDifficulty(), importResult.toString());
+                    block.getDifficultyBI(), importResult.toString());
         }
 
         repository = blockchain.getRepository();

--- a/ethereumj-core/src/test/java/org/ethereum/longrun/BlockchainValidation.java
+++ b/ethereumj-core/src/test/java/org/ethereum/longrun/BlockchainValidation.java
@@ -27,11 +27,11 @@ import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionInfo;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.datasource.DataSourceArray;
 import org.ethereum.datasource.NodeKeyCompositor;
 import org.ethereum.datasource.Source;
 import org.ethereum.datasource.SourceCodec;
 import org.ethereum.db.BlockStore;
+import org.ethereum.db.HeaderStore;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.trie.SecureTrie;
 import org.ethereum.trie.TrieImpl;
@@ -120,14 +120,14 @@ public class BlockchainValidation {
     }
 
     public static void checkFastHeaders(Ethereum ethereum, CommonConfig commonConfig, AtomicInteger fatalErrors) {
-        DataSourceArray<BlockHeader> headerStore = commonConfig.headerSource();
+        HeaderStore headerStore = commonConfig.headerStore();
         int blockNumber = headerStore.size() - 1;
         byte[] lastParentHash = null;
 
         try {
             testLogger.info("Checking fast headers from best block: {}", blockNumber);
             while (blockNumber > 0) {
-                BlockHeader header = headerStore.get(blockNumber);
+                BlockHeader header = headerStore.getHeaderByNumber(blockNumber);
                 if (lastParentHash != null) {
                     assert FastByteComparisons.equal(header.getHash(), lastParentHash);
                 }


### PR DESCRIPTION
- modified structure of headers store used in FastSync
- if skipHistory is used, headers store is used for getBlockHeaders message answer, so fixing https://github.com/ethereum/ethereumj/issues/1058
- total difficulty recalculated if skipHistory used, fixing https://github.com/ethereum/ethereumj/issues/1041
- migration added to modify DB for those who already did sync with skipHistory
- if skipHistory was not used, headers store is removed, because it's not used at all (1.6GB currently on MainNet)