### PR TITLE
Compiling with solc 0.5.0 broken

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java
@@ -296,6 +296,14 @@ public class SolidityCompiler {
             }
         }
 
+        //new in solidity 0.5.0: using stdin requires an explicit "-". The following output
+        //of 'solc' if no file is provided, e.g.,: solc --combined-json abi,bin,interface,metadata
+        //
+        // No input files given. If you wish to use the standard input please specify "-" explicitly.
+        //
+        // For older solc version "-" is not an issue as it is accepet as well
+        commandParts.add("-");
+
         return commandParts;
     }
 


### PR DESCRIPTION
When updating to solidity 0.5.0, solc compiling with ethereumj does not 
work anymore as using stdin requires an explicit "-". For older solc 
version "-" is not an issue as it is accepet as well.

solcJ update to 0.5.0 is here: https://github.com/tbocek/solcJ/commit/ab19eb45006812c6af7ee3301cb317f0754be79e