### PR TITLE
Fix/new peer ip check

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -89,6 +89,7 @@ public class HandshakeHandler extends ByteToMessageDecoder {
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        channel.setInetSocketAddress((InetSocketAddress) ctx.channel().remoteAddress());
         if (remoteId.length == 64) {
             channel.initWithNode(remoteId);
             initiate(ctx);

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -89,7 +89,6 @@ public class HandshakeHandler extends ByteToMessageDecoder {
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
-        channel.setInetSocketAddress((InetSocketAddress) ctx.channel().remoteAddress());
         if (remoteId.length == 64) {
             channel.initWithNode(remoteId);
             initiate(ctx);

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
@@ -207,7 +207,8 @@ public class ChannelManager {
      */
     public boolean isAddressInQueue(InetAddress peerAddr) {
         for (Channel peer: newPeers) {
-            if (peer.getInetSocketAddress().getAddress().getHostAddress().equals(peerAddr.getHostAddress())) {
+            if (peer.getInetSocketAddress() != null &&
+                    peer.getInetSocketAddress().getAddress().getHostAddress().equals(peerAddr.getHostAddress())) {
                 return true;
             }
         }

--- a/ethereumj-core/src/main/java/org/ethereum/net/server/EthereumChannelInitializer.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/server/EthereumChannelInitializer.java
@@ -67,6 +67,7 @@ public class EthereumChannelInitializer extends ChannelInitializer<NioSocketChan
             }
 
             final Channel channel = ctx.getBean(Channel.class);
+            channel.setInetSocketAddress(ch.remoteAddress());
             channel.init(ch.pipeline(), remoteId, peerDiscoveryMode, channelManager);
 
             if(!peerDiscoveryMode) {


### PR DESCRIPTION
This PR should fix `isAddressInQueue` null exception.
We will not have `InetSocketAddress` for outbound connections but with this line it will be added to inbound on early stage. Port is not an issue, we are changing it later anyway. 