### PR TITLE
Fix/ropsten constantinople

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/Initializer.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/Initializer.java
@@ -64,16 +64,13 @@ class Initializer implements BeanPostProcessor {
 
         // forcing loading blockchain config
         config.getBlockchainConfig();
+        logger.info("Blockchain config {}", config.getBlockchainConfig().toString());
 
         // forcing loading genesis to fail fast in case of error
         config.getGenesis();
 
         // forcing reading private key or generating it in database directory
         config.nodeId();
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("Blockchain config {}", config.getBlockchainConfig().toString());
-        }
     }
 
     @Override

--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -198,7 +198,7 @@ public class SystemProperties {
             Config testUserConfig = ConfigFactory.parseResources("test-user.conf");
             logger.info("Config (" + (testUserConfig.entrySet().size() > 0 ? " yes " : " no  ") + "): test properties from resource 'test-user.conf'");
             String file = System.getProperty("ethereumj.conf.file");
-            Config cmdLineConfigFile = mergeConfigs(res, s -> ConfigFactory.parseFile(new File(s)));
+            Config cmdLineConfigFile = mergeConfigs(file, s -> ConfigFactory.parseFile(new File(s)));
             logger.info("Config (" + (cmdLineConfigFile.entrySet().size() > 0 ? " yes " : " no  ") + "): user properties from -Dethereumj.conf.file file(s) '" + file + "'");
             logger.info("Config (" + (apiConfig.entrySet().size() > 0 ? " yes " : " no  ") + "): config passed via constructor");
             config = apiConfig

--- a/ethereumj-core/src/main/java/org/ethereum/config/net/BaseNetConfig.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/net/BaseNetConfig.java
@@ -57,10 +57,20 @@ public class BaseNetConfig implements BlockchainNetConfig {
 
     @Override
     public String toString() {
-        return "BaseNetConfig{" +
-                "blockNumbers=" + Arrays.toString(Arrays.copyOfRange(blockNumbers, 0, count)) +
-                ", configs=" + Arrays.toString(Arrays.copyOfRange(configs, 0, count)) +
-                ", count=" + count +
-                '}';
+        StringBuilder res = new StringBuilder()
+                .append("BaseNetConfig{")
+                .append("blockNumbers= ");
+
+        for (int i = 0; i < count; ++i) {
+            res.append("#").append(blockNumbers[i]).append(" => ");
+            res.append(configs[i]);
+            if (i != count - 1) {
+                res.append(", ");
+            }
+        }
+
+        res.append(" (total: ").append(count).append(")}");
+
+        return res.toString();
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -254,7 +254,7 @@ public class TransactionExecutor {
                 result.spendGas(basicTxCost);
             } else {
                 ProgramInvoke programInvoke =
-                        programInvokeFactory.createProgramInvoke(tx, currentBlock, cacheTrack, blockStore);
+                        programInvokeFactory.createProgramInvoke(tx, currentBlock, cacheTrack, track, blockStore);
 
                 this.vm = new VM(config, vmHook);
                 this.program = new Program(track.getCodeHash(targetAddress), code, programInvoke, tx, config, vmHook).withCommonConfig(commonConfig);
@@ -289,7 +289,8 @@ public class TransactionExecutor {
             m_endGas = m_endGas.subtract(BigInteger.valueOf(basicTxCost));
             result.spendGas(basicTxCost);
         } else {
-            ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(tx, currentBlock, cacheTrack, blockStore);
+            ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(tx, currentBlock,
+                    cacheTrack, track, blockStore);
 
             this.vm = new VM(config, vmHook);
             this.program = new Program(tx.getData(), programInvoke, tx, config, vmHook).withCommonConfig(commonConfig);

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -140,7 +140,7 @@ public class Program {
         this.traceListener = new ProgramTraceListener(config.vmTrace());
         this.memory = setupProgramListener(new Memory());
         this.stack = setupProgramListener(new Stack());
-        this.originalRepo = programInvoke.getRepository().clone();
+        this.originalRepo = programInvoke.getOrigRepository();
         this.storage = setupProgramListener(new Storage(programInvoke));
         this.trace = new ProgramTrace(config, programInvoke);
         this.blockchainConfig = config.getBlockchainConfig().getConfigForBlock(programInvoke.getNumber().longValue());
@@ -523,7 +523,7 @@ public class Program {
         InternalTransaction internalTx = addInternalTx(nonce, getGasLimit(), senderAddress, null, endowment, programCode, "create");
         ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(
                 this, DataWord.of(newAddress), getOwnerAddress(), value, gasLimit,
-                newBalance, null, track, this.invoke.getBlockStore(), false, byTestingSuite());
+                newBalance, null, track, this.invoke.getOrigRepository(), this.invoke.getBlockStore(), false, byTestingSuite());
 
         ProgramResult result = ProgramResult.createEmpty();
 
@@ -659,7 +659,7 @@ public class Program {
                     this, DataWord.of(contextAddress),
                     msg.getType().callIsDelegate() ? getCallerAddress() : getOwnerAddress(),
                     msg.getType().callIsDelegate() ? getCallValue() : msg.getEndowment(),
-                    msg.getGas(), contextBalance, data, track, this.invoke.getBlockStore(),
+                    msg.getGas(), contextBalance, data, track, this.invoke.getOrigRepository(), this.invoke.getBlockStore(),
                     msg.getType().callIsStatic() || isStaticCall(), byTestingSuite());
 
             VM vm = new VM(config, vmHook);

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvoke.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvoke.java
@@ -69,6 +69,8 @@ public interface ProgramInvoke {
 
     Repository getRepository();
 
+    Repository getOrigRepository();
+
     BlockStore getBlockStore();
 
     boolean isStaticCall();

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactory.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactory.java
@@ -33,12 +33,12 @@ import java.math.BigInteger;
 public interface ProgramInvokeFactory {
 
     ProgramInvoke createProgramInvoke(Transaction tx, Block block,
-                                      Repository repository, BlockStore blockStore);
+                                      Repository repository, Repository origRepository, BlockStore blockStore);
 
     ProgramInvoke createProgramInvoke(Program program, DataWord toAddress, DataWord callerAddress,
                                              DataWord inValue, DataWord inGas,
                                              BigInteger balanceInt, byte[] dataIn,
-                                             Repository repository, BlockStore blockStore,
+                                             Repository repository, Repository origRepository, BlockStore blockStore,
                                             boolean staticCall, boolean byTestingSuite);
 
 

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
@@ -46,7 +46,7 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
     // Invocation by the wire tx
     @Override
     public ProgramInvoke createProgramInvoke(Transaction tx, Block block, Repository repository,
-                                             BlockStore blockStore) {
+                                             Repository origRepository, BlockStore blockStore) {
 
         /***         ADDRESS op       ***/
         // YP: Get address of currently executing account.
@@ -132,7 +132,7 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
 
         return new ProgramInvokeImpl(address, origin, caller, balance, gasPrice, gas, callValue, data,
                 lastHash, coinbase, timestamp, number, difficulty, gaslimit,
-                repository, blockStore);
+                repository, origRepository, blockStore);
     }
 
     /**
@@ -142,7 +142,7 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
     public ProgramInvoke createProgramInvoke(Program program, DataWord toAddress, DataWord callerAddress,
                                              DataWord inValue, DataWord inGas,
                                              BigInteger balanceInt, byte[] dataIn,
-                                             Repository repository, BlockStore blockStore,
+                                             Repository repository, Repository origRepository, BlockStore blockStore,
                                              boolean isStaticCall, boolean byTestingSuite) {
 
         DataWord address = toAddress;
@@ -196,6 +196,6 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
 
         return new ProgramInvokeImpl(address, origin, caller, balance, gasPrice, gas, callValue,
                 data, lastHash, coinbase, timestamp, number, difficulty, gasLimit,
-                repository, program.getCallDeep() + 1, blockStore, isStaticCall, byTestingSuite);
+                repository, origRepository, program.getCallDeep() + 1, blockStore, isStaticCall, byTestingSuite);
     }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeImpl.java
@@ -51,6 +51,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
     private Map<DataWord, DataWord> storage;
 
     private final Repository repository;
+    private final Repository origRepository;
     private boolean byTransaction = true;
     private boolean byTestingSuite = false;
     private int callDeep = 0;
@@ -60,8 +61,8 @@ public class ProgramInvokeImpl implements ProgramInvoke {
                              DataWord gasPrice, DataWord gas, DataWord callValue, byte[] msgData,
                              DataWord lastHash, DataWord coinbase, DataWord timestamp, DataWord number, DataWord
                                      difficulty,
-                             DataWord gaslimit, Repository repository, int callDeep, BlockStore blockStore,
-                             boolean isStaticCall, boolean byTestingSuite) {
+                             DataWord gaslimit, Repository repository, Repository origRepository, int callDeep,
+                             BlockStore blockStore, boolean isStaticCall, boolean byTestingSuite) {
 
         // Transaction env
         this.address = address;
@@ -83,6 +84,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
         this.gaslimit = gaslimit;
 
         this.repository = repository;
+        this.origRepository = origRepository;
         this.byTransaction = false;
         this.callDeep = callDeep;
         this.blockStore = blockStore;
@@ -94,9 +96,10 @@ public class ProgramInvokeImpl implements ProgramInvoke {
                              byte[] gasPrice, byte[] gas, byte[] callValue, byte[] msgData,
                              byte[] lastHash, byte[] coinbase, long timestamp, long number, byte[] difficulty,
                              byte[] gaslimit,
-                             Repository repository, BlockStore blockStore, boolean byTestingSuite) {
+                             Repository repository, Repository origRepository, BlockStore blockStore,
+                             boolean byTestingSuite) {
         this(address, origin, caller, balance, gasPrice, gas, callValue, msgData, lastHash, coinbase,
-                timestamp, number, difficulty, gaslimit, repository, blockStore);
+                timestamp, number, difficulty, gaslimit, repository, origRepository, blockStore);
         this.byTestingSuite = byTestingSuite;
     }
 
@@ -105,7 +108,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
                              byte[] gasPrice, byte[] gas, byte[] callValue, byte[] msgData,
                              byte[] lastHash, byte[] coinbase, long timestamp, long number, byte[] difficulty,
                              byte[] gaslimit,
-                             Repository repository, BlockStore blockStore) {
+                             Repository repository, Repository origRepository, BlockStore blockStore) {
 
         // Transaction env
         this.address = DataWord.of(address);
@@ -127,6 +130,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
         this.gaslimit = DataWord.of(gaslimit);
 
         this.repository = repository;
+        this.origRepository = origRepository;
         this.blockStore = blockStore;
     }
 
@@ -261,6 +265,13 @@ public class ProgramInvokeImpl implements ProgramInvoke {
         return repository;
     }
 
+    /**
+     * Repository at the start of top-level ttransaction execution
+     */
+    public Repository getOrigRepository() {
+        return origRepository;
+    }
+
     @Override
     public BlockStore getBlockStore() {
         return blockStore;
@@ -309,6 +320,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
         if (origin != null ? !origin.equals(that.origin) : that.origin != null) return false;
         if (prevHash != null ? !prevHash.equals(that.prevHash) : that.prevHash != null) return false;
         if (repository != null ? !repository.equals(that.repository) : that.repository != null) return false;
+        if (origRepository != null ? !origRepository.equals(that.origRepository) : that.origRepository != null) return false;
         if (storage != null ? !storage.equals(that.storage) : that.storage != null) return false;
         if (timestamp != null ? !timestamp.equals(that.timestamp) : that.timestamp != null) return false;
 
@@ -334,6 +346,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
                 ", gaslimit=" + gaslimit +
                 ", storage=" + storage +
                 ", repository=" + repository +
+                ", origRepository=" + origRepository +
                 ", byTransaction=" + byTransaction +
                 ", byTestingSuite=" + byTestingSuite +
                 ", callDeep=" + callDeep +

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -240,7 +240,7 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
 
     @Override
     public Repository getOrigRepository() {
-        return this.repository;
+        return this.origRepository;
     }
 
     @Override
@@ -250,6 +250,10 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
 
     public void setRepository(Repository repository) {
         this.repository = repository;
+    }
+
+    public void setOrigRepository(Repository repository) {
+        this.origRepository = repository.clone();
     }
 
     @Override

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -37,6 +37,7 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     private byte[] msgData;
 
     private Repository repository;
+    private Repository origRepository;
     private byte[] ownerAddress = Hex.decode("cd2a3d9f938e13cd947ec05abc7fe734df8dd826");
     private final byte[] contractAddress = Hex.decode("471fd3ad3e9eeadeec4608b92d16ce6b500704cc");
 
@@ -61,6 +62,7 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
                         + "6040016014525451606001601e52545160800160"
                         + "28525460a052546016604860003960166000f260"
                         + "00603f556103e75660005460005360200235"));
+        this.origRepository = this.repository.clone();
     }
 
     public ProgramInvokeMockImpl(boolean defaults) {
@@ -233,6 +235,11 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
 
     @Override
     public Repository getRepository() {
+        return this.repository;
+    }
+
+    @Override
+    public Repository getOrigRepository() {
         return this.repository;
     }
 

--- a/ethereumj-core/src/main/resources/genesis/ropsten.json
+++ b/ethereumj-core/src/main/resources/genesis/ropsten.json
@@ -3,6 +3,7 @@
     "chainId": 3,
     "eip158Block": 10,
     "byzantiumBlock": 1700000,
+    "constantinopleBlock": 4230000,
 
     "headerValidators": [
       {"number": 10,     "hash": "0xb3074f936815a0425e674890d7db7b5e94f3a06dca5b22d291b55dcd02dde93e"},

--- a/ethereumj-core/src/test/java/org/ethereum/config/net/BaseNetConfigTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/config/net/BaseNetConfigTest.java
@@ -41,7 +41,7 @@ public class BaseNetConfigTest {
     @Test
     public void toStringShouldCaterForNulls() throws Exception {
         BaseNetConfig config = new BaseNetConfig();
-        assertEquals("BaseNetConfig{blockNumbers=[], configs=[], count=0}", config.toString());
+        assertEquals("BaseNetConfig{blockNumbers=  (total: 0)}", config.toString());
 
         BlockchainConfig blockchainConfig = new TestBlockchainConfig() {
             @Override
@@ -50,10 +50,10 @@ public class BaseNetConfigTest {
             }
         };
         config.add(0, blockchainConfig);
-        assertEquals("BaseNetConfig{blockNumbers=[0], configs=[TestBlockchainConfig], count=1}", config.toString());
+        assertEquals("BaseNetConfig{blockNumbers= #0 => TestBlockchainConfig (total: 1)}", config.toString());
 
         config.add(1, blockchainConfig);
-        assertEquals("BaseNetConfig{blockNumbers=[0, 1], configs=[TestBlockchainConfig, TestBlockchainConfig], count=2}", config.toString());
+        assertEquals("BaseNetConfig{blockNumbers= #0 => TestBlockchainConfig, #1 => TestBlockchainConfig (total: 2)}", config.toString());
     }
 
     private static class TestBlockchainConfig extends AbstractConfig {

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
@@ -83,6 +83,7 @@ public class GitHubBasicTest {
     }
 
     @Test
+    @Ignore("Disable Ropsten until cached tests commit is updated to commitSHA")
     public void btDifficultyRopsten() throws IOException, ParseException {
         runDifficultyTest(new RopstenNetConfig(), "BasicTests/difficultyRopsten.json", commitSHA);
     }

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
@@ -38,7 +38,7 @@ import static org.ethereum.jsontestsuite.GitHubJSONTestSuite.runDifficultyTest;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class GitHubBasicTest {
 
-    String commitSHA = "7f638829311dfc1d341c1db85d8a891f57fa4da7";
+    String commitSHA = "95a309203890e6244c6d4353ca411671973c13b5";
 
     @Test
     public void btCrypto() throws IOException {
@@ -83,7 +83,6 @@ public class GitHubBasicTest {
     }
 
     @Test
-    @Ignore("Disable Ropsten until tests are updated with correct difficulty")
     public void btDifficultyRopsten() throws IOException, ParseException {
         runDifficultyTest(new RopstenNetConfig(), "BasicTests/difficultyRopsten.json", commitSHA);
     }

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
@@ -339,9 +339,30 @@ public class GitHubStateTest {
                 "create2collisionStorage" // (nonce, balance 0, code empty, but some storage)
         )));
 // TODO: Update all, this one passes with following settings:
-//        String commitSHA = "3f5febc901913ef698f1b09dda8705babd729e4a";
-//        String treeSHA = "222ea3812849ed982ef0268ec41b609e5b13c412";
+//        String commitSHA = "95a309203890e6244c6d4353ca411671973c13b5";
+//        String treeSHA = "700fdc4aa7d74957a12fbda38785ecc7b846bcc0";
 //           targetNets += GitHubJSONTestSuite.Network.Constantinople
+    }
+
+    @Test
+    @Ignore("Update after all tests could pass latest develop")
+    public void stSstoreRefundBug() throws IOException {
+        final String commit = "9ff64743f0347952903287b9074803607e5855e8";
+
+        GeneralStateTestSuite.runSingle("stSStoreTest/SstoreCallToSelfSubRefundBelowZero.json", commit,
+                GitHubJSONTestSuite.Network.Constantinople);
+
+        GeneralStateTestSuite.runSingle("stSStoreTest/sstore_0to0.json", commit,
+                GitHubJSONTestSuite.Network.Constantinople);
+
+        GeneralStateTestSuite.runSingle("stSStoreTest/sstore_Xto0.json", commit,
+                GitHubJSONTestSuite.Network.Constantinople);
+
+        GeneralStateTestSuite.runSingle("stSStoreTest/sstore_XtoX.json", commit,
+                GitHubJSONTestSuite.Network.Constantinople);
+
+        GeneralStateTestSuite.runSingle("stSStoreTest/sstore_XtoY.json", commit,
+                GitHubJSONTestSuite.Network.Constantinople);
     }
 }
 

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/suite/TestProgramInvokeFactory.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/suite/TestProgramInvokeFactory.java
@@ -44,21 +44,23 @@ public class TestProgramInvokeFactory implements ProgramInvokeFactory {
 
 
     @Override
-    public ProgramInvoke createProgramInvoke(Transaction tx, Block block, Repository repository, BlockStore blockStore) {
-        return generalInvoke(tx, repository, blockStore);
+    public ProgramInvoke createProgramInvoke(Transaction tx, Block block,
+                                             Repository repository, Repository origRepository, BlockStore blockStore) {
+        return generalInvoke(tx, repository, origRepository, blockStore);
     }
 
     @Override
     public ProgramInvoke createProgramInvoke(Program program, DataWord toAddress, DataWord callerAddress,
                                              DataWord inValue, DataWord inGas,
                                              BigInteger balanceInt, byte[] dataIn,
-                                             Repository repository, BlockStore blockStore,
+                                             Repository repository, Repository origRepository, BlockStore blockStore,
                                              boolean isStaticCall, boolean byTestingSuite) {
         return null;
     }
 
 
-    private ProgramInvoke generalInvoke(Transaction tx, Repository repository, BlockStore blockStore) {
+    private ProgramInvoke generalInvoke(Transaction tx, Repository repository, Repository origRepository,
+                                        BlockStore blockStore) {
 
         /***         ADDRESS op       ***/
         // YP: Get address of currently executing account.
@@ -110,7 +112,7 @@ public class TestProgramInvokeFactory implements ProgramInvokeFactory {
 
         return new ProgramInvokeImpl(address, origin, caller, balance,
                 gasPrice, gas, callValue, data, lastHash, coinbase,
-                timestamp, number, difficulty, gaslimit, repository, blockStore);
+                timestamp, number, difficulty, gaslimit, repository, origRepository, blockStore);
     }
 
 }

--- a/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/suite/TestRunner.java
+++ b/ethereumj-core/src/test/java/org/ethereum/jsontestsuite/suite/TestRunner.java
@@ -223,7 +223,7 @@ public class TestRunner {
 
             ProgramInvoke programInvoke = new ProgramInvokeImpl(address, origin, caller, balance,
                     gasPrice, gas, callValue, msgData, lastHash, coinbase,
-                    timestamp, number, difficulty, gaslimit, repository, new BlockStoreDummy(), true);
+                    timestamp, number, difficulty, gaslimit, repository, repository.clone(), new BlockStoreDummy(), true);
 
             /* 3. Create Program - exec.code */
             /* 4. run VM */

--- a/ethereumj-core/src/test/java/org/ethereum/vm/VMMemoryOpTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/vm/VMMemoryOpTest.java
@@ -1023,6 +1023,7 @@ public class VMMemoryOpTest extends VMBaseOpTest {
         while (!program.isStopped())
             vm.step(program);
         invoke.getRepository().commit();
+        invoke.setOrigRepository(invoke.getRepository());
     }
 
     @Test // SSTORE EIP1283


### PR DESCRIPTION
To be updated.

Not yet ready for merge.

Fixed: Constantinople fork has not started at correct block.
Finished by updating ropsten.json and improving net config logging to reduce mistakes in the future:
```
16:30:14.153 DEBUG [general]  Rendering net config from genesis org.ethereum.core.genesis.GenesisConfig@57c03d88 ...
16:30:14.153 DEBUG [general]  Block #0 => Frontier
16:30:14.154 DEBUG [general]  Block #0 => Homestead
16:30:14.156 DEBUG [general]  Block #10 => EIP158, chainId: 3
16:30:14.156 DEBUG [general]  Block #1700000 => Byzantium, chainId: 3
16:30:14.157 DEBUG [general]  Block #4230000 => Constantinople, chainId: 3
16:30:14.157 DEBUG [general]  Finished rendering net config from genesis org.ethereum.core.genesis.GenesisConfig@57c03d88
16:30:14.158 INFO [general]  Blockchain config BaseNetConfig{blockNumbers= #0 => HomesteadConfig, #10 => org.ethereum.config.net.JsonNetConfig$1@518caac3, #1700000 => org.ethereum.config.net.JsonNetConfig
$2@68034211, #4230000 => org.ethereum.config.net.JsonNetConfig$3@4f74980d (total: 4)}
```