### PR TITLE
Compiling with solc 0.5.0 broken

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/solidity/compiler/SolidityCompiler.java
@@ -306,6 +306,14 @@ public class SolidityCompiler {
     public Result compileSrc(byte[] source, boolean optimize, boolean combinedJson, Option... options) throws IOException {
         List<String> commandParts = prepareCommandOptions(optimize, combinedJson, options);
 
+        //new in solidity 0.5.0: using stdin requires an explicit "-". The following output
+        //of 'solc' if no file is provided, e.g.,: solc --combined-json abi,bin,interface,metadata
+        //
+        // No input files given. If you wish to use the standard input please specify "-" explicitly.
+        //
+        // For older solc version "-" is not an issue as it is accepet as well
+        commandParts.add("-");
+
         ProcessBuilder processBuilder = new ProcessBuilder(commandParts)
                 .directory(solc.getExecutable().getParentFile());
         processBuilder.environment().put("LD_LIBRARY_PATH",


### PR DESCRIPTION
When updating to solidity 0.5.0, solc compiling with ethereumj does not
work anymore as using stdin requires an explicit "-". For older solc
version "-" is not an issue as it is accepted as well.

solcJ update to 0.5.0 is here: tbocek/solcJ@ab19eb4