### PR TITLE
Fixes: REVERT counts code storage gas cost while shouldn't

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -562,7 +562,9 @@ public class BlockchainImpl implements Blockchain, org.ethereum.facade.Blockchai
     public synchronized BlockSummary addImpl(Repository repo, final Block block) {
 
         if (exitOn < block.getNumber()) {
-            System.out.print("Exiting after block.number: " + bestBlock.getNumber());
+            String msg = String.format("Exiting after block.number: %d", bestBlock.getNumber());
+            logger.info(msg);
+            System.out.println(msg);
             dbFlushManager.flushSync();
             System.exit(-1);
         }

--- a/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/ethereumj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -552,20 +552,28 @@ public class Program {
         byte[] code = result.getHReturn();
 
         long storageCost = getLength(code) * getBlockchainConfig().getGasCost().getCREATE_DATA();
-        long afterSpend = programInvoke.getGas().longValue() - storageCost - result.getGasUsed();
-        if (afterSpend < 0) {
-            if (!blockchainConfig.getConstants().createEmptyContractOnOOG()) {
+        if (result.isRevert()) {
+            long afterSpend = programInvoke.getGas().longValue() - result.getGasUsed();
+            if (afterSpend < 0) {
                 result.setException(Program.Exception.notEnoughSpendingGas("No gas to return just created contract",
                         storageCost, this));
-            } else {
-                track.saveCode(newAddress, EMPTY_BYTE_ARRAY);
             }
-        } else if (getLength(code) > blockchainConfig.getConstants().getMAX_CONTRACT_SZIE()) {
-            result.setException(Program.Exception.notEnoughSpendingGas("Contract size too large: " + getLength(result.getHReturn()),
-                    storageCost, this));
-        } else if (!result.isRevert()){
-            result.spendGas(storageCost);
-            track.saveCode(newAddress, code);
+        } else {
+            long afterSpend = programInvoke.getGas().longValue() - result.getGasUsed() - storageCost;
+            if (afterSpend < 0) {
+                if (!blockchainConfig.getConstants().createEmptyContractOnOOG()) {
+                    result.setException(Program.Exception.notEnoughSpendingGas("No gas to return just created contract",
+                            storageCost, this));
+                } else {
+                    track.saveCode(newAddress, EMPTY_BYTE_ARRAY);
+                }
+            } else if (getLength(code) > blockchainConfig.getConstants().getMAX_CONTRACT_SZIE()) {
+                result.setException(Program.Exception.notEnoughSpendingGas("Contract size too large: " + getLength(result.getHReturn()),
+                        storageCost, this));
+            } else {
+                result.spendGas(storageCost);
+                track.saveCode(newAddress, code);
+            }
         }
 
         getResult().merge(result);


### PR DESCRIPTION
Fixes recent conflict on Ropsten.
Reference: [EIP-140 (REVERT)](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-140.md)
```
The cost of the REVERT instruction equals to that of the RETURN instruction, i.e. the rollback itself does not consume all gas, the contract only has to pay for memory.

In case there is not enough gas left to cover the cost of REVERT or there is a stack underflow, the effect of the REVERT instruction will equal to that of a regular out of gas exception, i.e. it will consume all gas.
```