### PR TITLE
Issue-1184: no distinction between uint and int

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/solidity/SolidityType.java
+++ b/ethereumj-core/src/main/java/org/ethereum/solidity/SolidityType.java
@@ -58,7 +58,8 @@ public abstract class SolidityType {
     public static SolidityType getType(String typeName) {
         if (typeName.contains("[")) return ArrayType.getType(typeName);
         if ("bool".equals(typeName)) return new BoolType();
-        if (typeName.startsWith("int") || typeName.startsWith("uint")) return new IntType(typeName);
+        if (typeName.startsWith("int")) return new IntType(typeName);
+        if (typeName.startsWith("uint")) return new UnsignedIntType(typeName);
         if ("address".equals(typeName)) return new AddressType();
         if ("string".equals(typeName)) return new StringType();
         if ("bytes".equals(typeName)) return new BytesType();
@@ -356,21 +357,15 @@ public abstract class SolidityType {
             return ByteUtil.bigIntegerToBytes(bi, 20);
         }
     }
-
-    public static class IntType extends SolidityType {
-        public IntType(String name) {
+    
+    public static abstract class NumericType extends SolidityType {
+        public NumericType(String name)
+        {
             super(name);
         }
 
-        @Override
-        public String getCanonicalName() {
-            if (getName().equals("int")) return "int256";
-            if (getName().equals("uint")) return "uint256";
-            return super.getCanonicalName();
-        }
-
-        @Override
-        public byte[] encode(Object value) {
+        BigInteger encodeInternal(Object value)
+        {
             BigInteger bigInt;
 
             if (value instanceof String) {
@@ -393,14 +388,21 @@ public abstract class SolidityType {
             } else {
                 throw new RuntimeException("Invalid value for type '" + this + "': " + value + " (" + value.getClass() + ")");
             }
-            return encodeInt(bigInt);
+            return bigInt;
+        }
+    }
+
+    public static class IntType extends NumericType {
+        public IntType(String name) {
+            super(name);
         }
 
         @Override
-        public Object decode(byte[] encoded, int offset) {
-            return decodeInt(encoded, offset);
+        public String getCanonicalName() {
+            if (getName().equals("int")) return "int256";
+            return super.getCanonicalName();
         }
-
+        
         public static BigInteger decodeInt(byte[] encoded, int offset) {
             return new BigInteger(Arrays.copyOfRange(encoded, offset, offset + 32));
         }
@@ -409,6 +411,49 @@ public abstract class SolidityType {
         }
         public static byte[] encodeInt(BigInteger bigInt) {
             return ByteUtil.bigIntegerToBytesSigned(bigInt, 32);
+        }
+        @Override
+        public Object decode(byte[] encoded, int offset) {
+            return decodeInt(encoded, offset);
+        }
+        @Override
+        public byte[] encode(Object value) {
+            BigInteger bigInt = encodeInternal(value);
+            return encodeInt(bigInt);
+        }
+    }
+    
+    public static class UnsignedIntType extends NumericType {
+        public UnsignedIntType(String name) {
+            super(name);
+        }
+        
+        @Override
+        public String getCanonicalName() {
+            if (getName().equals("uint")) return "uint256";
+            return super.getCanonicalName();
+        }
+        public static BigInteger decodeInt(byte[] encoded, int offset) {
+            return new BigInteger(1, Arrays.copyOfRange(encoded, offset, offset + 32));
+        }
+        public static byte[] encodeInt(int i) {
+            return encodeInt(new BigInteger("" + i));
+        }
+        public static byte[] encodeInt(BigInteger bigInt) {
+            return ByteUtil.bigIntegerToBytesSigned(bigInt, 32);
+        }
+
+        @Override
+        public byte[] encode(Object value)
+        {
+            BigInteger bigInt = encodeInternal(value);
+            return encodeInt(bigInt);
+        }
+
+        @Override
+        public Object decode(byte[] encoded, int offset)
+        {
+            return decodeInt(encoded, offset);
         }
     }
 

--- a/ethereumj-core/src/test/java/org/ethereum/solidity/SolidityTypeTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/solidity/SolidityTypeTest.java
@@ -1,0 +1,33 @@
+package org.ethereum.solidity;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+public class SolidityTypeTest
+{
+    @Test
+    public void ensureUnsignedInteger_isDecodedWithCorrectSignum()
+    {
+        byte[] bigNumberByteArray = {-13, -75, 19, 86, -119, 67, 112, -4, 118, -86, 98, -46, 103, -42, -126, 63, -60, -15, -87, 57, 43, 11, -17, -52, 0, 3, -65, 14, -67, -40, 65, 119};
+        SolidityType testObject = new SolidityType.UnsignedIntType("uint256");
+        Object decode = testObject.decode(bigNumberByteArray);
+        assertEquals(decode.getClass(), BigInteger.class);
+        BigInteger actualBigInteger = (BigInteger) decode;
+        BigInteger expectedBigInteger = new BigInteger("f3b51356894370fc76aa62d267d6823fc4f1a9392b0befcc0003bf0ebdd84177", 16);
+        assertEquals(expectedBigInteger, actualBigInteger);
+    }
+    @Test
+    public void ensureSignedInteger_isDecoded()
+    {
+        byte[] bigNumberByteArray = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 127, -1, -1, -1, -1, -1, -1, -1}; 
+        SolidityType testObject = new SolidityType.IntType("int256");
+        Object decode = testObject.decode(bigNumberByteArray);
+        assertEquals(decode.getClass(), BigInteger.class);
+        BigInteger actualBigInteger = (BigInteger) decode;
+        BigInteger expectedBigInteger = new BigInteger(bigNumberByteArray);
+        assertEquals(expectedBigInteger, actualBigInteger);
+    }
+}

--- a/ethereumj-core/src/test/java/org/ethereum/util/StandaloneBlockchainTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/util/StandaloneBlockchainTest.java
@@ -121,7 +121,7 @@ public class StandaloneBlockchainTest {
         a.callFunction("f", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         BigInteger r = (BigInteger) a.callConstFunction("a")[0];
         System.out.println(r.toString(16));
-        Assert.assertEquals(new BigInteger(Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), r);
+        Assert.assertEquals(new BigInteger(1, Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), r);
     }
 
     @Test


### PR DESCRIPTION
During regression testing the `org.ethereum.util.StandaloneBlockchainTest.encodeTest1()` failed because the assumption on the expected value was wrong, imho:

The written SolidityContract has a setter-alike function and the value that is set is tested. However the value is an unsigned-int, so i doubt that the expected value `-1` was correct due to the wrong uint implementation, but feel free to clear my mind. 
