### PR TITLE
Null hash for transaction, mainly with Standalone blockchain

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -473,7 +473,7 @@ public class Transaction {
         return rlpRaw;
     }
 
-    public byte[] getEncoded() {
+    public synchronized byte[] getEncoded() {
 
         if (rlpEncoded != null) return rlpEncoded;
 

--- a/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -256,8 +256,8 @@ public class Transaction {
     public byte[] getHash() {
         if (!isEmpty(hash)) return hash;
         rlpParse();
-        byte[] plainMsg = getEncoded();
-        return hash = HashUtil.sha3(plainMsg);
+        getEncoded();
+        return hash;
     }
 
     public byte[] getRawHash() {

--- a/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -256,8 +256,8 @@ public class Transaction {
     public byte[] getHash() {
         if (!isEmpty(hash)) return hash;
         rlpParse();
-        getEncoded();
-        return hash;
+        byte[] plainMsg = getEncoded();
+        return hash = HashUtil.sha3(plainMsg);
     }
 
     public byte[] getRawHash() {


### PR DESCRIPTION
Fix for empty array returned when (hash == null && parsed == true && rlpEncoded != null). See pull request #1057