### PR TITLE
Fixing Memory usage with empty size data in VM

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/VM.java
@@ -109,7 +109,7 @@ public class VM {
         long gasCost = 0;
 
         // Avoid overflows
-        if (newMemSize.compareTo(MAX_MEM_SIZE) == 1) {
+        if (newMemSize.compareTo(MAX_MEM_SIZE) > 0) {
             throw Program.Exception.gasOverflow(newMemSize, MAX_MEM_SIZE);
         }
 
@@ -790,7 +790,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = "data: " + toHexString(msgData);
 
-                    program.memorySave(memOffsetData.intValueSafe(), msgData);
+                    program.memorySave(memOffsetData.intValueSafe(), lengthData.intValueSafe(), msgData);
                     program.step();
                 }
                 break;
@@ -818,7 +818,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = "data: " + toHexString(msgData);
 
-                    program.memorySave(memOffsetData.intValueSafe(), msgData);
+                    program.memorySave(memOffsetData.intValueSafe(), lengthData.intValueSafe(), msgData);
                     program.step();
                 }
                 break;
@@ -870,7 +870,7 @@ public class VM {
                     if (logger.isInfoEnabled())
                         hint = "code: " + toHexString(codeCopy);
 
-                    program.memorySave(memOffset, codeCopy);
+                    program.memorySave(memOffset, lengthData, codeCopy);
                     program.step();
                 }
                 break;

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/Memory.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/Memory.java
@@ -72,6 +72,7 @@ public class Memory implements ProgramListenerAware {
     }
 
     public void write(int address, byte[] data, int dataSize, boolean limited) {
+        if (dataSize <= 0) return;
 
         if (data.length < dataSize)
             dataSize = data.length;
@@ -107,7 +108,7 @@ public class Memory implements ProgramListenerAware {
 
     public void extendAndWrite(int address, int allocSize, byte[] data) {
         extend(address, allocSize);
-        write(address, data, data.length, false);
+        write(address, data, allocSize, false);
     }
 
     public void extend(int address, int size) {

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1200,7 +1200,7 @@ public class Program {
                 track.rollback();
             }
 
-            this.memorySave(msg.getOutDataOffs().intValue(), out.getRight());
+            this.memorySave(msg.getOutDataOffs().intValue(), msg.getOutDataSize().intValueSafe(), out.getRight());
         }
     }
 

--- a/ethereumj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
@@ -341,15 +341,11 @@ public class ProgramMemoryTest {
         assertEquals(32, program.getMemSize());
     }
 
-    @Ignore
     @Test
-    public void testInitialInsert() {
-
-
-        // todo: fix the array out of bound here
+    public void testEmptyInsert() {
         int offset = 32;
-        int size = 00;
-        program.memorySave(32, 0, new byte[0]);
-        assertEquals(32, program.getMemSize());
+        int size = 0;
+        program.memorySave(offset, size, new byte[] {0x01});
+        assertEquals(0, program.getMemSize());
     }
 }


### PR DESCRIPTION
Should fix block 3467853 in Ropsten
Some points:
```
Over an account’s execution, the total fee for memoryusage
payable is proportional to smallest multiple of 32
bytes that are required such that all memory indices
(whether for read or write) are included in the range. This
is paid for on a just-in-time basis; as such, referencing an
area of memory at least 32 bytes greater than any previously
indexed memory will certainly result in an additional
memory usage fee.
```
From yellow paper. So, when addressing 0 length part of memory we are not addressing any memory part.