### PR TITLE
Fix the validation rule for gasUsed.

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/validator/GasValueRule.java
+++ b/ethereumj-core/src/main/java/org/ethereum/validator/GasValueRule.java
@@ -31,8 +31,8 @@ public class GasValueRule extends BlockHeaderRule {
 
     @Override
     public ValidationResult validate(BlockHeader header) {
-        if (new BigInteger(1, header.getGasLimit()).compareTo(BigInteger.valueOf(header.getGasUsed())) < 0) {
-            return fault("header.getGasLimit() < header.getGasUsed()");
+        if (new BigInteger(1, header.getGasLimit()).compareTo(BigInteger.valueOf(header.getGasUsed())) <= 0) {
+            return fault("header.getGasLimit() <= header.getGasUsed()");
         }
 
         return Success;


### PR DESCRIPTION
According to the agreement in the yellow book, it should be gasLimit <= gasUsed.
![image](https://user-images.githubusercontent.com/4555304/62699310-d149dd00-ba11-11e9-96f1-52ad58ae2c67.png)
