### PR TITLE
`org.ethereum.net.rlpx.discover.NodeManager::setBootNodes` should be …

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/rlpx/discover/NodeManager.java
@@ -117,7 +117,7 @@ public class NodeManager implements Consumer<DiscoveryEvent>{
         return pongTimer;
     }
 
-    void setBootNodes(List<Node> bootNodes) {
+    public void setBootNodes(List<Node> bootNodes) {
         this.bootNodes = bootNodes;
     }
 


### PR DESCRIPTION
…`public` and not package-private. Without setting boot nodes, the object is very difficult to use outside of the package.