### PR TITLE
fix same composed key of contract storage nodes

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/datasource/NodeKeyCompositor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/NodeKeyCompositor.java
@@ -12,13 +12,14 @@ import static org.ethereum.crypto.HashUtil.sha3;
  * <p>
  *     <b>Input:</b> 32-bytes node key, 20-bytes contract address
  * <br/>
- *     <b>Output:</b> 32-bytes composed key <i>[first 16-bytes of node key : first 16-bytes of address hash]</i>
+ *     <b>Output:</b> 32-bytes composed key <i>[first 16-bytes of address hash : second 16-bytes of node key]</i>
  *
  * <p>
  *     Example: <br/>
  *     Contract address hash <i>a9539c810cc2e8fa20785bdd78ec36ccb25e1b5be78dbadf6c4e817c6d170bbb</i> <br/>
  *     Key of one of the storage nodes <i>bbbbbb5be78dbadf6c4e817c6d170bbb47e9916f8f6cc4607c5f3819ce98497b</i> <br/>
  *     Composed key will be <i>bbbbbb5be78dbadf6c4e817c6d170bbba9539c810cc2e8fa20785bdd78ec36cc</i>
+ *     Composed key will be <i>cb25e1b5be78dbadf6c4e817c6d170bba9539c810cc2e8fa20785bdd78ec36cc</i>
  *
  * <p>
  *     This mechanism is a part of flat storage source which is free from reference counting
@@ -58,8 +59,8 @@ public class NodeKeyCompositor implements Serializer<byte[], byte[]> {
         validateKey(key);
 
         byte[] derivative = new byte[key.length];
-        arraycopy(key, 0, derivative, 0, PREFIX_BYTES);
-        arraycopy(addrHash, 0, derivative, PREFIX_BYTES, PREFIX_BYTES);
+        arraycopy(addrHash, 0, derivative, 0, PREFIX_BYTES);
+        arraycopy(key, 0, derivative, PREFIX_BYTES, PREFIX_BYTES);
 
         return derivative;
     }


### PR DESCRIPTION
32-bytes composed key should be 
[first 16-bytes of address hash:second 16-bytes of node key] 

There seems a  BIG problem. I noticed in solidity, for dynamic type such as  `string`， `bytes`
first 16-bytes of node-key are same and second 16-bytes of node are different.
So if one field has been encoded to many storage-key. the composed key will be same.

For example
        s1 = "1111111111111111111111111111111111111112222222222222222222222222222222222222222333333333333333333333333333333333333";

encoded result:
```
key of storage node								value of storage node													     
0000000000000000000000000000000000000000000000000000000000000000 00000000000000000000000000000000000000000000000000000000000000e7
290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563 3131313131313131313131313131313131313131313131313131313131313131
290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e564 3131313131313132323232323232323232323232323232323232323232323232
290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e565 3232323232323232323232323232323333333333333333333333333333333333
290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e566 3333333333333333333333333333333333333300000000000000000000000000
```





