### PR TITLE
Fix MIN_GAS_LIMIT constant.

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/Constants.java
@@ -28,7 +28,7 @@ import java.math.BigInteger;
  */
 public class Constants {
     private static final int MAXIMUM_EXTRA_DATA_SIZE = 32;
-    private static final int MIN_GAS_LIMIT = 125000;
+    private static final int MIN_GAS_LIMIT = 5000;
     private static final int GAS_LIMIT_BOUND_DIVISOR = 1024;
     private static final BigInteger MINIMUM_DIFFICULTY = BigInteger.valueOf(131072);
     private static final BigInteger DIFFICULTY_BOUND_DIVISOR = BigInteger.valueOf(2048);


### PR DESCRIPTION
Correct the MIN_GAS_LIMIT constant according to the Yellow Paper.
Otherwise, it may cause ethereumj to be incompatible with other language implementations.
![image](https://user-images.githubusercontent.com/4555304/62686001-62ab5600-b9f6-11e9-9ea6-5343d14ff75c.png)
