### PR TITLE
Fix discovery exception handling

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/Node.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/Node.java
@@ -85,6 +85,10 @@ public class Node implements Serializable {
         this.port = port;
     }
 
+    /**
+     * Instantiates node from RLP list containing node data.
+     * @throws IllegalArgumentException if node id is not a valid EC point.
+     */
     public Node(RLPList nodeRLP) {
         byte[] hostB = nodeRLP.get(0).getRLPData();
         byte[] portB = nodeRLP.get(1).getRLPData();
@@ -100,7 +104,9 @@ public class Node implements Serializable {
 
         this.host = bytesToIp(hostB);
         this.port = port;
-        this.id = idB;
+
+        // a tricky way to check whether given data is a valid EC point or not
+        this.id = ECKey.fromNodeId(idB).getNodeId();
     }
 
     public Node(byte[] rlp) {

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/MessageHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/MessageHandler.java
@@ -52,7 +52,7 @@ public class MessageHandler extends SimpleChannelInboundHandler<DiscoveryEvent>
         try {
             nodeManager.handleInbound(event);
         } catch (Throwable t) {
-            logger.error("Failed to process incoming message: {}", event.getMessage(), t);
+            logger.info("Failed to process incoming message: {}, caused by: {}", event.getMessage(), t.toString());
         }
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/MessageHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/MessageHandler.java
@@ -49,7 +49,11 @@ public class MessageHandler extends SimpleChannelInboundHandler<DiscoveryEvent>
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, DiscoveryEvent event) throws Exception {
-        nodeManager.handleInbound(event);
+        try {
+            nodeManager.handleInbound(event);
+        } catch (Throwable t) {
+            logger.error("Failed to process incoming message: {}", event.getMessage(), t);
+        }
     }
 
     @Override

--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeHandler.java
@@ -333,7 +333,7 @@ public class NodeHandler {
     @Override
     public String toString() {
         return "NodeHandler[state: " + state + ", node: " + node.getHost() + ":" + node.getPort() + ", id="
-                + (node.getId().length > 0 ? Hex.toHexString(node.getId(), 0, 4) : "empty") + "]";
+                + (node.getId().length >= 4 ? Hex.toHexString(node.getId(), 0, 4) : "empty") + "]";
     }
 
 

--- a/ethereumj-core/src/test/java/org/ethereum/net/rlpx/RLPXTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/net/rlpx/RLPXTest.java
@@ -83,8 +83,7 @@ public class RLPXTest {
         int port = 30303;
 
         byte[] part1 = sha3("007".getBytes(Charset.forName("UTF-8")));
-        byte[] part2 = sha3("007".getBytes(Charset.forName("UTF-8")));
-        byte[] id = merge(part1, part2);
+        byte[] id = ECKey.fromPrivate(part1).getNodeId();
 
         Node node = new Node(id, ip, port);
 
@@ -146,7 +145,7 @@ public class RLPXTest {
     @Test
     public void test6() {
 
-        byte[] id_1 = sha3("+++".getBytes(Charset.forName("UTF-8")));
+        byte[] id_1 = ECKey.fromPrivate(sha3("+++".getBytes(Charset.forName("UTF-8")))).getNodeId();
         String host_1 = "85.65.19.231";
         int port_1 = 30303;
 
@@ -260,6 +259,16 @@ public class RLPXTest {
         assertEquals("0.0.0.0", msg1.getFromHost());
         assertEquals(13272, msg1.getToPort());
         assertEquals("58.136.8.186", msg1.getToHost());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidNodeId() {
+        byte[] id_1 = sha3("+++".getBytes(Charset.forName("UTF-8")));
+        String host_1 = "85.65.19.231";
+        int port_1 = 30303;
+
+        Node node_1 = new Node(id_1, host_1 , port_1);
+        new Node(node_1.getRLP());
     }
 }
 


### PR DESCRIPTION
Fixes `UDPListener` crash caused by malformed `nodeId` received from malicious peers.