### PR TITLE
Sync improvement for usage in private networks

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/mine/BlockMiner.java
+++ b/ethereumj-core/src/main/java/org/ethereum/mine/BlockMiner.java
@@ -52,7 +52,7 @@ public class BlockMiner {
 
     private static ExecutorService executor = Executors.newSingleThreadExecutor();
 
-    private Blockchain blockchain;
+    protected Blockchain blockchain;
 
     private BlockStore blockStore;
 

--- a/ethereumj-core/src/main/java/org/ethereum/sync/BlockDownloader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/BlockDownloader.java
@@ -47,7 +47,7 @@ public abstract class BlockDownloader {
 
     // Max number of Blocks / Headers in one request
     public static int MAX_IN_REQUEST = 192;
-    private static int REQUESTS = 32;
+    protected static int REQUESTS = 32;
 
     private BlockHeaderValidator headerValidator;
 
@@ -56,16 +56,16 @@ public abstract class BlockDownloader {
     private SyncQueueIfc syncQueue;
 
     private boolean headersDownload = true;
-    private boolean blockBodiesDownload = true;
+    protected boolean blockBodiesDownload = true;
 
-    private CountDownLatch receivedHeadersLatch = new CountDownLatch(0);
-    private CountDownLatch receivedBlocksLatch = new CountDownLatch(0);
+    protected CountDownLatch receivedHeadersLatch = new CountDownLatch(0);
+    protected CountDownLatch receivedBlocksLatch = new CountDownLatch(0);
 
     private Thread getHeadersThread;
     private Thread getBodiesThread;
 
     protected boolean headersDownloadComplete;
-    private boolean downloadComplete;
+    protected boolean downloadComplete;
 
     private CountDownLatch stopLatch = new CountDownLatch(1);
 
@@ -145,7 +145,7 @@ public abstract class BlockDownloader {
         this.blockQueueLimit = blockQueueLimit;
     }
 
-    private void headerRetrieveLoop() {
+    protected void headerRetrieveLoop() {
         List<SyncQueueIfc.HeadersRequest> hReq = emptyList();
         while(!Thread.currentThread().isInterrupted()) {
             try {
@@ -214,7 +214,7 @@ public abstract class BlockDownloader {
         }
     }
 
-    private void blockRetrieveLoop() {
+    protected void blockRetrieveLoop() {
         class BlocksCallback implements FutureCallback<List<Block>> {
             private Channel peer;
 
@@ -311,7 +311,7 @@ public abstract class BlockDownloader {
      * @param blocks block list received from remote peer and be added to the queue
      * @param nodeId nodeId of remote peer which these blocks are received from
      */
-    private void addBlocks(List<Block> blocks, byte[] nodeId) {
+    protected void addBlocks(List<Block> blocks, byte[] nodeId) {
 
         if (blocks.isEmpty()) {
             return;
@@ -355,7 +355,7 @@ public abstract class BlockDownloader {
      * @return true if blocks passed validation and were added to the queue,
      *          otherwise it returns false
      */
-    private boolean validateAndAddHeaders(List<BlockHeader> headers, byte[] nodeId) {
+    protected boolean validateAndAddHeaders(List<BlockHeader> headers, byte[] nodeId) {
 
         if (headers.isEmpty()) return true;
 


### PR DESCRIPTION
This change allows to use ethereumj with its configurations (ethereumj.conf), without the need of starting sync manager nor the block miner manually.

At starting, it triggers the "OnSyncDone" event after a period of time if it does not find any peer.
This time is 120sec by default, and is modifiable through following static variable:

SyncManager.WAIT_TIME = 120   

  
In the context of a standalone node (without discovery nor peer configured), this wait time could be reduced to -1. 

When the time is over, the mining process will start according to the setup in the SystemProperties (or config file).

The other change is about the moment when sync is considered as done in the context of a private network. Indeed, the node was always waiting for a new block, while now it is considered as finished when the last known BestBlock is downloaded.

This merge request will really help people who wants to start using ethereunj in a private network context (and making syncs between nodes), without implementing manual synchronizations between the SyncManager and the BlockMiner processes. 

In fact it simply enables to use ethereumj with its out of the box capabilities...

This change still implies that the sync manager to be always activated in the configuration even for a standalone node.

It also includes one bug fix to prevent an infinite loop when there are only 2 blocks to sync.  
