### PR TITLE
DBSettings should be initialized in write lock.

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/datasource/rocksdb/RocksDbDataSource.java
+++ b/ethereumj-core/src/main/java/org/ethereum/datasource/rocksdb/RocksDbDataSource.java
@@ -94,9 +94,9 @@ public class RocksDbDataSource implements DbSource<byte[]> {
 
     @Override
     public void init(DbSettings settings) {
-        this.settings = settings;
         resetDbLock.writeLock().lock();
         try {
+            this.settings = settings;
             logger.debug("~> RocksDbDataSource.init(): " + name);
 
             if (isAlive()) return;


### PR DESCRIPTION
Current code is:
```
    public void init(DbSettings settings) {
        (1) this.settings = settings;
        (2) resetDbLock.writeLock().lock();
        try {
            logger.debug("~> RocksDbDataSource.init(): " + name);
```

If two threads (named T1 and T2) call the method with different DbSettings, follow code may go wrong::
```
    options.setMaxOpenFiles(settings.getMaxOpenFiles());
    options.setIncreaseParallelism(settings.getMaxThreads());
```
For example, T1(1)->T2(1)->T1(2)->T2(2))，T1 will create the DB with settings passed by T2. For now, it still works well. But it may go wrong if init is called outside in future code.