### PR TITLE
Fix/ropsten forks

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -198,7 +198,7 @@ public class SystemProperties {
             Config testUserConfig = ConfigFactory.parseResources("test-user.conf");
             logger.info("Config (" + (testUserConfig.entrySet().size() > 0 ? " yes " : " no  ") + "): test properties from resource 'test-user.conf'");
             String file = System.getProperty("ethereumj.conf.file");
-            Config cmdLineConfigFile = mergeConfigs(res, s -> ConfigFactory.parseFile(new File(s)));
+            Config cmdLineConfigFile = mergeConfigs(file, s -> ConfigFactory.parseFile(new File(s)));
             logger.info("Config (" + (cmdLineConfigFile.entrySet().size() > 0 ? " yes " : " no  ") + "): user properties from -Dethereumj.conf.file file(s) '" + file + "'");
             logger.info("Config (" + (apiConfig.entrySet().size() > 0 ? " yes " : " no  ") + "): config passed via constructor");
             config = apiConfig

--- a/ethereumj-core/src/main/resources/genesis/ropsten.json
+++ b/ethereumj-core/src/main/resources/genesis/ropsten.json
@@ -7,7 +7,8 @@
 
     "headerValidators": [
       {"number": 10,     "hash": "0xb3074f936815a0425e674890d7db7b5e94f3a06dca5b22d291b55dcd02dde93e"},
-      {"number": 585503, "hash": "0xe8d61ae10fd62e639c2e3c9da75f8b0bdb3fa5961dbd3aed1223f92e147595b9"}
+      {"number": 585503, "hash": "0xe8d61ae10fd62e639c2e3c9da75f8b0bdb3fa5961dbd3aed1223f92e147595b9"},
+      {"number": 4230000, "hash": "0xbd9e8b9e8d8c00f8e0119cd996d2b665eec3dcd711a86b0681538fd9904c3f25"}
     ]
   },
 


### PR DESCRIPTION
Add correct fork indentity, as there are a lot of peers with incorrect fork in Ropsten and there is a big chance that peer will not get block choice from the correct fork if no restriction is applied