### PR TITLE
Use original gnu license document

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (c) [2016] [ <ether.camp> ], Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
The copyright affects the license-text itself, so it must be


**Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>**

