### PR TITLE
Validate header chain in downloader

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -726,7 +726,6 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
         boolean isValid = true;
 
         if (!block.isGenesis()) {
-            isValid = isValid(block.getHeader());
 
             // Sanity checks
             String trieHash = toHexString(block.getTxTrieRoot());

--- a/ethereumj-core/src/main/java/org/ethereum/sync/BlockDownloader.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/BlockDownloader.java
@@ -23,10 +23,12 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.ethereum.core.*;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.net.server.Channel;
 import org.ethereum.validator.BlockHeaderValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -411,6 +413,11 @@ public abstract class BlockDownloader {
      */
     protected void dropIfValidationFailed(SyncQueueIfc.ValidatedHeaders res) {
         if (!res.isValid() && res.getNodeId() != null) {
+            if (logger.isWarnEnabled()) logger.warn("Invalid header received: {}, reason: {}, peer: {}",
+                    res.getHeader() == null ? "" : res.getHeader().getShortDescr(),
+                    res.getReason(),
+                    Hex.toHexString(res.getNodeId()).substring(0, 8));
+
             Channel peer = pool.getByNodeId(res.getNodeId());
             if (peer != null) {
                 peer.dropConnection();

--- a/ethereumj-core/src/main/java/org/ethereum/sync/SyncQueueIfc.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/SyncQueueIfc.java
@@ -18,6 +18,7 @@
 package org.ethereum.sync;
 
 import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockHeaderWrapper;
 
 import javax.annotation.Nullable;
@@ -70,10 +71,16 @@ public interface SyncQueueIfc {
 
         private final List<BlockHeaderWrapper> headers;
         private final boolean valid;
+        private final String reason;
 
-        public ValidatedHeaders(List<BlockHeaderWrapper> headers, boolean valid) {
+        public ValidatedHeaders(List<BlockHeaderWrapper> headers, boolean valid, String reason) {
             this.headers = headers;
             this.valid = valid;
+            this.reason = reason;
+        }
+
+        public ValidatedHeaders(List<BlockHeaderWrapper> headers, boolean valid) {
+            this(headers, valid, "");
         }
 
         public boolean isValid() {
@@ -84,10 +91,20 @@ public interface SyncQueueIfc {
             return headers;
         }
 
+        public String getReason() {
+            return reason;
+        }
+
         @Nullable
         public byte[] getNodeId() {
             if (headers == null || headers.isEmpty()) return null;
             return headers.get(0).getNodeId();
+        }
+
+        @Nullable
+        public BlockHeader getHeader() {
+            if (headers == null || headers.isEmpty()) return null;
+            return headers.get(0).getHeader();
         }
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/sync/SyncQueueImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/SyncQueueImpl.java
@@ -23,6 +23,7 @@ import org.ethereum.core.BlockHeaderWrapper;
 import org.ethereum.core.Blockchain;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteArrayMap;
+import org.ethereum.validator.DependentBlockHeaderRule;
 
 import java.util.*;
 import java.util.function.Function;
@@ -183,6 +184,8 @@ public class SyncQueueImpl implements SyncQueueIfc {
 
     Random rnd = new Random(); // ;)
 
+    DependentBlockHeaderRule parentHeaderValidator = null;
+
     public SyncQueueImpl(List<Block> initBlocks) {
         init(initBlocks);
     }
@@ -264,6 +267,10 @@ public class SyncQueueImpl implements SyncQueueIfc {
 
     private void trimChain() {
         List<HeaderElement> longestChain = getLongestChain();
+        trimChainImpl(longestChain);
+    }
+
+    private void trimChainImpl(List<HeaderElement> longestChain) {
         if (longestChain.size() > MAX_CHAIN_LEN) {
             long newTrimNum = getLongestChain().get(longestChain.size() - MAX_CHAIN_LEN).header.getNumber();
             for (int i = 0; darkZoneNum < newTrimNum; darkZoneNum++, i++) {
@@ -361,6 +368,79 @@ public class SyncQueueImpl implements SyncQueueIfc {
     }
 
     @Override
+    public ValidatedHeaders addHeadersAndValidate(Collection<BlockHeaderWrapper> headers) {
+        for (BlockHeaderWrapper header : headers) {
+            addHeader(header);
+        }
+
+        List<HeaderElement> longestChain = getLongestChain();
+        ValidatedHeaders result = validateChain(longestChain);
+        if (result.isValid()) {
+            trimChainImpl(longestChain);
+        } else {
+            // erase chain starting from first invalid header
+            eraseChain(longestChain, result.getHeaders().get(0).getNumber());
+        }
+
+        return result;
+    }
+
+    /**
+     * Runs parent header validation and returns after first occurrence of invalid header
+     */
+    ValidatedHeaders validateChain(List<HeaderElement> chain) {
+        if (chain.size() <= MAX_CHAIN_LEN || parentHeaderValidator == null)
+            return ValidatedHeaders.Empty;
+
+        for (int i = 1; i < chain.size(); i++) {
+            BlockHeaderWrapper parent = chain.get(i - 1).header;
+            BlockHeaderWrapper header = chain.get(i).header;
+            if (!parentHeaderValidator.validate(header.getHeader(), parent.getHeader())) {
+                return new ValidatedHeaders(Collections.singletonList(header), false);
+            }
+        }
+
+        return ValidatedHeaders.Empty;
+    }
+
+    void eraseChain(List<HeaderElement> chain, long startFrom) {
+        if (chain.isEmpty())
+            return;
+
+        // prevent from going beyond dark zone
+        startFrom = Math.max(darkZoneNum + 1, startFrom);
+
+        HeaderElement head = chain.get(chain.size() - 1);
+        for (int i = chain.size() - 1; i >= 0; i--) {
+            HeaderElement el = chain.get(i);
+            if (el.header.getNumber() < startFrom) break; // erase up to startFrom number
+            Map<ByteArrayWrapper, HeaderElement> gen = headers.get(el.header.getNumber());
+            gen.remove(new ByteArrayWrapper(el.header.getHash()));
+            // clean empty gens
+            if (gen.isEmpty()) {
+                headers.remove(el.header.getNumber());
+            }
+        }
+
+        // adjust maxNum
+        if (head.header.getNumber() == maxNum) {
+            Map<ByteArrayWrapper, HeaderElement> lastValidatedGen = headers.get(darkZoneNum);
+            assert lastValidatedGen.size() == 1;
+            long maxNotEmptyGen = lastValidatedGen.values().iterator().next().header.getNumber();
+
+            // find new maxNum after chain has been erased
+            for (long num = head.header.getNumber(); num >= darkZoneNum; num--) {
+                Map<ByteArrayWrapper, HeaderElement> gen = headers.get(num);
+                if (gen != null && !gen.isEmpty() && num > maxNotEmptyGen) {
+                    maxNotEmptyGen = num;
+                    break;
+                }
+            }
+            maxNum = maxNotEmptyGen;
+        }
+    }
+
+    @Override
     public synchronized int getHeadersCount() {
         return (int) (maxNum - minNum);
     }
@@ -436,6 +516,11 @@ public class SyncQueueImpl implements SyncQueueIfc {
 
     public synchronized List<Block> pollBlocks() {
         return null;
+    }
+
+    public SyncQueueImpl withParentHeaderValidator(DependentBlockHeaderRule validator) {
+        this.parentHeaderValidator = validator;
+        return this;
     }
 
 

--- a/ethereumj-core/src/main/java/org/ethereum/sync/SyncQueueImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/SyncQueueImpl.java
@@ -396,7 +396,8 @@ public class SyncQueueImpl implements SyncQueueIfc {
             BlockHeaderWrapper parent = chain.get(i - 1).header;
             BlockHeaderWrapper header = chain.get(i).header;
             if (!parentHeaderValidator.validate(header.getHeader(), parent.getHeader())) {
-                return new ValidatedHeaders(Collections.singletonList(header), false);
+                return new ValidatedHeaders(Collections.singletonList(header), false,
+                        parentHeaderValidator.getErrors().isEmpty() ? "" : parentHeaderValidator.getErrors().get(0));
             }
         }
 

--- a/ethereumj-core/src/main/java/org/ethereum/sync/SyncQueueReverseImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/sync/SyncQueueReverseImpl.java
@@ -143,6 +143,12 @@ public class SyncQueueReverseImpl implements SyncQueueIfc {
     }
 
     @Override
+    public ValidatedHeaders addHeadersAndValidate(Collection<BlockHeaderWrapper> headers) {
+        List<BlockHeaderWrapper> added = addHeaders(headers);
+        return new ValidatedHeaders(added, true);
+    }
+
+    @Override
     public synchronized BlocksRequest requestBlocks(int maxSize) {
         List<BlockHeaderWrapper> reqHeaders = new ArrayList<>();
         for (BlockHeaderWrapper header : headers.descendingMap().values()) {

--- a/ethereumj-core/src/test/java/org/ethereum/manager/BlockLoaderTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/manager/BlockLoaderTest.java
@@ -9,6 +9,9 @@ import org.ethereum.db.DbFlushManager;
 import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.validator.BlockHeaderRule;
 import org.ethereum.validator.BlockHeaderValidator;
+import org.ethereum.validator.DependentBlockHeaderRule;
+import org.ethereum.validator.DependentBlockHeaderRuleAdapter;
+import org.ethereum.validator.ParentBlockHeaderValidator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -76,6 +79,11 @@ public class BlockLoaderTest {
         }
 
         @Bean
+        public ParentBlockHeaderValidator parentHeaderValidator() {
+            return new ParentBlockHeaderValidator(Collections.emptyList());
+        }
+
+        @Bean
         public Blockchain blockchain(Holder<Block> lastBlockHolder) {
             Blockchain blockchain = Mockito.mock(Blockchain.class);
             when(blockchain.getBestBlock()).thenAnswer(invocation -> lastBlockHolder.get());
@@ -107,8 +115,9 @@ public class BlockLoaderTest {
         }
 
         @Bean
-        public BlockLoader blockLoader(BlockHeaderValidator headerValidator, Blockchain blockchain, DbFlushManager dbFlushManager) {
-            return new BlockLoader(headerValidator, blockchain, dbFlushManager);
+        public BlockLoader blockLoader(BlockHeaderValidator headerValidator, Blockchain blockchain, DbFlushManager dbFlushManager,
+                                       ParentBlockHeaderValidator parentHeaderValidator) {
+            return new BlockLoader(headerValidator, blockchain, dbFlushManager, parentHeaderValidator);
         }
     }
 

--- a/ethereumj-core/src/test/java/org/ethereum/sync/SyncQueueImplTest.java
+++ b/ethereumj-core/src/test/java/org/ethereum/sync/SyncQueueImplTest.java
@@ -21,11 +21,20 @@ import org.ethereum.TestUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockHeaderWrapper;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.FastByteComparisons;
+import org.ethereum.validator.DependentBlockHeaderRule;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.ethereum.crypto.HashUtil.randomPeerId;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Created by Anton Nashatyrev on 30.05.2016.
@@ -157,6 +166,46 @@ public class SyncQueueImplTest {
     }
 
     @Test
+    // a copy of testReverseHeaders2 with #addHeadersAndValidate() instead #addHeaders(),
+    // makes sure that nothing is broken
+    public void testReverseHeaders3() {
+        List<Block> randomChain = TestUtils.getRandomChain(new byte[32], 0, 194);
+        Peer[] peers = new Peer[]{new Peer(randomChain), new Peer(randomChain)};
+        SyncQueueReverseImpl syncQueue = new SyncQueueReverseImpl(randomChain.get(randomChain.size() - 1).getHash(), true);
+        List<BlockHeaderWrapper> result = new ArrayList<>();
+        int peerIdx = 1;
+        int cnt = 0;
+        while (cnt < 100) {
+            System.out.println("Cnt: " + cnt++);
+            Collection<SyncQueueIfc.HeadersRequest> headersRequests = syncQueue.requestHeaders(192, 10, Integer.MAX_VALUE);
+            if (headersRequests == null) break;
+            for (SyncQueueIfc.HeadersRequest request : headersRequests) {
+                System.out.println("Req: " + request);
+                List<BlockHeader> headers = peers[peerIdx].getHeaders(request);
+
+                // Removing genesis header, which we will not get from real peers
+                Iterator<BlockHeader> it = headers.iterator();
+                while (it.hasNext()) {
+                    if (FastByteComparisons.equal(it.next().getHash(), randomChain.get(0).getHash())) it.remove();
+                }
+
+                peerIdx = (peerIdx + 1) % 2;
+                SyncQueueIfc.ValidatedHeaders ret = syncQueue.addHeadersAndValidate(createHeadersFromHeaders(headers, peer0));
+                assert ret.isValid();
+                result.addAll(ret.getHeaders());
+                System.out.println("Result length: " + result.size());
+            }
+        }
+
+        assert cnt != 100;
+        assert result.size() == randomChain.size() - 1; // - genesis
+        for (int  i = 0; i < result.size() - 1; i++) {
+            assert Arrays.equals(result.get(i + 1).getHash(), result.get(i).getHeader().getParentHash());
+        }
+        assert Arrays.equals(randomChain.get(0).getHash(), result.get(result.size() - 1).getHeader().getParentHash());
+    }
+
+    @Test
     public void testLongLongestChain() {
         List<Block> randomChain = TestUtils.getRandomAltChain(new byte[32], 0, 10500, 3);
         SyncQueueImpl syncQueue = new SyncQueueImpl(randomChain);
@@ -244,6 +293,80 @@ public class SyncQueueImplTest {
         randomChain.addAll(blockSaver2);
 
         assert new SyncQueueImpl(randomChain).getLongestChain().size() == 15; // 0 .. 14
+    }
+
+    @Test
+    public void testValidateChain() {
+        List<Block> randomChain = TestUtils.getRandomChain(new byte[32], 0, 100);
+        SyncQueueImpl queue = new SyncQueueImpl(randomChain);
+        byte[] nodeId = randomPeerId();
+
+        List<Block> chain = TestUtils.getRandomChain(randomChain.get(randomChain.size() - 1).getHash(),
+                100, SyncQueueImpl.MAX_CHAIN_LEN - 100 - 1);
+        queue.addHeaders(createHeadersFromBlocks(chain, nodeId));
+
+        List<SyncQueueImpl.HeaderElement> longestChain = queue.getLongestChain();
+
+        // no validator is set
+        assertEquals(SyncQueueIfc.ValidatedHeaders.Empty, queue.validateChain(longestChain));
+
+        // the chain is too short
+        queue.withParentHeaderValidator(RedRule);
+        assertEquals(SyncQueueIfc.ValidatedHeaders.Empty, queue.validateChain(longestChain));
+
+        chain = TestUtils.getRandomChain(chain.get(chain.size() - 1).getHash(),
+                SyncQueueImpl.MAX_CHAIN_LEN - 1, SyncQueueImpl.MAX_CHAIN_LEN);
+        queue.addHeaders(createHeadersFromBlocks(chain, nodeId));
+
+        chain = TestUtils.getRandomChain(chain.get(chain.size() - 1).getHash(),
+                2 * SyncQueueImpl.MAX_CHAIN_LEN - 1, SyncQueueImpl.MAX_CHAIN_LEN);
+
+        // the chain is invalid
+        queue.withParentHeaderValidator(RedRule);
+        SyncQueueIfc.ValidatedHeaders ret = queue.addHeadersAndValidate(createHeadersFromBlocks(chain, nodeId));
+        assertFalse(ret.isValid());
+        assertArrayEquals(nodeId, ret.getNodeId());
+
+        // the chain is valid
+        queue.withParentHeaderValidator(GreenRule);
+        ret = queue.addHeadersAndValidate(createHeadersFromBlocks(chain, nodeId));
+        assertEquals(SyncQueueIfc.ValidatedHeaders.Empty, ret);
+    }
+
+    @Test
+    public void testEraseChain() {
+        List<Block> randomChain = TestUtils.getRandomChain(new byte[32], 0, 1024);
+        SyncQueueImpl queue = new SyncQueueImpl(randomChain);
+
+        List<Block> chain1 = TestUtils.getRandomChain(randomChain.get(randomChain.size() - 1).getHash(),
+                1024, SyncQueueImpl.MAX_CHAIN_LEN / 2);
+        queue.addHeaders(createHeadersFromBlocks(chain1, randomPeerId()));
+
+        List<Block> chain2 = TestUtils.getRandomChain(randomChain.get(randomChain.size() - 1).getHash(),
+                1024, SyncQueueImpl.MAX_CHAIN_LEN / 2 - 1);
+        queue.addHeaders(createHeadersFromBlocks(chain2, randomPeerId()));
+
+        List<SyncQueueImpl.HeaderElement> longestChain = queue.getLongestChain();
+        long maxNum = longestChain.get(longestChain.size() - 1).header.getNumber();
+        assertEquals(1024 + SyncQueueImpl.MAX_CHAIN_LEN / 2 - 1, maxNum);
+        assertEquals(1024 + SyncQueueImpl.MAX_CHAIN_LEN / 2 - 1, queue.getHeadersCount());
+
+        List<Block> chain3 = TestUtils.getRandomChain(chain1.get(chain1.size() - 1).getHash(),
+                1024 + SyncQueueImpl.MAX_CHAIN_LEN / 2, SyncQueueImpl.MAX_CHAIN_LEN / 10);
+        // the chain is invalid and must be erased
+        queue.withParentHeaderValidator(new DependentBlockHeaderRule() {
+            @Override
+            public boolean validate(BlockHeader header, BlockHeader dependency) {
+                // chain2 should become best after erasing
+                return header.getNumber() < chain2.get(chain2.size() - 2).getNumber();
+            }
+        });
+        queue.addHeadersAndValidate(createHeadersFromBlocks(chain3, randomPeerId()));
+
+        longestChain = queue.getLongestChain();
+        assertEquals(maxNum - 1, queue.getHeadersCount());
+        assertEquals(chain2.get(chain2.size() - 1).getHeader(),
+                longestChain.get(longestChain.size() - 1).header.getHeader());
     }
 
     public void test2Impl(List<Block> mainChain, List<Block> initChain, Peer[] peers) {
@@ -382,4 +505,18 @@ public class SyncQueueImplTest {
         }
         return ret;
     }
+
+    static final DependentBlockHeaderRule RedRule = new DependentBlockHeaderRule() {
+        @Override
+        public boolean validate(BlockHeader header, BlockHeader dependency) {
+            return false;
+        }
+    };
+
+    static final DependentBlockHeaderRule GreenRule = new DependentBlockHeaderRule() {
+        @Override
+        public boolean validate(BlockHeader header, BlockHeader dependency) {
+            return true;
+        }
+    };
 }


### PR DESCRIPTION
### What's done
Fixes a problem that has been discovered on Ropsten net during the mess happened around Constantinople HF. The fix is covered with unit tests and ready for merge. Testing on Ropsten's data went well.

### The problem
`BlockDownloader` didn't run header validations that depends on parent block (like difficulty check). These validations used to be run in `BlockchainImpl` before block started to be imported. Thus, if there is a peer with invalid chain in a list of active peers, `BlockDownloader` could stick to that chain and never do a re-branch and the sync gets stuck as a result.

### The fix
Parent header checks have been moved to `BlockDownloader` and now all checks are run there. Hence, preventing `BlockDownloader` from going down the wrong chain.